### PR TITLE
Update ES cross section calculator for nubar and high energy support

### DIFF
--- a/src/gen/include/RAT/ESCrossSec.hh
+++ b/src/gen/include/RAT/ESCrossSec.hh
@@ -10,28 +10,28 @@
 /// \author Nuno Barros <nfbarros@hep.upenn.edu> -- contact person
 ///
 /// REVISION HISTORY:\n
-/// 23-NOV-2010 - Nuno Barros 	- Imported and adapted into SNO+ RAT
-///             				- Shamelessly taken from SNO QPhysics class PNuE
+/// 23-NOV-2010 - Nuno Barros   - Imported and adapted into SNO+ RAT
+///                             - Shamelessly taken from SNO QPhysics class PNuE
 ///
-/// 22-JUN-2012 - Nuno Barros	- Cleaned up code and solved a small problem with unit conversion.
+/// 22-JUN-2012 - Nuno Barros   - Cleaned up code and solved a small problem with unit conversion.
 ///
-/// 07-JUL-2012 - Nuno Barros 	- Removed all Geant4 streamers replacing them by RAT log objects.
-///								- Changed geant4 data types by C++ data types (suggestion by CIC).
-///								- Revised constness of members.
+/// 07-JUL-2012 - Nuno Barros   - Removed all Geant4 streamers replacing them by RAT log objects.
+///                             - Changed geant4 data types by C++ data types (suggestion by CIC).
+///                             - Revised constness of members.
 ///
 ///
 /// \details Calculates the neutrino-electron ES cross section.
-///			The calculation is performed either for the ES_e (W+Z) channel, or the ES_mu,tau (Z) channel.
-/// 		Some remarks concerning the calculations.
-///			\param E,Enu 	: Neutrino energy (MeV).
-///			\param T,Te		: Recoil electron energy (MeV).
-///			\return Cross section in units of $10^{-42}cm^{2}$
+///         The calculation is performed either for the ES_e (W+Z) channel, or the ES_mu,tau (Z) channel.
+///         Some remarks concerning the calculations.
+///         \param E,Enu    : Neutrino energy (MeV).
+///         \param T,Te     : Recoil electron energy (MeV).
+///         \return Cross section in units of $10^{-42}cm^{2}$
 ///
-///			Available strategies for the ES cross section calculation (set by messenger):
-///			- 1 : Original routine from QSNO::PNuE (Bahcall).
-///			- 2 : Improved routine from QSNO::PNuE (without rad. corrections).
-///			- 3 : Improved routine from QSNO::PNuE (with rad. corrections - analytical).
-///			- 4 (default) : Improved routine from QSNO::PNuE (with rad. corrections - table).
+///         Available strategies for the ES cross section calculation (set by messenger):
+///         - 1 : Original routine from QSNO::PNuE (Bahcall).
+///         - 2 : Improved routine from QSNO::PNuE (without rad. corrections).
+///         - 3 : Improved routine from QSNO::PNuE (with rad. corrections - analytical).
+///         - 4 (default) : Improved routine from QSNO::PNuE (with rad. corrections - table).
 ///
 ///
 ////////////////////////////////////////////////////////////////////
