### PR TITLE
Adding Trigger time offset to WaveformGenerator algorythm

### DIFF
--- a/src/daq/include/RAT/SplitEVDAQProc.hh
+++ b/src/daq/include/RAT/SplitEVDAQProc.hh
@@ -11,6 +11,8 @@
 #include <RAT/WaveformAnalysis.hh>
 #include <string>
 
+const UShort_t INVALID = 99999;
+
 namespace RAT {
 
 class SplitEVDAQProc : public Processor {

--- a/src/daq/src/WaveformAnalysis.cc
+++ b/src/daq/src/WaveformAnalysis.cc
@@ -80,9 +80,10 @@ double WaveformAnalysis::CalculateTime(std::vector<UShort_t> wfm, UShort_t low_w
   double peak = 9999;
   UShort_t peak_sample = 0;
   GetPeak(wfm, dy, pedestal, peak, peak_sample);
-
   UShort_t threshold_crossing_sample =
       GetThresholdCrossing(wfm, dy, pedestal, peak, peak_sample, cfd_fraction, lookback);
+
+  if(threshold_crossing_sample == INVALID) return INVALID;
 
   double time_step = 1.0 / sampling_rate;  // in ns
 
@@ -91,7 +92,6 @@ double WaveformAnalysis::CalculateTime(std::vector<UShort_t> wfm, UShort_t low_w
   double v1 = (wfm[threshold_crossing_sample + 1] - pedestal) * dy;
   double v2 = (wfm[threshold_crossing_sample] - pedestal) * dy;
   double dt = Interpolate(v1, v2, voltage_crossing, time_step);
-
   double tcdf = double(threshold_crossing_sample) * time_step + dt;
 
   return tcdf;


### PR DESCRIPTION
Adding a calibrated trigger time correction to the waveform generation algorithm. This forces later light to be in the correct time window prior to generating the waveform.

This allows neutron and radionuclide production to record waveform. There may now be an offset with time 0 for electrons/gamma simulation due to this correction. 

Attached is a plot for neutron simulated in a pure scintillator (gd_scintillator option) detector. Y-axis shows the baseline corrected waveform integral vs the generated charge (they are not supposed to match one for one, but should be linear with each other). 

![Screen Shot 2023-01-11 at 12 14 32](https://user-images.githubusercontent.com/4052178/211908479-4940a130-1055-4c2b-99cc-0b3a767acff1.png)
