### PR TITLE
Set cry random to clhep

### DIFF
--- a/src/gen/src/VertexGen_CRY.cc
+++ b/src/gen/src/VertexGen_CRY.cc
@@ -58,6 +58,9 @@ VertexGen_CRY::VertexGen_CRY(const char *arg_dbname)
   // Setup
   std::string crydirectory = static_cast<std::string>(getenv("CRYDATA"));
   CRYSetup* setup = new CRYSetup(setupString, crydirectory);
+  setup->setRandomFunction(
+      [](){return CLHEP::RandFlat::shoot();}
+  );
   generator = new CRYGenerator(setup);
   // Setup the time based on the configuration date string
   int month = stoi(date.substr(0, date.find("-")));


### PR DESCRIPTION
Setup to fix issue #15

Currently cry uses
```c++
 66 double CRYUtils::tmpRandom() {
 67   static unsigned long int next = 1;
 68 
 69   next=next*1103515245+123345;
 70   unsigned temp=(unsigned)(next/65536) % 32768;
 71 
 72   return ( temp + 1.0 ) / 32769.0;
 73 }
``` 