@@ -49,211 +49,183 @@
 
 namespace RAT {
 
-  // Forward declarations within the namespace
-  class ESCrossSecMessenger;
-
+    // Forward declarations within the namespace
+    class ESCrossSecMessenger;
 
     class ESCrossSec {
 
     public:
-	enum NuEType {nue,nuebar,numu,numubar};
+    enum NuEType {nue,nuebar,numu,numubar};
 
-	ESCrossSec(const char* flavor = "nue");
+    ESCrossSec(const char* flavor = "nue");
 
-	~ESCrossSec();
+    ~ESCrossSec();
 
-	// Set's the defaults for the calculation
-	void Defaults();
+    /**
+     * @brief Calculate the total cross section for the neutrino energy Enu.
+     *
+     * @param Enu
+     * @return total cross section in units of \f$ 10^{-42} cm^{2} \f$ .
+     */
+    double Sigma(const double Enu) const;
 
+    /**
+     * @brief Calculate the differential cross section for the neutrino energy Enu.
+     *
+     * @param Enu Incoming neutrino energy (MeV).
+     * @param Te  Recoil electron energy (MeV).
+     * @return Differencial cross section \f$ \frac{d\sigma}{dT} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
+     */
+    double dSigmadT(const double Enu,const double Te) const;
 
-	/**
-	 * @brief Calculate the total cross section for the neutrino energy Enu.
-	 *
-	 * @param Enu
-	 * @return total cross section in units of \f$ 10^{-42} cm^{2} \f$ .
-	 */
-	double Sigma(const double Enu) const;
+    /**
+     * Integrate the differential cross section between recoil energies T1 and T2.
+     *
+     * @param Enu Incoming neutrino energy (MeV).
+     * @param T1  Lower limit of recoil energy interval (MeV).
+     * @param T2  Upper limit of recoil energy interval (MeV).
+     * @return \f$ \left.\frac{d\sigma}{dT}\right|_{\left[T1;T2\right]} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
+     */
+    double IntegraldSigmadT(const double Enu,const double T1,const double T2) const ;
 
+    /**
+     * @brief Calculate the differential cross section as a function of the recoil angle.
+     *
+     * @param Enu Incoming neutrino energy.
+     * @param CosTh Cosine of laboratory recoil angle of the electron.
+     * @return  \f$ \frac{d\sigma}{d\cos \theta} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
+     */
+    double dSigmadCosTh(const double Enu,const double CosTh) const;
 
-	/**
-	 * @brief Calculate the differential cross section for the neutrino energy Enu.
-	 *
-	 * @param Enu Incoming neutrino energy (MeV).
-	 * @param Te  Recoil electron energy (MeV).
-	 * @return Differencial cross section \f$ \frac{d\sigma}{dT} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
-	 */
-	double dSigmadT(const double Enu,const double Te) const;
+    //-----------------------------------------------------------------------
+    /**
+     * @brief Setter for which calculation to use.
+     *
+     * The available calculations are:
+     *  -# 1 : No radiative corrections (Bahcall first calculation).
+     *  -# 2 : No radiative corrections from table.
+     *  -# 3 : Full analytical calculation with radiative corrections.
+     *  -# 4 : Full calculations with radiative corrections from table (default).
+     *
+     * @param ii Option for calculation to use.
+     *
+     */
+    void SetRadiativeCorrection(const int ii);
 
-	/**
-	 * Integrate the differential cross section between recoil energies T1 and T2.
-	 *
-	 * @param Enu Incoming neutrino energy (MeV).
-	 * @param T1  Lower limit of recoil energy interval (MeV).
-	 * @param T2  Upper limit of recoil energy interval (MeV).
-	 * @return \f$ \left.\frac{d\sigma}{dT}\right|_{\left[T1;T2\right]} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
-	 */
-	double IntegraldSigmadT(const double Enu,const double T1,const double T2) const ;
+    /**
+     * @brief Getter of the cross section calculation type being used.
+     *
+     * @return index of calculation type.
+     */
+    inline int GetRadiativeCorrection( ) const {return fRadiativeCorrection;};
 
-	/**
-	 * @brief Calculate the differential cross section as a function of the recoil angle.
-	 *
-	 * @param Enu Incoming neutrino energy.
-	 * @param CosTh Cosine of laboratory recoil angle of the electron.
-	 * @return  \f$ \frac{d\sigma}{d\cos \theta} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
-	 */
-	double dSigmadCosTh(const double Enu,const double CosTh) const;
+    /**
+     * @brief Setter for the Weak mixing angle.
+     *
+     * @param sintw Weak mixing angle : \f$ \sin \theta_{W} \f$
+     *
+     */
+    void SetSinThetaW(const double &sintw );
 
-	/**
-	 * @brief 3D equivalent of ESCrossSec::dSigmadCosTh
-	 *
-	 * @param Enu Incoming neutrino energy.
-	 * @param theta Cosine (FIXME) of laboratory recoil angle of the electron.
-	 * @param phi 	Azimuthal recoil angle.
-	 * @return  \f$ \frac{d\sigma}{d\Omega} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
-	 *
-	 * @note Usually not used. Needs further verification.
-	 *
-	 */
-	double dSigmadOmega(const double Enu,const double theta, const double phi) const;
+    /**
+     * @brief Getter for the Weak mixing angle.
+     *
+     * @return Weak mixing angle : \f$ \sin \theta_{W} \f$
+     *
+     */
+    double GetSinThetaW() const {return fsinthetaW2;};
 
+    /**
+     * @brief Setter for the neutrino type to be used.
+     *
+     * @param reaction neutrino type (nue,numu,nuebar,numubar)
+     */
+    void SetReaction(const std::string &reaction);
 
-	//-----------------------------------------------------------------------
-	/**
-	 * @brief Setter for which calculation to use.
-	 *
-	 * The available calculations are:
-	 * 	-# 1 : No radiative corrections (Bahcall first calculation).
-	 * 	-# 2 : No radiative corrections from table.
-	 * 	-# 3 : Full analytical calculation with radiative corrections.
-	 * 	-# 4 : Full calculations with radiative corrections from table (default).
-	 *
-	 * @param ii Option for calculation to use.
-	 *
-	 */
-	void SetRadiativeCorrection(const int ii);
-
-	/**
-	 * @brief Getter of the cross section calculation type being used.
-	 *
-	 * @return index of calculation type.
-	 */
-	inline int GetRadiativeCorrection( ) const {return fRadiativeCorrection;};
-
-	/**
-	 * @brief Setter for the Weak mixing angle.
-	 *
-	 * @param sintw Weak mixing angle : \f$ \sin \theta_{W} \f$
-	 *
-	 */
-	void SetSinThetaW(const double &sintw ) ; //{fsinthetaW2 = sintw;};
-
-	/**
-	 * @brief Getter for the Weak mixing angle.
-	 *
-	 * @return Weak mixing angle : \f$ \sin \theta_{W} \f$
-	 *
-	 */
-	double GetSinThetaW() const {return fsinthetaW2;};
-
-	/**
-	 * @brief Setter for the neutrino type to be used.
-	 *
-	 * @param reaction neutrino type (nue,numu,nuebar,numubar)
-	 */
-	void SetReaction(const std::string &reaction);
-
-	/**
-	 * @brief Getter for the neutrino type to be used.
-	 *
-	 * @return reaction neutrino type (nue,numu,nuebar,numubar)
-	 */
+    /**
+     * @brief Getter for the neutrino type to be used.
+     *
+     * @return reaction neutrino type (nue,numu,nuebar,numubar)
+     */
     const std::string& GetReaction() const {return fReactionStr;};
 
-	/**
-	 * @brief Return a TGraph with the differential cross section for an incoming neutrino with energy Enu.
-	 * @param Enu Incoming neutrino energy (MeV)
-	 * @return TGraph with the shape of \f$ \frac{d\sigma}{dT} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
-	 */
-	TGraph *DrawdSigmadT(const double Enu) const;
+    /**
+     * @brief Return a TGraph with the differential cross section for an incoming neutrino with energy Enu.
+     * @param Enu Incoming neutrino energy (MeV)
+     * @return TGraph with the shape of \f$ \frac{d\sigma}{dT} \f$ in units of \f$ 10^{-42} cm^{2} \f$ .
+     */
+    TGraph *DrawdSigmadT(const double Enu) const;
 
-	/**
-	 * Returns the global normalization of the cross section calculation.
-	 * For precision reasons, the cross-section is performed on a different scale, and therefore
-	 * any result returned by the calculation is missing this scale, which has to be applied separately.
-	 *
-	 * @return cross section scaling factor (1e-42)
-	 */
-	double CrossSecNorm() const {return 1e-42;};
+    /**
+     * Returns the global normalization of the cross section calculation.
+     * For precision reasons, the cross-section is performed on a different scale, and therefore
+     * any result returned by the calculation is missing this scale, which has to be applied separately.
+     *
+     * @return cross section scaling factor (1e-42)
+     */
+    double CrossSecNorm() const {return 1e-42;};
 
     protected:
 
-	/**
-	 * @brief Internal function to load the data from the DB.
-	 */
-	void LoadTablesDB();
+    /**
+     * @brief Internal function to load the data from the DB.
+     */
+    void LoadTablesDB();
 
-	void CalcG();
-
+    void CalcG();
 
     private:
 
-	/**
-	 * Rename of ESCrossSec::Sigma. To be discontinued.
-	 *
-	 * @see ESCrossSec::Sigma
-	 * @param Enu Incoming neutrino energy.
-	 * @return total cross section in units of \f$ 10^{-42} cm^{2} \f$ .
-	 */
-    double SigmaLab(double Enu) const;
+    // Sets the defaults for the calculation
+    void Defaults();
+
+    // add by y.t. 16-JAN-2003
     double fL(const double x) const;
 
+    NuEType fReaction;      /// Reaction type
+    std::string fReactionStr;   /// String characterizing the reaction type
 
-	NuEType fReaction;   	/// Reaction type
-	std::string fReactionStr;	/// String characterizing the reaction type
+    double fEmin,fEmax; /// Auxiliary variables to deal with the energies
 
-	double fEmin,fEmax;	/// Auxiliary variables to deal with the energies
+    // Some constants
+    static const double  fGf;       /// Fermi constant (GeV^-2)
+    static const double  fhbarc;    /// hbar*c (MeV*fm)
+    static const double  fhbarc2;   /// hbar*c^2(GeV^2 mb)
+    static const double  falpha;    /// radiative correction term
 
-	// Some constants
-	static const double  fGf; 		/// Fermi constant (GeV^-2)
-	static const double  fhbarc; 	/// hbar*c (MeV*fm)
-	static const double  fhbarc2;	/// hbar*c^2(GeV^2 mb)
-	static const double  falpha;	/// radiative correction term
+    /**
+     * This variable is defined as static (and not const) because it can be changed
+     * in the macro file. However, the change should propagate to all instances of the class
+     */
+    static double  fsinthetaW2;
 
+    double  fMe;            /// electron mass
+    double  fSigmaOverMe;    /// \f$ \frac{\sigma}{m_{e^{-}}}\f$
 
-	/**
-	 * This variable is defined as static (and not const) because it can be changed
-	 * in the macro file. However, the change should propagate to all instances of the class
-	 */
-	static double  fsinthetaW2;
+    double  fgL;
+    double  fgR;
 
-	double  fMe;			/// electron mass
-	double  sigmaoverme; 	/// \f$ \frac{\sigma}{m_{e^{-}}}\f$
+    //-----------------------------------------------------------------------
+    int     fRadiativeCorrection;  // flag to use radiative correction or not
 
-	double  fgL;
-	double  fgR;
+    /// Vars to manipulate the tables. Since the tables are the same for all instances, these can be static
+    static const double  fTableTeMin;
+    static const double  fTableTeMax;
 
-	//-----------------------------------------------------------------------
-	// add by y.t. 16-JAN-2003
-	int     fRadiativeCorrection;  // flag to use radiative correction or not
-	//double  fL(double x);        // internal routine
+    // Total cross section table
+    bool                 fExistTableTot;
+    int                  fNDataTot;
+    double               fEnuStepTot;
+    LinearInterp<double> fTableTot_e;
 
+    // Differential cross section table
+    bool                 fExistTableDif;
+    int                  fNDataDif;
+    double               fEnuStepDif;
+    LinearInterp<double> fTableDif_e;
+    std::vector<double>  fTableDif;
 
-	/// Vars to manipulate the tables. Since the tables are the same for all instances, these can be static
-	static const double  fTableTeMin;
-	static const double  fTableTeMax;
-
-	// Total cross section table
-	int    fNDataTot;
-	float  fEnuStepTot;
-	LinearInterp<double> fTableTot_e;
-
-	// Differential cross section table
-	int                  fNDataDif;
-	float                fEnuStepDif;
-	LinearInterp<double> fTableDif_e;
-	std::vector<double>  fTableDif;
-
-	ESCrossSecMessenger *fMessenger;
+    ESCrossSecMessenger *fMessenger;
 
     };
 
@@ -261,42 +233,29 @@ namespace RAT {
 // Some inline definitions to make the code a bit faster
 //
 
-    inline void ESCrossSec::CalcG()
-    {
-	// calculate the gL and gR for
-	// the reaction type
-
-	if ( fReaction == nue)           {
-
-	    fgL =  0.5 + fsinthetaW2;
-	    fgR =  fsinthetaW2;
-
-	} else if (fReaction == nuebar)  {
-
-	    fgL =   fsinthetaW2;
-	    fgR =   0.5 + fsinthetaW2;
-
-	} else if (fReaction == numu)    {
-
-	    fgL =   -0.5 + fsinthetaW2;
-	    fgR =    fsinthetaW2;
-
-	} else if (fReaction == numubar) {
-
-	    fgL =   fsinthetaW2;
-	    fgR =   -0.5 + fsinthetaW2;
-
-	}
-	else throw std::invalid_argument("Unknown reaction " + fReactionStr);
+    inline void ESCrossSec::CalcG() {
+        // calculate the gL and gR for
+        // the reaction type
+        if (fReaction == nue) {
+            fgL = 0.5 + fsinthetaW2;
+            fgR = fsinthetaW2;
+        }
+        else if (fReaction == nuebar) {
+            fgL = fsinthetaW2;
+            fgR = 0.5 + fsinthetaW2;
+        }
+        else if (fReaction == numu) {
+            fgL = -0.5 + fsinthetaW2;
+            fgR = fsinthetaW2;
+        }
+        else if (fReaction == numubar) {
+            fgL = fsinthetaW2;
+            fgR = -0.5 + fsinthetaW2;
+        }
+        else {
+            throw std::invalid_argument("Unknown reaction " + fReactionStr);
+        }
     }
 }
 
-
-
 #endif
-
-
-
-
-
-

--- a/src/gen/src/ESCrossSec.cc
+++ b/src/gen/src/ESCrossSec.cc
@@ -17,7 +17,6 @@
 // -- ROOT includes
 #include <CLHEP/Units/SystemOfUnits.h>
 #include <CLHEP/Units/PhysicalConstants.h>
-#include <TH1F.h>
 
 using namespace CLHEP;
 
@@ -33,12 +32,10 @@ namespace RAT {
 // in the code, which are different from the ones
 // provided from Geant4/CLHEP
  */
-
-const double  RAT::ESCrossSec::fGf    = 1.166371e-5;        	// Fermi constant (GeV^-2)
-const double  RAT::ESCrossSec::fhbarc = hbarc*1e12; 			// hbar*c (MeV*fm)
-const double  RAT::ESCrossSec::fhbarc2= fhbarc*fhbarc*1e-5; 	// hbar*c^2(GeV^2 mb)
+const double  RAT::ESCrossSec::fGf    = 1.166371e-5;            // Fermi constant (GeV^-2)
+const double  RAT::ESCrossSec::fhbarc = hbarc*1e12;             // hbar*c (MeV*fm)
+const double  RAT::ESCrossSec::fhbarc2= fhbarc*fhbarc*1e-5;     // hbar*c^2(GeV^2 mb)
 const double  RAT::ESCrossSec::falpha = fine_structure_const;   //
-
 
 /**
  * Some other static constants that are valid for all instances of the class.
@@ -54,622 +51,556 @@ const double RAT::ESCrossSec::fTableTeMax = 0.95;
  */
 double RAT::ESCrossSec::fsinthetaW2 = 0.23116;
 
-ESCrossSec::ESCrossSec(const char* flavor)
-{
-	fReactionStr = flavor;
-	Defaults();
+ESCrossSec::ESCrossSec(const char* flavor) {
+    fReactionStr = flavor;
+    Defaults();
 
-	// Messenger to override some parameters
-	fMessenger = new ESCrossSecMessenger(this);
-
+    // Messenger to override some parameters
+    fMessenger = new ESCrossSecMessenger(this);
 }
 
-ESCrossSec::~ESCrossSec()
-{
-
-	if (fMessenger != NULL) {
-		delete fMessenger;
-		fMessenger = NULL;
-	}
-
+ESCrossSec::~ESCrossSec() {
+    if (fMessenger != NULL) {
+        delete fMessenger;
+        fMessenger = NULL;
+    }
 }
 
-void ESCrossSec::Defaults()
-{
-	// load default parameters
+void ESCrossSec::Defaults() {
+    // load default parameters
 
-	//fMe = (G4ParticleTable::GetParticleTable()->FindParticle("e-"))->GetPDGMass(); // MeV
+    // defaults to PDG value.
+    // Can be tuned in the macro file or in the command
+    // file through the ESxsectionMessenger
+    // /generator/es/xsection/wma
+    //fsinthetaW2 = 0.23116; // effective angle PDG 2010
 
-	// defaults to PDG value.
-	// Can be tuned in the macro file or in the command
-	// file through the ESxsectionMessenger
-	// /generator/es/xsection/wma
-	//fsinthetaW2 = 0.23116; // effective angle PDG 2010
+    fMe = (G4ParticleTable::GetParticleTable()->FindParticle("e-"))->GetPDGMass(); // MeV
+    fSigmaOverMe = 2*fGf*fGf*fMe*1.0e9*fhbarc2/pi; // 10^-42 cm^2/MeV
 
-	fMe = (G4ParticleTable::GetParticleTable()->FindParticle("e-"))->GetPDGMass(); // MeV
-	sigmaoverme = 2*fGf*fGf*fMe*1.0e9*fhbarc2/pi; // 10^-42 cm^2/MeV
+    // Default calculation strategy
+    // Can be set by messenger
+    // /generator/es/xsection/strategy
+    SetReaction(fReactionStr);
 
-	// Default calculation strategy
-	// Can be set by messenger
-	// /generator/es/xsection/strategy
-	SetReaction(fReactionStr);
-
-	/** Options for strategy:
-	 *
-	 *  * 1:       previous routine
-	 *  * 2:       new routine w/o  rad. cor.
-	 *  * 3:       new routine with rad. cor. w/o table
-	 *  * 4:       new routine with rad. cor. with table
-	 *  * others:  new routine with rad. cor. with or
-	 *          w/o table (fTableTeMin/fTableTeMax)
-	 */
-
-  if (fReaction == nue || fReaction == numu)
-    SetRadiativeCorrection(4);
-  else
-    SetRadiativeCorrection(1);
-
-
-
-//	// Limits for which the table should not be trusted (the interpolation is not as efficient).
-//	fTableTeMin = 0.05;       // don't use table from 0 upto 0.05*Temax
-//	fTableTeMax = 0.90;       // don't use table from 0.90*Temax upto Temax
-
-//	sigmaoverme = 2*fGf*fGf*fMe*1.0e9*fhbarc2/pi; // 10^-42 cm^2/MeV
-
+    /** Options for strategy:
+     *
+     *  * 1:       previous routine
+     *  * 2:       new routine w/o  rad. cor.
+     *  * 3:       new routine with rad. cor. w/o table
+     *  * 4:       new routine with rad. cor. with table
+     *  * others:  new routine with rad. cor. with or
+     *          w/o table (fTableTeMin/fTableTeMax)
+     */
+    if (fReaction == nue || fReaction == numu) {
+        SetRadiativeCorrection(4);
+    }
+    else {
+        SetRadiativeCorrection(1);
+    }
 }
 
 //-------------------------------------------------------------------
 
+//---------------- private routine ----------------------------
 
-/// Calculates total cross section for a given neutrino energy
-double ESCrossSec::Sigma(const double Enu) const
-{
-	// return total cross section in units cm^-42
-	// for laboratory neutrino energy Enu
-	// The calculation varies according to the chosen strategy
+// fL(): add by y.t. 14-JAN-2003
+double ESCrossSec::fL(const double x) const {
+    int istep = 1000;    // should not be hard corded??
 
-	// First do the most basic check
-	if (Enu == 0) return 0.0;
-	if (Enu < 0) {
-		std::stringstream ss;
-		ss << "[ESCrossSec]::Sigma : Invalid neutrino Energy ( Enu = "
-				<< Enu << " ).";
-		RAT::Log::Die(ss.str(),1);
-		throw std::invalid_argument("Invalid neutrino energy (" + ss.str() + ").");
-	}
+    double dstep = x / istep;
+    double sum = 0.0;
 
-	double   sigma = 0.0;
-	double   Temax = Enu - 1.0/(2.0/fMe + 1.0/Enu);
+    for (int i = 1; i <= istep; i++) {
+        double t = dstep * i;
+        sum += log(fabs(1.0 - t))/t * dstep;
+    }
 
-	if (fRadiativeCorrection == 1) {
-
-		/////////////////////////////////////////////////////////////
-		// previous routine
-		/////////////////////////////////////////////////////////////
-
-		const double   gL2 = fgL*fgL;
-		const double   gR2 = fgR*fgR;
-		const double   gLR = fgL*fgR;
-
-		sigma =    (gL2 + gR2)*Temax
-				- (gR2/Enu + gLR*fMe/(2.0*Enu*Enu))*Temax*Temax
-				+ (gR2/(3.0*Enu*Enu))*Temax*Temax*Temax;
-
-		sigma = sigma*sigmaoverme;
-
-		return sigma;
-
-	} else {
-
-		/////////////////////////////////////////////////////////////
-		// radiative correction
-		/////////////////////////////////////////////////////////////
-		const int k = ((int)(Enu/fEnuStepTot) - 1);
-		// Different than 1,2 or 3 --> Table
-		if (fRadiativeCorrection != 3 && fRadiativeCorrection != 2 &&
-				k >= 0 && k < fNDataTot - 1) {
-
-			if ( fReaction == nue || fReaction == numu ) {
-				// interpolate by a straight line
-				sigma = fTableTot_e(Enu);
-
-			} else {
-				// no support for nuebar and numubar
-				// in tables
-				std::stringstream ss;
-				ss << "[ESCrossSec]::Sigma : " << fReactionStr
-					<< " not supported with Radiative correction strategy "
-					<< fRadiativeCorrection << " !!";
-				RAT::Log::Die(ss.str(),1);
-				throw;
-			}
-
-			return sigma;
-
-		} else {
-			// Apply Radiative corrections without the table
-			// fRadiativeCorrection = 2,3 or 4 in the outer range
-
-			// To avoid log(-1.0e-15) in dSigmadT()
-			Temax = Temax *(1.0 - 1.0e-13);
-
-			const int     istep = 1000;     // should not be hard corded??
-			const double  dstep = Temax / (double) istep;
-			double  Te;
-
-			for (int i = 1; i <= istep; i++) {
-				Te = dstep * (double) i;
-				sigma = sigma + dSigmadT(Enu, Te) * dstep;
-			}
-			return sigma;
-		}
-
-	}
-
-
-	// Should never reach this point
-	// Throw an exception if that happens
-	std::stringstream ss;
-	ss << "[ESCrossSec]::Sigma : Reached end of function while calculating Sigma. Something is wrong with the calculation.\n";
-
-	ss << "[ESCrossSec]::Sigma : Current parameters : Calculation Strategy : [ "
-			<< fRadiativeCorrection << " ], Reaction : [ " << fReactionStr << " ].\n";
-	ss << "[ESCrossSec]::Sigma : Enu : [ " << Enu << " ], TeMax  : [ "
-			<<  Temax << " ].";
-	RAT::Log::Die(ss.str(),1);
-	throw;
+    return sum;
 }
 
-//--------------------------------------
-double ESCrossSec::SigmaLab(const double elab) const
-{
-	return Sigma(elab);
+
+/// Calculates total cross section for a given neutrino energy
+double ESCrossSec::Sigma(const double Enu) const {
+    // return total cross section in units cm^-42
+    // for laboratory neutrino energy Enu
+    // The calculation varies according to the chosen strategy
+
+    // First do the most basic check
+    if (Enu == 0) {
+        return 0.0;
+    }
+    if (Enu < 0) {
+        std::stringstream ss;
+        ss << "ESCrossSec::Sigma : Invalid neutrino Energy ( Enu = " << Enu << " ).";
+        // -- Die throws an exception...
+        RAT::Log::Die(ss.str(),1);
+    }
+
+    double sigma = 0.0;
+    double Temax = Enu - 1.0/(2.0/fMe + 1.0/Enu);
+
+    if (fRadiativeCorrection == 1) {
+        /////////////////////////////////////////////////////////////
+        // previous routine
+        /////////////////////////////////////////////////////////////
+        const double gL2 = fgL*fgL;
+        const double gR2 = fgR*fgR;
+        const double gLR = fgL*fgR;
+
+        sigma = (gL2 + gR2)*Temax
+            - (gR2/Enu + gLR*fMe/(2.0*Enu*Enu))*Temax*Temax
+            + (gR2/(3.0*Enu*Enu))*Temax*Temax*Temax;
+
+        sigma = sigma*fSigmaOverMe;
+
+        return sigma;
+
+    }
+    else {
+        /////////////////////////////////////////////////////////////
+        // radiative correction
+        /////////////////////////////////////////////////////////////
+        const int k = ((int)(Enu/fEnuStepTot) - 1);
+        // Different than 1,2 or 3 --> Table
+        if (fRadiativeCorrection != 3 && fRadiativeCorrection != 2 && fExistTableTot && k >= 0 && k < fNDataTot - 1) {
+            if (fExistTableTot) {
+                // interpolate by a straight line
+                sigma = fTableTot_e(Enu);
+            }
+            else {
+                // Currently no support for nuebar and numubar in tables. Should never reach here but have
+				// functionality to default to in place anyway.
+                warn << "ESCrossSec::Sigma : " << fReactionStr << " not supported with Radiative correction strategy " << fRadiativeCorrection << " !!"
+				     << " Computing analytically instead." << newline;
+
+            	// To avoid log(-1.0e-15) in dSigmadT()
+            	Temax = Temax *(1.0 - 1.0e-13);
+            	sigma = IntegraldSigmadT(Enu, 0, Temax);
+			}
+            return sigma;
+        }
+        else {
+            // Apply Radiative corrections without the table
+            // fRadiativeCorrection = 2,3 or 4 in the outer range, or no table found
+
+            // To avoid log(-1.0e-15) in dSigmadT()
+            Temax = Temax *(1.0 - 1.0e-13);
+            sigma = IntegraldSigmadT(Enu, 0, Temax);
+
+            return sigma;
+        }
+
+    }
+
+    // Should never reach this point
+    // Throw an exception if that happens
+    std::stringstream ss;
+    ss << "ESCrossSec::Sigma : Reached end of function while calculating Sigma. Something is wrong with the calculation.\n";
+    ss << "ESCrossSec::Sigma : Current parameters : Calculation Strategy : [ "
+       << fRadiativeCorrection << " ], Reaction : [ " << fReactionStr << " ].\n";
+    ss << "ESCrossSec::Sigma : Enu : [ " << Enu << " ], TeMax  : [ " <<  Temax << " ].";
+    RAT::Log::Die(ss.str(),1);
+    throw;
 }
 
 //--------------------------------------
 // Differential cross-section calculation
 
-double ESCrossSec::dSigmadT(const double Enu,const double Te) const
-{
-	// Differential cross section
-	//  d Sigma
-	//  -------
-	//  d Te
-	//
-	//  Enu = laboratory neutrino energy        -- units: MeV
-	//  Te  = laboratory recoil electron energy -- units: MeV
-	//  dSigmadT units:  10^-42 cm^2/MeV
+double ESCrossSec::dSigmadT(const double Enu,const double Te) const {
+    // Differential cross section
+    //  d Sigma
+    //  -------
+    //  d Te
+    //
+    //  Enu = laboratory neutrino energy        -- units: MeV
+    //  Te  = laboratory recoil electron energy -- units: MeV
+    //  dSigmadT units:  10^-42 cm^2/MeV
 
-	// check kinematical limit
-	double Temax = Enu - 1.0/(2.0/fMe + 1.0/Enu);
+    // check kinematical limit
+    double Temax = Enu - 1.0/(2.0/fMe + 1.0/Enu);
 
-	if(Te <= 0.0 || Te > Temax) return 0.;
+    if (Te <= 0.0 || Te > Temax) {
+        return 0.;
+    }
 
+    int k1;
+    int k2;
 
-	int k1;
-	int k2;
+    if (fRadiativeCorrection == 1) {
+        /////////////////////////////////////////////////////////////
+        // previous routine
+        /////////////////////////////////////////////////////////////
 
-	if (fRadiativeCorrection == 1) {
-		/////////////////////////////////////////////////////////////
-		// previous routine
-		/////////////////////////////////////////////////////////////
+        // Taken from Bahcall "Neutrino Astrophysics" eqn 8.29 and 8.31
+        //
+        // radiative corrections are NOT included in this option
+        //
 
-		// Taken from Bahcall "Neutrino Astrophysics" eqn 8.29 and 8.31
-		//
-		// radiative corrections are NOT included in this option
-		//
+        // hacked together from eqn A1 of Bahcall, Kamionkowski and Sirlin
+        // astro-ph/9502003
 
-		// hacked together from eqn A1 of Bahcall, Kamionkowski and Sirlin
-		// astro-ph/9502003
+        const double z = Te/Enu;
+        const double mq = fMe/Enu;
 
-		const double z = Te/Enu;
-		const double mq = fMe/Enu;
+        const double gL2 = fgL*fgL;
+        const double gR2 = fgR*fgR;
+        const double gLR = fgL*fgR;
+        const double oneMz = 1.0 - z;
 
-		const double   gL2 = fgL*fgL;
-		const double   gR2 = fgR*fgR;
-		const double   gLR = fgL*fgR;
-		const double   oneMz = 1.0 - z;
+        double dsigdT = fSigmaOverMe * (gL2 + (gR2*oneMz*oneMz) - gLR*mq*z);
 
-		double dsigdT = sigmaoverme * (gL2 + (gR2*oneMz*oneMz) - gLR*mq*z);
+        return dsigdT;
+    }
+    else {
+        /////////////////////////////////////////////////////////////
+        // radiative correction
+        /////////////////////////////////////////////////////////////
 
+        /// \todo Optimize the interpolation.
 
-		return dsigdT;
-	} //if (fRadiativeCorrection == 1)
-	else {
+        // check table
+        k1 = (int) ((Enu/fEnuStepDif + 0.5) - 1);
+        k2 = (int) ((Te/fEnuStepDif + 0.5) - 1);
 
-		/////////////////////////////////////////////////////////////
-		// radiative correction
-		/////////////////////////////////////////////////////////////
-
-		/// \todo Optimize the interpolation.
-
-		// check table
-		//     k1 = (int)(Enu/fEnuStepDif) - 1;
-		//     k2 = (int)(Te/fEnuStepDif) - 1;
-		k1 = (int)((Enu/fEnuStepDif +0.5) - 1);
-		k2 = (int)((Te/fEnuStepDif +0.5) - 1);
-
-		if ( k1 < 0 || k2 < 0 ) {
-			std::stringstream ss;
-			warn << "[ESCrossSec]::dSigmadT : Got invalid values for variables k_i: k1 " << k1
-					<< " k2 " << k2 << newline;
-
-			warn << "[ESCrossSec]::dSigmadT : Enu : [ " << Enu << " ], Te  : [ "
-					<<  Te << " ] " << " fEnuStepDif : " << fEnuStepDif << "\n\n" << newline;
-
+        if (fExistTableDif && (k1 < 0 || k2 < 0)) {
+            warn << "[ESCrossSec]::dSigmadT : Got invalid values for variables k_i: k1 " << k1 << " k2 " << k2 << newline;
+            warn << "[ESCrossSec]::dSigmadT : Enu : [ " << Enu << " ], Te  : [ " <<  Te << " ] " << " fEnuStepDif : " << fEnuStepDif << "\n\n" << newline;
 
             Log::Die("[ESCrossSec]::dSigmadT : Got invalid values for variables k_i: k1 " + util_to_string(k1) + " k2 " + util_to_string(k2));
-		}
+        }
 
-		double e1 = fEnuStepDif * (double) (k1+1);
-		double e2 = fEnuStepDif * (double) (k1+2);
-		double t1 = fEnuStepDif * (double) (k2+1);
-		double t2 = fEnuStepDif * (double) (k2+2);
+        double e1 = fEnuStepDif * (double) (k1+1);
+        double e2 = fEnuStepDif * (double) (k1+2);
+        double t1 = fEnuStepDif * (double) (k2+1);
+        double t2 = fEnuStepDif * (double) (k2+2);
 
-		double sig_e1_t1 = 0.0;
-		double sig_e1_t2 = 0.0;
-		double sig_e2_t1 = 0.0;
-		double sig_e2_t2 = 0.0;
+        double sig_e1_t1 = 0.0;
+        double sig_e1_t2 = 0.0;
+        double sig_e2_t1 = 0.0;
+        double sig_e2_t2 = 0.0;
 
-		double Te1 = Temax * fTableTeMin;
-		double Te2 = Temax * fTableTeMax;
+        double Te1 = Temax * fTableTeMin;
+        double Te2 = Temax * fTableTeMax;
 
-		/**
-		 * List of relevant variables at this point:
-		 * - k1 : Index of Enu part of the table.
-		 * - k2 : Index of the Te part of the table.
-		 * - e1,e1 : Closest points in Enu in the table.
-		 * - t1,t2 : Closest points in Te in the table.
-		 * - sig_e1_t1,sig_e2_t2,sig_e2_t1,sig_e1_t2 : \f$ \frac{d\sigma}{dT}\left(e_{i},Te_{j}\right)\f$
-		 * - Te1,Te2 : Limits on the recoil energy in the table.
-		 */
+        /**
+         * List of relevant variables at this point:
+         * - k1 : Index of Enu part of the table.
+         * - k2 : Index of the Te part of the table.
+         * - e1,e1 : Closest points in Enu in the table.
+         * - t1,t2 : Closest points in Te in the table.
+         * - sig_e1_t1,sig_e2_t2,sig_e2_t1,sig_e1_t2 : \f$ \frac{d\sigma}{dT}\left(e_{i},Te_{j}\right)\f$
+         * - Te1,Te2 : Limits on the recoil energy in the table.
+         */
 
-		// Check indexes against table entries
-		if (k1 >= 0 && k1 < fNDataDif-1 && k2 >= 0 && k2 < fNDataDif-1) {
-
-			// Get the closest points of \f$\frac{d\sigma}{dT}\f$
-			if ( fReaction == nue || fReaction == numu) {
-				sig_e1_t1 = fTableDif[k1 * fNDataDif + k2];
-				sig_e1_t2 = fTableDif[k1 * fNDataDif + k2+1];
-				sig_e2_t1 = fTableDif[(k1+1) * fNDataDif + k2];
-				sig_e2_t2 = fTableDif[(k1+1) * fNDataDif + k2+1];
-			} else {
-				warn << "[ESCrossSec]::dSigmadT : " << fReactionStr
-						<< " not supported with Radiative correction strategy "
-						<< fRadiativeCorrection << " !!" << newline;
+        // Check indexes against table entries
+        if (fExistTableDif && k1 >= 0 && k1 < fNDataDif-1 && k2 >= 0 && k2 < fNDataDif-1) {
+            // Get the closest points of \f$\frac{d\sigma}{dT}\f$
+            if (fReaction == nue || fReaction == numu) {
+                sig_e1_t1 = fTableDif[k1 * fNDataDif + k2];
+                sig_e1_t2 = fTableDif[k1 * fNDataDif + k2+1];
+                sig_e2_t1 = fTableDif[(k1+1) * fNDataDif + k2];
+                sig_e2_t2 = fTableDif[(k1+1) * fNDataDif + k2+1];
+            }
+            else {
+                //Should never reach here if table does not exist. Instead should use analytic calculations below.
+                warn << "[ESCrossSec]::dSigmadT : " << fReactionStr
+                     << " not supported with Radiative correction strategy "
+             		 << fRadiativeCorrection << " !!" << newline;
                 Log::Die("[ESCrossSec]::dSigmadT : " + fReactionStr
-						+ " not supported with Radiative correction strategy "
-						+ util_to_string(fRadiativeCorrection) + " !!");
-			}
+                     + " not supported with Radiative correction strategy "
+                     + util_to_string(fRadiativeCorrection) + " !!");
+            }
+        }
 
-			// If strategy is 4 (1 has already been put out)
-			// If diff. cross-sections are valid
-			// If recoil energy is inside table limits.
-			if (fRadiativeCorrection != 3 && fRadiativeCorrection != 2 &&
-					sig_e1_t1 > 0.0 && sig_e1_t2 > 0.0 &&
-					sig_e2_t1 > 0.0 && sig_e2_t2 > 0.0 &&
-					(fRadiativeCorrection == 4 || (Te > Te1 && Te < Te2))) {
+        // If strategy is 4 (1 has already been put out)
+        // If table exists
+        // If diff. cross-sections are valid
+        // If recoil energy is inside table limits.
+        if (fRadiativeCorrection != 3 && fRadiativeCorrection != 2 && fExistTableDif &&
+                sig_e1_t1 > 0.0 && sig_e1_t2 > 0.0 &&
+                sig_e2_t1 > 0.0 && sig_e2_t2 > 0.0 &&
+                (fRadiativeCorrection == 4 || (Te > Te1 && Te < Te2))) {
+            // Interpolate from the table.
+            double r1 = (sig_e1_t2 - sig_e1_t1) / (t2 -t1)
+                * (Te - t1) +  sig_e1_t1;
+            double r2 = (sig_e2_t2 - sig_e2_t1) / (t2 -t1)
+                * (Te - t1) +  sig_e2_t1;
+            return ((r2 - r1) / (e2 - e1) * (Enu - e1) + r1);
+        }
+        else {
+            // If strategy is 2 or 3
+            // If strategy is 4 but Te is outside interpolation range
+            double E = fMe + Te;
+            double x = sqrt(1.0 + 2.0 * fMe / Te);
+            double z = Te / Enu;
+            double el = sqrt(E * E - fMe * fMe);
+            double IT = 1.0 / 6.0 * (1.0 / 3.0 + (3.0 - x * x)
+                    * (0.5 * x * log((x + 1.0) / (x - 1.0)) - 1.0));
 
-				// Interpolate from the table.
-				double r1 = (sig_e1_t2 - sig_e1_t1) / (t2 -t1)
-					* (Te - t1) +  sig_e1_t1;
-				double r2 = (sig_e2_t2 - sig_e2_t1) / (t2 -t1)
-					* (Te - t1) +  sig_e2_t1;
-				return ((r2 - r1) / (e2 - e1) * (Enu - e1) + r1);
-
-			} else {
-				// If strategy is not 2 or 3
-				// If strategy is 4 but Te is outside interpolation range
-
-				double E = fMe + Te;
-
-				double x = sqrt(1.0 + 2.0 * fMe / Te);
-
-				double z = Te / Enu;
-				double el = sqrt(E * E - fMe * fMe);
-				double IT = 1.0 / 6.0 * (1.0 / 3.0 + (3.0 - x * x)
-						* (0.5 * x * log((x + 1.0) / (x - 1.0)) - 1.0));
-
-				// FIXME : Correct this otherwise the maximum won't be for Te = Temax
-				// To avoid log(-1.0e15) in fm,fpz,fpm when Te = Temax
-				if (1.0-z-fMe/(E+el) <= 0.0) {
+            // FIXME : Correct this otherwise the maximum won't be for Te = Temax
+            // To avoid log(-1.0e15) in fm,fpz,fpm when Te = Temax
+            if (1.0-z-fMe/(E+el) <= 0.0) {
 #ifdef RATDEBUG
-					debug << "[ESCrossSec]::dSigmadT :  warning: 1.0-z-fMe/(E+el) = "
-							<< 1.0-z-fMe/(E+el) << newline;
-					debug << "[ESCrossSec]::dSigmadT : Enu = " << Enu << " Te = " <<Te << newline;
+                debug << "[ESCrossSec]::dSigmadT :  warning: 1.0-z-fMe/(E+el) = " << 1.0-z-fMe/(E+el) << newline;
+                debug << "[ESCrossSec]::dSigmadT : Enu = " << Enu << " Te = " <<Te << newline;
 #endif
-					return 0.0;
+                return 0.0;
+            }
+
+            // just use central values for pnc and kappa (correct ?)
+            double gl, gr, kappa, pnc = 1.0126;
+
+            if (fRadiativeCorrection != 2) {
+                if (fReaction == nue) {
+                    kappa = 0.9791 + 0.0097 * IT;
+                    if (fRadiativeCorrection == 2) {
+                        pnc = kappa = 1.0;
+                    }
+                    gl =  pnc * (0.5 - kappa * fsinthetaW2) - 1.0;
+                    gr = -pnc * kappa * fsinthetaW2;
+                }
+                else if (fReaction == numu) {
+                    kappa = 0.9970 - 0.00037 * IT;
+                    if (fRadiativeCorrection == 2) {
+                        pnc = kappa = 1.0;
+                    }
+                    gl =  pnc * (0.5 - kappa * fsinthetaW2);
+                    gr = -pnc * kappa * fsinthetaW2;
+
+                }
+                else {
+                    warn << "[ESCrossSec]::dSigmadT : " << fReactionStr
+                         << " not supported with Radiative correction strategy "
+                      	 << fRadiativeCorrection << ". Computing analytically without radiative corrections instead." << newline;
+                    // Analytical radiative correction not supported yet for nuebar, numubar
+                    gl = fgL;
+                    gr = fgR;
 				}
+            }
+            else {
+                gl = fgL;
+                gr = fgR;
+            }
 
-				// just use central values for pnc and kappa (correct ?)
-				double gl = 0, gr = 0, kappa = 0, pnc = 1.0126;
+            // turn off radiative correction,
+            // if fRadiativeCorrection == 2
+            double fm  = 0.0;
+            double fpz = 0.0;
+            double fpm = 0.0;
 
-				if ( fReaction == nue) {
-					kappa = 0.9791 + 0.0097 * IT;
-					if (fRadiativeCorrection == 2) {
-						pnc = kappa = 1.0;
-					}
-					gl =  pnc * (0.5 - kappa * fsinthetaW2) - 1.0;
-					gr = -pnc * kappa * fsinthetaW2;
-				} else if (fReaction == numu)    {
-					kappa = 0.9970 - 0.00037 * IT;
-					if (fRadiativeCorrection == 2) {
-						pnc = kappa = 1.0;
-					}
-					gl =  pnc * (0.5 - kappa * fsinthetaW2);
-					gr = -pnc * kappa * fsinthetaW2;
+            //Calculate corrections for strategy 3, 4 when outside bounds
+            if (fRadiativeCorrection != 2) {
+                fm = (E/el * log((E+el)/fMe)-1.0) *
+                    (2.0*log(1.0-z-fMe/(E+el))
+                     - log(1.0-z) - 0.5*log(z) - 5.0/12.0) + 0.5 *
+                    (fL(z) - fL(el/E)) - 0.5 * log(1.0-z)*log(1.0-z) -
+                    (11.0/12.0 + 0.5 * z) * log(1.0-z)
+                    + z * (log(z) + 0.5 * log(2.0*Enu/fMe))
+                    - (31.0/18.0 + 1.0/12.0 * log(z))*el/E
+                    - 11.0/12.0 * z + z*z/24.0;
 
-				} else {
-					warn << "[ESCrossSec]::dSigmadT : " << fReactionStr
-							<< " not supported with Radiative correction strategy "
-							<< fRadiativeCorrection << " !!" << newline;
-                    Log::Die("[ESCrossSec]::dSigmadT : " + fReactionStr
-							+ " not supported with Radiative correction strategy "
-							+ util_to_string(fRadiativeCorrection) + " !!");
-					// not supported yet
-				}
+                fpz = (E/el * log((E+el)/fMe)-1.0) *
+                    ((1.0-z)*(1.0-z) * (2.0*log(1.0-z-fMe/(E+el))
+                        - log(1.0-z) - 0.5*log(z) - 2.0/3.0) - 0.5 *
+                     (z*z * log(z) + 1.0 - z))
+                    - 0.5 * (1.0-z)*(1.0-z) * (log(1.0-z)*log(1.0-z) + el/E *
+                            (fL(1.0-z) - log(z) * log(1.0-z)))
+                    + log(1.0-z) * (z*z/2.0*log(z) + (1.0-z)/3.0*
+                            (2.0*z-1.0/2.0))
+                    - 0.5 * z*z * fL(1.0-z) - z*(1.0-2.0*z)/3.0 *
+                    log(z) - z*(1.0-z)/6.0 - el/E/12.0*(log(z) +
+                            (1.0-z)*(115.0-109.0*z)/6.0);
 
-				// turn off radiative correction,
-				// if fRadiativeCorrection == 2
-				double fm  = 0.0;
-				double fpz = 0.0;
-				double fpm = 0.0;
+                fpm = (E/el * log((E+el)/fMe)-1.0) * 2.0 *
+                    log(1.0-z-fMe/(E+el));
+            }
 
-				if (fRadiativeCorrection != 2) {
-					fm = (E/el * log((E+el)/fMe)-1.0) *
-							(2.0*log(1.0-z-fMe/(E+el))
-					- log(1.0-z) - 0.5*log(z) - 5.0/12.0) + 0.5 *
-					(fL(z) - fL(el/E)) - 0.5 * log(1.0-z)*log(1.0-z) -
-					(11.0/12.0 + 0.5 * z) * log(1.0-z)
-					+ z * (log(z) + 0.5 * log(2.0*Enu/fMe))
-					- (31.0/18.0 + 1.0/12.0 * log(z))*el/E
-					- 11.0/12.0 * z + z*z/24.0;
+            double dsigma_dT = 2.0 * fGf*fGf * fMe / pi * (
+                    gl * gl * (1.0 + falpha / pi * fm)
+                    + gr * gr * ((1.0 - z) * (1.0 - z) + falpha / pi * fpz)
+                    - gr * gl * fMe / Enu * z * (1.0 + falpha / pi * fpm));
 
-					fpz = (E/el * log((E+el)/fMe)-1.0) *
-							((1.0-z)*(1.0-z) * (2.0*log(1.0-z-fMe/(E+el))
-					- log(1.0-z) - 0.5*log(z) - 2.0/3.0) - 0.5 *
-					(z*z * log(z) + 1.0 - z))
-					- 0.5 * (1.0-z)*(1.0-z) * (log(1.0-z)*log(1.0-z) + el/E *
-							(fL(1.0-z) - log(z) * log(1.0-z)))
-							+ log(1.0-z) * (z*z/2.0*log(z) + (1.0-z)/3.0*
-									(2.0*z-1.0/2.0))
-									- 0.5 * z*z * fL(1.0-z) - z*(1.0-2.0*z)/3.0 *
-									log(z) - z*(1.0-z)/6.0 - el/E/12.0*(log(z) +
-											(1.0-z)*(115.0-109.0*z)/6.0);
+            return   dsigma_dT * fhbarc2 * 1.0e9;
+        }
+    }
 
-					fpm = (E/el * log((E+el)/fMe)-1.0) * 2.0 *
-							log(1.0-z-fMe/(E+el));
-				}
-
-				double dsigma_dT = 2.0 * fGf*fGf * fMe / pi * (
-						gl * gl * (1.0 + falpha / pi * fm)
-						+ gr * gr * ((1.0 - z) * (1.0 - z) + falpha / pi * fpz)
-						- gr * gl * fMe / Enu * z * (1.0 + falpha / pi * fpm));
-
-				return   dsigma_dT * fhbarc2 * 1.0e9;
-			}
-		} else {
-			warn << "[ESCrossSec]::dSigmadT : Got invalid values for variables k_i: k1 " << k1
-					<< " k2 " << k2 << newline;
-            Log::Die("[ESCrossSec]::dSigmadT : Got invalid values for variables k_i: k1 " + util_to_string(k1) + " k2 " + util_to_string(k2));
-		}
-
-	}
-
-	warn << "[ESCrossSec]::dSigmadT > Reached end of function while calculating dSigmadT. Something is wrong with the calculation." << newline;
-	warn << "[ESCrossSec]::dSigmadT > Current parameters : Calculation Strategy : [ "
-			<< fRadiativeCorrection << " ], Reaction : [ " << fReactionStr << " ] " << newline;
-	warn << "[ESCrossSec]::dSigmadT > Enu : [ " << Enu << " ], Te  : [ "
-			<<  Te << " ], TeMax  : [ "  <<  Temax << " ] " << newline;
-	warn << "[ESCrossSec]::dSigmadT > k1 : " << k1 << " k2 : " << k2 << " fEnuStepDif : " << fEnuStepDif << newline;
+    warn << "[ESCrossSec]::dSigmadT > Reached end of function while calculating dSigmadT. Something is wrong with the calculation." << newline;
+    warn << "[ESCrossSec]::dSigmadT > Current parameters : Calculation Strategy : [ " << fRadiativeCorrection
+         << " ], Reaction : [ " << fReactionStr << " ] " << newline;
+    warn << "[ESCrossSec]::dSigmadT > Enu : [ " << Enu << " ], Te  : [ " <<  Te << " ], TeMax  : [ "  <<  Temax << " ] " << newline;
+    warn << "[ESCrossSec]::dSigmadT > k1 : " << k1 << " k2 : " << k2 << " fEnuStepDif : " << fEnuStepDif << newline;
     Log::Die("Failed calculation of dSigmadT.");
-	return 0.0;
+    return 0.0;
 
 }
 
-double ESCrossSec::IntegraldSigmadT(const double Enu,const double T1,const double T2) const
-{
-	// Integrate dSigma/dT of Enu from T1 to T2
+double ESCrossSec::IntegraldSigmadT(const double Enu,const double T1,const double T2) const {
+    // Integrate dSigma/dT of Enu from T1 to T2
+    const int  nbins = 1000;
+    double Tstep = (T2-T1)/nbins;
 
+    double integral = 0.5*(dSigmadT(Enu,T1) + dSigmadT(Enu,T2));
+    for (double T = T1 + Tstep; T < T2; T += Tstep) {
+        integral += dSigmadT(Enu,T);
+    }
+    integral *= Tstep;
 
-	int i;
-	const int  nbins = 100;
-	double integral;
-	double x1 = T1;
-	double x2 = T2;
-	double T,dsig;
-	double Tstep = (x2-x1)/(double)nbins;
-
-
-	TH1F *h = new TH1F("h1","h1",nbins,x1,x2);
-	for(i=0, T=x1;i<nbins;i++,T+= Tstep){
-		dsig = dSigmadT(Enu,T);
-		h->Fill(T + (Tstep/2.0),dsig * Tstep);
-	}
-	integral = h->Integral();
-	delete h;
-
-	return(integral);
+    return integral;
 }
-
 
 //--------------------------------------
 
+double ESCrossSec::dSigmadCosTh(const double Enu,const double CosTh) const {
+    // Differential cross section
+    //  d Sigma
+    //  -------
+    //  d CosTh
+    //
+    //  Enu = laboratory neutrino energy        -- units: MeV
+    //  CosTh = laboratory recoil electron direction cosine
+    //  dSigmadT units:  10^-42 cm^2/MeV
+    //
+    // Taken from Bahcall "Neutrino Astrophysics" eqn 8.40
+    //
+    // modified: M. Chen 14 March 2001
+    // correcting John Bahcall's bad Te in units of me formulae
+    const double mu    = CosTh;
+    const double mu2   = mu*mu;
+    const double Enu2  = Enu*Enu;
+    const double meEnu = fMe + Enu;
 
-double ESCrossSec::dSigmadCosTh(const double Enu,const double CosTh) const
-{
-	// Differential cross section
-	//  d Sigma
-	//  -------
-	//  d CosTh
-	//
-	//  Enu = laboratory neutrino energy        -- units: MeV
-	//  CosTh = laboratory recoil electron direction cosine
-	//  dSigmadT units:  10^-42 cm^2/MeV
-	//
-	// Taken from Bahcall "Neutrino Astrophysics" eqn 8.40
-	//
-	// modified: M. Chen 14 March 2001
-	// correcting John Bahcall's bad Te in units of me formulae
+    // first see if scattering angle is greater than 90 degrees
+    // (not allowed)
+    if (mu < 0.0) {
+        return 0.0;
+    }
 
+    double Denom = meEnu*meEnu - Enu2*mu2;
+    double T = (2.0 * Enu2 * mu2 * fMe) / Denom;
+    double dsigdT = dSigmadT(Enu,T);
+    double dSdCosT = dsigdT *fMe*4.0*meEnu*meEnu*Enu2*mu/(Denom*Denom);
 
-
-
-	const double mu = CosTh;
-	const double mu2 = mu*mu;
-	const double Enu2 = Enu*Enu;
-	const double meEnu = fMe + Enu;
-
-	// first see if scattering angle is greater than 90 degrees
-	// (not allowed)
-	if(mu < 0.0){
-		return 0.0;
-	}
-
-
-
-	double Denom = meEnu*meEnu - Enu2*mu2;
-
-	double T  = (2.0 * Enu2 * mu2 * fMe) / Denom;
-
-	double dsigdT = dSigmadT(Enu,T);
-
-	return dsigdT *fMe*4.0*meEnu*meEnu*Enu2*mu/(Denom*Denom);
+    return dSdCosT;
 }
-
-
-
-//---------------- private routine ----------------------------
-
-// fL(): add by y.t. 14-JAN-2003
-double ESCrossSec::fL(const double x) const
-{
-	int istep = 1000;    // should not be hard corded??
-
-	double dstep = x / (double) istep;
-	double t;
-	double sum = 0.0;
-
-	for (int i = 1; i <= istep; i++) {
-		t = dstep * (double) i;
-		sum = sum + log(fabs(1.0 - t))/t * dstep;
-	}
-
-	return sum;
-}
-
 
 //--------------------------------------
-
-
 void ESCrossSec::SetRadiativeCorrection(const int ii) {
-	fRadiativeCorrection = ii;
-
-	// if any of the table options are set we need to load the table
-	if (fRadiativeCorrection != 1) LoadTablesDB();
-
+    //Don't change anything if the setting is the same
+    if (fRadiativeCorrection != ii) {
+        fRadiativeCorrection = ii;
+        // if any of the table options are set we need to load the table
+        if (fRadiativeCorrection != 1) {
+            LoadTablesDB();
+        }
+    }
 }
 
 //--------------------------------------
+void ESCrossSec::LoadTablesDB() {
+    // Get two different links (total and differential)
+    // depending on the reaction
+    // load the total cross section table
+    std::string tblname = "pnue_tot_";
+    tblname += fReactionStr;
 
-void ESCrossSec::LoadTablesDB()
-{
-	// Get two different links (total and differential)
-	// depending on the reaction
-	// load the total cross section table
-	std::string tblname = "pnue_tot_";
-	tblname += fReactionStr;
+    try {
+        DBLinkPtr linkdb = DB::Get()->GetLink("ESXS",tblname.c_str());
+        fNDataTot = 0;
+        fEnuStepTot = 0.0;
 
-	DBLinkPtr linkdb = DB::Get()->GetLink("ESXS",tblname.c_str());
-	fNDataTot = 0;
-	fEnuStepTot = 0.0;
+        fNDataTot   = linkdb->GetI("NData");
+        fEnuStepTot = linkdb->GetD("EStep");
+        fTableTot_e.Set(linkdb->GetDArray("data_enu"),linkdb->GetDArray("data_xsec"));
+        fExistTableTot = true;
+    }
+    catch (DBNotFoundError &) {
+        RAT::warn << "ESCrossSec: Table ESXS[" << tblname << "] does not exist or is incomplete. Defaulting to analytic calculation" << newline;
+        fExistTableTot = false;
+    }
+    // now load the differential cross section table
+    // This is a "square" table. It contains as many entries in Enu as Te
+    // It increases first in Enu and then in T
+    tblname = "pnue_dif_";
+    tblname += fReactionStr;
 
-	fNDataTot   = linkdb->GetI("NData");
-	fEnuStepTot = linkdb->GetD("EStep");
-	fTableTot_e.Set(linkdb->GetDArray("data_enu"),linkdb->GetDArray("data_xsec"));
+    try {
+        DBLinkPtr linkdb = DB::Get()->GetLink("ESXS",tblname.c_str());
+        fNDataDif = linkdb->GetI("NData");
+        fEnuStepDif = linkdb->GetD("EStep");
 
-	// now load the differential cross section table
-	// This is a "square" table. It contains as many entries in Enu as Te
-	// It increases first in Enu and then in T
-	tblname = "pnue_dif_";
-	tblname += fReactionStr;
-	linkdb = DB::Get()->GetLink("ESXS",tblname.c_str());
-	fNDataDif = linkdb->GetI("NData");
-	fEnuStepDif = linkdb->GetD("EStep");
-
-	fTableDif = linkdb->GetDArray("data_xsec");
-
+        fTableDif = linkdb->GetDArray("data_xsec");
+        fExistTableDif = true;
+    }
+    catch (DBNotFoundError &) {
+        RAT::warn << "ESCrossSec: Table ESXS[" << tblname << "] does not exist or is incomplete. Defaulting to analytic calculation" << newline;
+        fExistTableDif = false;
+    }
 }
 
 //_________________________________________________________________________
-void ESCrossSec::SetReaction(const std::string &rstr)
-{
+void ESCrossSec::SetReaction(const std::string &rstr) {
+    // Set the reaction type
+    // valid types are:  nue     --  nu_e + e       -> nu_e + e
+    //                   nuebar  --  anti nu_e + e  -> anti nu_e + e
+    //                   numu    --  nu_mu + e      -> nu_mu + e
+    //                   numubar --  anti nu_mu + e -> anti nu_mu + e
+    if (rstr == std::string("nue")) {
+        fReactionStr = rstr;
+        fReaction = nue;
+    }
+    else if (rstr == std::string("numu")) {
+        fReactionStr = rstr;
+        fReaction = numu;
+    }
+    else if (rstr == std::string("numubar")) {
+        fReactionStr = rstr;
+        fReaction = numubar;
+    }
+    else if (rstr == std::string("nuebar")) {
+        fReactionStr = rstr;
+        fReaction = nuebar;
+    }
+    else {
+        warn << "ESCrossSec::SetReaction > Unknown reaction [ " << rstr << " ]." << newline;
+        throw std::invalid_argument("Unknown reaction " + rstr);
+    }
 
-	// Set the reaction type
-	// valid types are:  nue     --  nu_e + e       -> nu_e + e
-	//                   nuebar  --  anti nu_e + e  -> anti nu_e + e
-	//                   numu    --  nu_mu + e      -> nu_mu + e
-	//                   numubar --  anti nu_mu + e -> anti nu_mu + e
-
-	if (rstr == std::string("nue")) {
-		fReactionStr = rstr;
-		fReaction = nue;
-	} else if (rstr == std::string("numu")) {
-		fReactionStr = rstr;
-		fReaction = numu;
-	} else if (rstr == std::string("numubar")) {
-		fReactionStr = rstr;
-		fReaction = numubar;
-	} else if (rstr == std::string("nuebar")) {
-		fReactionStr = rstr;
-		fReaction = nuebar;
-	} else {
-		warn << "ESCrossSec::SetReaction > Unknown reaction [ "
-				<< rstr << " ]." << newline;
-		throw std::invalid_argument("Unknown reaction " + rstr);
-	}
-
-	// Now that the reaction is set perform
-	// the calculation of the gL and gR constants
-	// These only depend on the weak mixing angle
-	// and the specific reaction type
-	CalcG();
-	if (fRadiativeCorrection != 1) LoadTablesDB();
-
+    // Now that the reaction is set perform
+    // the calculation of the gL and gR constants
+    // These only depend on the weak mixing angle
+    // and the specific reaction type
+    CalcG();
+    if (fRadiativeCorrection != 1) {
+        LoadTablesDB();
+    }
 }
 
 //________________________________________________________________________________
 void ESCrossSec::SetSinThetaW(const double &sintw) {
-	fsinthetaW2 = sintw;
-	// New calculation.
-	// Force recalculation of gL and GR
-	CalcG();
+    fsinthetaW2 = sintw;
+    // New calculation.
+    // Force recalculation of gL and GR
+    CalcG();
 }
 
 TGraph *ESCrossSec::DrawdSigmadT(const double Enu) const {
 #ifdef RATDEBUG
-	debug << "[ESCrossSec]::DrawdSigmadT : Sampling Enu=" << Enu << " MeV." << newline;
+   debug << "[ESCrossSec]::DrawdSigmadT : Sampling Enu=" << Enu << " MeV." << newline;
 #endif
 
-	TGraph *g = new TGraph();
-	const int npoints = 1024;
-	const double emin = 0.0, emax = Enu;
-	const double xwid = emax - emin;
-	const double xstep = xwid/(double)npoints;
+   TGraph *g = new TGraph();
+   const int npoints = 1024;
+   const double xstep = Enu/npoints;
 #ifdef RATDEBUG
-	debug << "[ESCrossSec]::DrawdSigmadT : Sampling data: emin=" << emin << " MeV."
-			<< " emax=" << emax << " MeV xwid=" << xwid << " MeV  xstep=" << xstep
-			<< newline;
+   debug << "[ESCrossSec]::DrawdSigmadT : Sampling data: xstep= " << xstep << " MeV. " << newline;
 #endif
 
-	double Te,dsigma;
-	for (int ip = 0; ip < npoints; ++ip) {
-		Te = emin + (double)ip*xstep;
-		dsigma = dSigmadT(Enu,Te);
-		g->SetPoint(ip,Te,dsigma);
-	}
-	//g->Print();
-	return g;
+    for (int ip = 0; ip < npoints; ++ip) {
+        double Te = ip*xstep;
+        double dsigma = dSigmadT(Enu,Te);
+        g->SetPoint(ip,Te,dsigma);
+    }
+    return g;
 }
 } // -- namespace RAT


### PR DESCRIPTION
Like I've done for the SNO+ RAT version of this code, I've reworked things for the ES cross section calculator to allow for calculation above the table bounds and for nubars in addition to just nus. The changes should be essentially 1-to-1 with what I did for SNO+ albeit the calculator is subclassed from a generic cross section calculator class in SNO+ RAT so there are some slight differences. The SNO+ changes were reviewed and merged, so this should be good to go.