### PR TITLE
Improvements to logging 

### DIFF
--- a/src/cmd/src/CCCrossSecMessenger.cc
+++ b/src/cmd/src/CCCrossSecMessenger.cc
@@ -34,10 +34,10 @@ CCCrossSecMessenger::~CCCrossSecMessenger() { ; }
 void CCCrossSecMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
   if (command == fWmaCmd) {
     G4double wma = fWmaCmd->GetNewDoubleValue(newValue);
-    std::cout << "Warning not using WMA: " << wma << std::endl;
+    info << "Warning not using WMA: " << wma << newline;
   } else if (command == fStratCmd) {
     G4int strat = fStratCmd->GetNewIntValue(newValue);
-    std::cout << "Warning not using strategy: " << strat << std::endl;
+    info << "Warning not using strategy: " << strat << newline;
   } else {
     warn << "Error: Invalid CCCrossSecMessenger \"set\" command" << newline;
   }

--- a/src/cmd/src/CoincidenceMessenger.cc
+++ b/src/cmd/src/CoincidenceMessenger.cc
@@ -10,6 +10,7 @@
 #include <G4UIdirectory.hh>
 #include <RAT/CoincidenceMessenger.hh>
 #include <RAT/Coincidence_Gen.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 

--- a/src/cmd/src/FastNeutronMessenger.cc
+++ b/src/cmd/src/FastNeutronMessenger.cc
@@ -12,6 +12,7 @@
 #include <G4UIcommand.hh>
 #include <G4UIdirectory.hh>
 #include <RAT/VertexGen_FastNeutron.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 

--- a/src/cmd/src/GLG4DebugMessenger.cc
+++ b/src/cmd/src/GLG4DebugMessenger.cc
@@ -105,7 +105,7 @@ GLG4DebugMessenger::GLG4DebugMessenger(RAT::DetectorConstruction *mydetector) : 
 GLG4DebugMessenger::~GLG4DebugMessenger() {}
 
 static void DumpGeom(G4VPhysicalVolume *pv, const char *s) {
-  G4cout << "*******************************\n";
+  G4cout << "*******************************" << newline;
   G4cout << "Physical volume dump for " << s << G4endl;
   G4cout << " Name: " << pv->GetName() << G4endl;
 
@@ -128,7 +128,7 @@ static void DumpGeom(G4VPhysicalVolume *pv, const char *s) {
   if (ndaught == 0) {
     G4cout << "Has no daughters." << G4endl;
   } else {
-    G4cout << "Has " << ndaught << " daughters:\n";
+    G4cout << "Has " << ndaught << " daughters:" << newline;
     for (G4int i = 0; i < ndaught; i++) G4cout << "\t" << lv->GetDaughter(i)->GetName();
     G4cout << G4endl;
   }
@@ -142,7 +142,7 @@ static void SetMaterial(G4String newValues) {
   G4String matName;
   iss >> lvName >> matName;
   if (iss.fail()) {
-    G4cerr << "Could not parse volume and material name from command args\n";
+    G4cerr << "Could not parse volume and material name from command args" << newline;
     G4cerr.flush();
     return;
   }
@@ -158,7 +158,7 @@ static void SetMaterial(G4String newValues) {
     if (lv->GetName() == lvName) break;
   }
   if (lv == NULL || ilv >= nlv) {  // not found
-    G4cerr << "Error, logical volume named \'" << lvName << "\' not found\n";
+    G4cerr << "Error, logical volume named \'" << lvName << "\' not found" << newline;
     G4cerr.flush();
     return;
   }
@@ -166,7 +166,7 @@ static void SetMaterial(G4String newValues) {
   // access the store of materials
   G4Material *mat = G4Material::GetMaterial(matName);
   if (mat == NULL) {
-    G4cerr << "Error, material named \'" << matName << "\' not found\n";
+    G4cerr << "Error, material named \'" << matName << "\' not found" << newline;
     G4cerr.flush();
     return;
   }
@@ -216,7 +216,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
         if (pv->GetName() == newValues) break;
       }
       if (pv == NULL || ipv >= npv) {  // not found
-        G4cerr << "Error, name \'" << newValues << "\' not found\n";
+        G4cerr << "Error, name \'" << newValues << "\' not found" << newline;
         G4cerr.flush();
       } else {
         DumpGeom(pv, newValues);
@@ -239,7 +239,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
 
     // if no arguments or nloop==0, list the solids
     if (nloop == 0) {
-      G4cout << "Here is a list of solid names\n";
+      G4cout << "Here is a list of solid names" << newline;
       for (isolid = 0; isolid < nsolid; isolid++) {
         G4VSolid *aSolid = (*theSolidStore)[isolid];
         if (!aSolid) break;
@@ -256,8 +256,8 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
         if (aSolid->GetName() == nameptr) break;
       }
       if (aSolid == NULL || isolid >= nsolid) {  // solid not found
-        G4cerr << "Error, solid name \'" << nameptr << "\' not found\n";
-        G4cerr << "Enter command with no parameters to get list of names\n";
+        G4cerr << "Error, solid name \'" << nameptr << "\' not found" << newline;
+        G4cerr << "Enter command with no parameters to get list of names" << newline;
         G4cerr.flush();
       } else {  // we found the solid, now test it
         G4Timer timer;
@@ -282,7 +282,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
     G4double new_value;
     iss >> parameterName;
     if (iss.fail()) {
-      G4cerr << "Could not parse parameter name from command args\n";
+      G4cerr << "Could not parse parameter name from command args" << newline;
       G4cerr.flush();
       return;
     }
@@ -327,7 +327,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
 
   // invalid command
   else {
-    G4cerr << "invalid GLG4 \"set\" command\n" << std::flush;
+    G4cerr << "invalid GLG4 \"set\" command" << newline << std::flush;
   }
 }
 

--- a/src/cmd/src/GLG4PrimaryGeneratorMessenger.cc
+++ b/src/cmd/src/GLG4PrimaryGeneratorMessenger.cc
@@ -13,6 +13,7 @@
 #include <RAT/Factory.hh>
 #include <RAT/GLG4PrimaryGeneratorAction.hh>
 #include <RAT/GLG4PrimaryGeneratorMessenger.hh>
+#include <RAT/Log.hh>
 #include <sstream>  // for string streams
 
 #include "G4Event.hh"

--- a/src/cmd/src/GLG4VisMessenger.cc
+++ b/src/cmd/src/GLG4VisMessenger.cc
@@ -18,6 +18,7 @@
 #include "RAT/GLG4VisManager.hh"
 #include "globals.hh"
 #include "local_g4compat.hh"
+#include <RAT/Log.hh>
 
 GLG4VisMessenger::GLG4VisMessenger(GLG4VisManager *pVMan_) : pVMan(pVMan_) {
   // the glg4vis directory
@@ -63,10 +64,10 @@ void GLG4VisMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
     vp.SetDolly(0.);
     vp.SetViewpointDirection(G4Vector3D(0., 1., 0.));
     vp.SetUpVector(G4Vector3D(0., 0., 1.));
-    G4cout << "Target point reset to (0.0,0.0,0.0)\n";
-    G4cout << "Zoom factor reset to 1.\n";
-    G4cout << "Dolly distance reset to 0.\n";
-    G4cout << "Viewpoint direction reset to +y.\n";
+    G4cout << "Target point reset to (0.0,0.0,0.0)" << newline;
+    G4cout << "Zoom factor reset to 1." << newline;
+    G4cout << "Dolly distance reset to 0." << newline;
+    G4cout << "Viewpoint direction reset to +y." << newline;
     G4cout << "Up vector set to +z.";
     G4cout << G4endl;
   } else if (commandname == "upvector") {

--- a/src/cmd/src/IBDgenMessenger.cc
+++ b/src/cmd/src/IBDgenMessenger.cc
@@ -6,6 +6,7 @@
 #include <G4UIdirectory.hh>
 #include <RAT/IBDgen.hh>
 #include <RAT/IBDgenMessenger.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 IBDgenMessenger::IBDgenMessenger(IBDgen *re) : ibdgen(re) {

--- a/src/cmd/src/IsotopeMessenger.cc
+++ b/src/cmd/src/IsotopeMessenger.cc
@@ -12,6 +12,7 @@
 #include <G4UIcommand.hh>
 #include <G4UIdirectory.hh>
 #include <RAT/VertexGen_Isotope.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 

--- a/src/cmd/src/ReacIBDgenMessenger.cc
+++ b/src/cmd/src/ReacIBDgenMessenger.cc
@@ -10,6 +10,7 @@
 #include <G4UIdirectory.hh>
 #include <RAT/ReacIBDgen.hh>
 #include <RAT/ReacIBDgenMessenger.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 ReacIBDgenMessenger::ReacIBDgenMessenger(ReacIBDgen *re) : reacibdgen(re) {

--- a/src/cmd/src/SNgenMessenger.cc
+++ b/src/cmd/src/SNgenMessenger.cc
@@ -10,6 +10,7 @@
 #include <G4UIdirectory.hh>
 #include <RAT/SNgen.hh>
 #include <RAT/SNgenMessenger.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 

--- a/src/core/src/GLG4SteppingAction.cc
+++ b/src/core/src/GLG4SteppingAction.cc
@@ -17,6 +17,7 @@
 #include "RAT/GLG4SteppingAction.hh"
 
 #include <RAT/TrackInfo.hh>
+#include <RAT/Log.hh>
 
 #include "CLHEP/Units/PhysicalConstants.h"
 #include "G4OpticalPhoton.hh"
@@ -113,7 +114,7 @@ int GLG4SteppingAction_dump_IlluminationMap(void) {
       static char filename[] = "map#.ppm";
       filename[3] = kmap + '0';
       std::ofstream of(filename);
-      of << "P6\n# Illumination map " << kmap << "\n" << nrowIlluminationMap << ' ' << nrowIlluminationMap << " 255\n";
+      of << "P6\n# Illumination map " << kmap << newline << nrowIlluminationMap << ' ' << nrowIlluminationMap << " 255" << newline;
       for (int irow = 0; irow < nrowIlluminationMap; irow++) {
         for (int jcol = 0; jcol < ncolIlluminationMap; jcol++)
           for (int kcol = 0; kcol < 3; kcol++) {
@@ -164,14 +165,14 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
   // check for very high number of steps
   if (track->GetCurrentStepNumber() % GLG4SteppingAction_MaxStepNumber == 0) {
     G4cerr << "warning:  step_no=" << track->GetCurrentStepNumber() << "  %  " << GLG4SteppingAction_MaxStepNumber
-           << " == 0 for particle: " << track->GetDefinition()->GetParticleName() << "\n";
+           << " == 0 for particle: " << track->GetDefinition()->GetParticleName() << newline;
   }
 
   if (track->GetCurrentStepNumber() > GLG4SteppingAction_MaxStepNumber &&
       !(track->GetDefinition()->GetParticleName() == "mu-" || track->GetDefinition()->GetParticleName() == "mu+")) {
     const G4VPhysicalVolume *pv = track->GetVolume();
     const G4VProcess *lastproc = track->GetStep()->GetPostStepPoint()->GetProcessDefinedStep();
-    G4cerr << "GLG4SteppingAction: Too many steps for this track, terminating!\n"
+    G4cerr << "GLG4SteppingAction: Too many steps for this track, terminating!" << newline
            << " step_no=" << track->GetCurrentStepNumber() << " type=" << track->GetDefinition()->GetParticleName()
            << "\n volume=" << (pv != 0 ? pv->GetName() : G4String("NULL"))
            << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))
@@ -307,7 +308,7 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
   // check for NULL world volume
   if (track->GetVolume() == NULL) {
     const G4VProcess *lastproc = track->GetStep()->GetPostStepPoint()->GetProcessDefinedStep();
-    G4cerr << "GLG4SteppingAction: Track in NULL volume, terminating!\n"
+    G4cerr << "GLG4SteppingAction: Track in NULL volume, terminating!" << newline
            << " step_no=" << track->GetCurrentStepNumber() << " type=" << track->GetDefinition()->GetParticleName()
            << "\n volume=NULL"
            << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))

--- a/src/core/src/GLG4VEventAction.cc
+++ b/src/core/src/GLG4VEventAction.cc
@@ -23,6 +23,7 @@
 #include "G4ios.hh"
 #include "RAT/GLG4Scint.hh"  // for doScintilllation and total energy deposition info
 #include "local_g4compat.hh"
+#include <RAT/Log.hh>
 
 // GLG4HitPhotonCollection GLG4VEventAction :: theHitPhotons=
 // GLG4HitPhotonCollection();
@@ -108,7 +109,7 @@ void GLG4VEventAction::SetNewValue(G4UIcommand *command, G4String newValue) {
   } else if (command->GetCommandName() == "doParameterizedScintillation") {
     fgDoParameterizedScintillation = (atoi((const char *)newValue) != 0);
   } else {
-    G4cerr << "Unknown command ``" << command->GetCommandName() << " passed to GLG4EventAction::SetNewValue\n";
+    G4cerr << "Unknown command ``" << command->GetCommandName() << " passed to GLG4EventAction::SetNewValue" << newline;
   }
 }
 

--- a/src/core/src/StackingAction.cc
+++ b/src/core/src/StackingAction.cc
@@ -11,6 +11,7 @@
 #include "G4Step.hh"
 #include "G4Track.hh"
 #include "G4VProcess.hh"
+#include <RAT/Log.hh>
 
 // constructor
 StackingAction::StackingAction() {}

--- a/src/daq/src/LessSimpleDAQProc.cc
+++ b/src/daq/src/LessSimpleDAQProc.cc
@@ -2,6 +2,7 @@
 #include <RAT/DB.hh>
 #include <RAT/DetectorConstruction.hh>
 #include <RAT/LessSimpleDAQProc.hh>
+#include <RAT/Log.hh>
 #include <iostream>
 #include <vector>
 
@@ -38,7 +39,7 @@ Processor::Result LessSimpleDAQProc::DSEvent(DS::Root *ds) {
   unsigned long triggerThreshold = 6;
   unsigned long hits = 0;
 
-  // std::cout <<"New Event====================================" << std::endl;
+  // info <<"New Event====================================" << newline;
   //  First part is to load into std::vector PMT information for full event
   std::vector<double> timeAndChargeAndID;
   std::vector<std::vector<double>> pmtARRAY;
@@ -71,7 +72,7 @@ Processor::Result LessSimpleDAQProc::DSEvent(DS::Root *ds) {
 
   // get the number odd subevent
   // and tally the cluster time of each subevent
-  // std::cout <<"oooooooooooooooo sorted oooooooooooo" << std::endl;
+  // info <<"oooooooooooooooo sorted oooooooooooo" << newline;
 
   for (unsigned long pmtIndex = 0; pmtIndex < pmtARRAY.size(); pmtIndex++) {
     time = pmtARRAY[pmtIndex][0];

--- a/src/db/src/DB.cc
+++ b/src/db/src/DB.cc
@@ -38,7 +38,7 @@ int DB::Load(std::string filename, bool printPath) {
   // Try to get file info assuming the name is literal
   struct stat s;
   if (stat(filename.c_str(), &s) == 0) {
-    if (printPath) std::cout << "DB: Loading " << filename << "\n";
+    if (printPath) info << "DB: Loading " << filename << newline;
     if (S_ISDIR(s.st_mode))
       return LoadAll(filename);
     else
@@ -47,7 +47,7 @@ int DB::Load(std::string filename, bool printPath) {
     // Check through the data directories
     for (auto dir : Rat::ratdb_directories) {
       std::string newfilename = dir + "/" + filename;
-      if (printPath) std::cout << "DB: Loading " << newfilename << "\n";
+      if (printPath) info << "DB: Loading " << newfilename << newline;
       if (stat(newfilename.c_str(), &s) == 0) {
         if (S_ISDIR(s.st_mode))
           return LoadAll(newfilename);
@@ -70,7 +70,7 @@ int DB::LoadTable(DBTable *table) {
 
     DBTable *oldtable = FindTable(id.name, id.index, id.run);
     if (oldtable) {
-      std::cerr << "DB: Replacing default " << id.name << "[" << id.index << "] in database.\n" << std::endl;
+      warn << "DB: Replacing default " << id.name << "[" << id.index << "] in database." << newline << newline;
     }
 
     tables[id] = table;
@@ -79,7 +79,7 @@ int DB::LoadTable(DBTable *table) {
 
     DBTable *oldtable = FindTable(id.name, id.index, id.run);
     if (oldtable) {
-      std::cerr << "DB: Replacing user " << id.name << "[" << id.index << "] in database.\n" << std::endl;
+      warn << "DB: Replacing user " << id.name << "[" << id.index << "] in database." << newline << newline;
     }
 
     tables[id] = table;
@@ -94,8 +94,8 @@ int DB::LoadTable(DBTable *table) {
 
       DBTable *oldtable = FindTable(id.name, id.index, id.run);
       if (oldtable) {
-        std::cerr << "DB: Replacing " << id.name << "[" << id.index << "]"
-                  << " for run " << id.run << " in database.\n";
+        warn << "DB: Replacing " << id.name << "[" << id.index << "]"
+                  << " for run " << id.run << " in database." << newline;
       }
 
       tables[id] = tablePtr;
@@ -117,7 +117,7 @@ int DB::LoadFile(std::string filename) {
   try {
     contents = ReadRATDBFile(filename);
   } catch (FileError &e) {
-    std::cerr << "DB: Error! Cannot open " << e.filename << "\n";
+    warn << "DB: Error! Cannot open " << e.filename << newline;
     return 0;
   }
 
@@ -141,11 +141,11 @@ int DB::LoadAll(std::string dirname, std::string pattern) {
   if (glob(pattern.c_str(), 0, 0, &g) == 0) {
     for (unsigned i = 0; i < g.gl_pathc; i++) {
       std::string path(g.gl_pathv[i]);
-      std::cout << "DB: Loading " << path << " ... ";
+      info << "DB: Loading " << path << " ... ";
       if (Load(path))
-        std::cout << "Success!" << std::endl;
+        info << "Success!" << newline;
       else {
-        std::cout << "Load Failed!" << std::endl;
+        info << "Load Failed!" << newline;
         globfree(&g);
         return 0;
       }
@@ -190,7 +190,7 @@ void DB::SetServer(std::string url) {
     info << " " << key;
   }
 
-  info << "\n";
+  info << newline;
 }
 
 void DB::SetDefaultRun(int _run) { run = _run; }
@@ -382,9 +382,9 @@ DBTable *DB::FindTable(std::string tblname, std::string index, int runNumber) {
   tables[forDeletion.first]->GetBytes(); if (forDeletion.second)
       serverTableBytes -= deleteSize;
     tables.erase(forDeletion.first);
-    std::cerr << "Evicting " << forDeletion.first.name << "[" <<
+    warn << "Evicting " << forDeletion.first.name << "[" <<
   forDeletion.first.index << "], run " << forDeletion.first.run << " (" <<
-  deleteSize << " bytes)\n";
+  deleteSize << " bytes)" << newline;
   }
   */
 
@@ -401,7 +401,7 @@ DBTable *DB::FindTable(std::string tblname, std::string index, int runNumber) {
   // Last entry in queue gets billed for all the space (since it isn't freed
   // until the last is deleted)
   tablesFromServer.back().second = true;
-  // std::cerr << "Memory cache = " << serverTableBytes << "\n";
+  // warn << "Memory cache = " << serverTableBytes << newline;
 
   info << dformat("RATDB: Loaded table %s[%s] from server\n", newTable->GetName().c_str(),
                   newTable->GetIndex().c_str());

--- a/src/db/src/DBTextLoader.cc
+++ b/src/db/src/DBTextLoader.cc
@@ -545,7 +545,7 @@ std::vector<DBTable *> DBTextLoader::parse(std::string filename) {
       if (table->GetFieldType("name") == DBTable::STRING)
         table->SetName(table->GetS("name"));
       else {
-        std::cerr << "Unnamed table in " << filename << std::endl;
+        warn << "Unnamed table in " << filename << newline;
         bad = true;
       }
 
@@ -577,15 +577,15 @@ std::vector<DBTable *> DBTextLoader::parse(std::string filename) {
           table->Set("run_range", run_range);
           table->SetRunRange(run_range[0], run_range[1]);
         } else {
-          std::cerr << "Table has old-style valid_begin/valid_end arrays not set to "
+          warn << "Table has old-style valid_begin/valid_end arrays not set to "
                        "default or user plane.  Discarding..."
-                    << std::endl;
+                    << newline;
           bad = true;
         }
 
       } else {
-        std::cerr << "Table " << table->GetName() << " has bad/missing validity information." << std::endl
-                  << "Discarding..." << std::endl;
+        warn << "Table " << table->GetName() << " has bad/missing validity information." << newline
+                  << "Discarding..." << newline;
         bad = true;
       }
 
@@ -602,7 +602,7 @@ std::vector<DBTable *> DBTextLoader::parse(std::string filename) {
   } catch (ParseError &p) {
     // Inform user of parse failure and keep handing the exception up
     // the call stack (presumably we will exit the entire program)
-    std::cerr << p.GetFull();
+    warn << p.GetFull();
     throw;
   }
 

--- a/src/fit/src/FitTensorProc.cc
+++ b/src/fit/src/FitTensorProc.cc
@@ -84,7 +84,7 @@ cppflow::tensor FitTensorProc::CreateProjection(DS::EV *ev, DS::PMTInfo *pmtinfo
     for (int j = 0; j < ydim; j++) {
       float red_value = red[i][j];
       red_value = isnan(red_value) ? 0 : red_value;
-      // std::cout << red_value << std::endl;
+      // info << red_value << newline;
       flatArray.push_back(std::min(std::max(static_cast<float>(0.0), red_value), static_cast<float>(1.0)));
       float green_value = green[i][j];
       green_value = isnan(green_value) ? 0 : green_value;
@@ -92,9 +92,9 @@ cppflow::tensor FitTensorProc::CreateProjection(DS::EV *ev, DS::PMTInfo *pmtinfo
     }
   }
   float totalTester = accumulate(flatArray.begin(), flatArray.end(), 0);
-  // std::cout << totalTester << std::endl;
+  // info << totalTester << newline;
   for (auto &a : flatArray) {
-    // std::cout << a << ", ";
+    // info << a << ", ";
   }
   cppflow::tensor input(flatArray, shape);
   return input;

--- a/src/fit/src/MiniSim.cc
+++ b/src/fit/src/MiniSim.cc
@@ -4,6 +4,7 @@
 #include <G4VParticleChange.hh>
 #include <RAT/DB.hh>
 #include <RAT/GLG4Scint.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 
@@ -92,7 +93,7 @@ void MiniSim::UserSteppingAction(const G4Step *aStep) {
   if (track->GetCurrentStepNumber() > 1000000) {
     const G4VPhysicalVolume *pv = track->GetVolume();
     const G4VProcess *lastproc = track->GetStep()->GetPostStepPoint()->GetProcessDefinedStep();
-    G4cerr << "MiniSim: Too many steps for this track, terminating!\n"
+    G4cerr << "MiniSim: Too many steps for this track, terminating!" << newline
            << " step_no=" << track->GetCurrentStepNumber() << " type=" << track->GetDefinition()->GetParticleName()
            << "\n volume=" << (pv != 0 ? pv->GetName() : G4String("NULL"))
            << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))

--- a/src/gen/src/AmBeGen.cc
+++ b/src/gen/src/AmBeGen.cc
@@ -20,6 +20,7 @@
 #include <RAT/GLG4PosGen.hh>
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/GLG4TimeGen.hh>
+#include <RAT/Log.hh>
 #include <cstring>
 
 #undef DEBUG
@@ -55,8 +56,8 @@ void AmBeGen::GenerateEvent(G4Event *event) {
   int numberGammas = ambeSource.GetNumGamma();
 
 #ifdef DEBUG
-  std::cout << "RAT::AmBeGen::GenerateEvent: " << numberNeutrons << " neutrons, " << numberGammas << " photons"
-            << std::endl;
+  debug << "RAT::AmBeGen::GenerateEvent: " << numberNeutrons << " neutrons, " << numberGammas << " photons"
+            << newline;
 #endif
 
   // For each neutron...
@@ -76,10 +77,10 @@ void AmBeGen::GenerateEvent(G4Event *event) {
     event->AddPrimaryVertex(vertex);
 
 #ifdef DEBUG
-    std::cout << "RAT::AmBeGen::GenerateEvent: "
+    debug << "RAT::AmBeGen::GenerateEvent: "
               << "Neutron " << i << " of " << numberNeutrons << "    time=" << G4BestUnit(time, "Time")
               << ", position=" << G4BestUnit(position, "Length") << ", momentum=" << G4BestUnit(p, "Energy")
-              << std::endl;
+              << newline;
 #endif
 
   }  // for each neutron
@@ -102,10 +103,10 @@ void AmBeGen::GenerateEvent(G4Event *event) {
     event->AddPrimaryVertex(vertex);
 
 #ifdef DEBUG
-    std::cout << "RAT::AmBeGen::GenerateEvent: "
+    debug << "RAT::AmBeGen::GenerateEvent: "
               << "Gamma " << i << " of " << numberGammas << "    time=" << G4BestUnit(time, "Time")
               << ", position=" << G4BestUnit(position, "Length") << ", momentum=" << G4BestUnit(p, "Energy")
-              << std::endl;
+              << newline;
 #endif
 
   }  // for each prompt photon
@@ -115,15 +116,15 @@ void AmBeGen::ResetTime(double offset) {
   double eventTime = timeGen->GenerateEventTime();
   nextTime = eventTime + offset;
 #ifdef DEBUG
-  std::cout << "RAT::AmBeGen::ResetTime:"
+  debug << "RAT::AmBeGen::ResetTime:"
             << " eventTime=" << G4BestUnit(eventTime, "Time") << ", offset=" << G4BestUnit(offset, "Time")
-            << ", nextTime=" << G4BestUnit(nextTime, "Time") << std::endl;
+            << ", nextTime=" << G4BestUnit(nextTime, "Time") << newline;
 #endif
 }
 
 void AmBeGen::SetState(G4String state) {
 #ifdef DEBUG
-  std::cout << "RAT::AmBeGen::SetState called with state='" << state << "'" << std::endl;
+  debug << "RAT::AmBeGen::SetState called with state='" << state << "'" << newline;
 #endif
 
   // Break the argument to the this generator into sub-std::strings
@@ -133,7 +134,7 @@ void AmBeGen::SetState(G4String state) {
   size_t nArgs = parts.size();
 
 #ifdef DEBUG
-  std::cout << "RAT::AmBeGen::SetState: nArgs=" << nArgs << std::endl;
+  debug << "RAT::AmBeGen::SetState: nArgs=" << nArgs << newline;
 #endif
 
   try {
@@ -156,7 +157,7 @@ void AmBeGen::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -166,7 +167,7 @@ void AmBeGen::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "AmBeGen error: Cannot set time state, no time generator selected" << std::endl;
+    warn << "AmBeGen error: Cannot set time state, no time generator selected" << newline;
 }
 
 G4String AmBeGen::GetTimeState() const {
@@ -180,9 +181,9 @@ void AmBeGen::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "AmBeGen error: Cannot set position state, no position generator "
+    warn << "AmBeGen error: Cannot set position state, no position generator "
                  "selected"
-              << std::endl;
+              << newline;
 }
 
 G4String AmBeGen::GetPosState() const {

--- a/src/gen/src/AmBeSource.cc
+++ b/src/gen/src/AmBeSource.cc
@@ -14,6 +14,7 @@
 #include <G4Neutron.hh>
 #include <G4ParticleDefinition.hh>
 #include <RAT/AmBeSource.hh>
+#include <RAT/Log.hh>
 #include <cmath>
 #include <cstring>
 #include <fstream>  // file I/O
@@ -62,7 +63,7 @@ AmBeSource::AmBeSource() {
     double fspace[probDensSize];
 
 #ifdef DEBUG
-    std::cout << "AmBeSource initialization" << std::endl;
+    debug << "AmBeSource initialization" << newline;
 #endif
 
     // Find function values at bin centers.
@@ -70,7 +71,7 @@ AmBeSource::AmBeSource() {
       float value = (float(i) + 0.5) * (fhigh - flow) / (float)probDensSize;
       fspace[i] = AmBeNeutronSpectrum(value);
 #ifdef DEBUG
-      std::cout << "   i=" << i << ", value = " << value << " f,m,g=" << fspace[i] << std::endl;
+      debug << "   i=" << i << ", value = " << value << " f,m,g=" << fspace[i] << newline;
 #endif
     }
 
@@ -78,9 +79,9 @@ AmBeSource::AmBeSource() {
     fGenerate = new CLHEP::RandGeneral(fspace, probDensSize);
 
 #ifdef DEBUG
-    std::cout << " Random generator test (f):" << std::endl;
+    debug << " Random generator test (f):" << newline;
     for (size_t i = 0; i != 20; i++) {
-      std::cout << i << ": " << fGenerate->shoot() * (fhigh - flow) + flow << std::endl;
+      debug << i << ": " << fGenerate->shoot() * (fhigh - flow) + flow << newline;
     }
 
 #endif
@@ -89,15 +90,15 @@ AmBeSource::AmBeSource() {
   // pick a neutron multiplicity
   Nneutron = 1;  // only one neutron generated
 
-  // std::cout << "   " << Nneutron << " neutrons" << std::endl;
+  // info << "   " << Nneutron << " neutrons" << newline;
   //
   //  pick a momentum direction for each neutron
   //
   for (int nn = 0; nn < Nneutron; nn++) {
     double neutronKE = fGenerate->shoot() * (fhigh - flow) + flow;
-    // 	  std::cout << "neutronKE = " << neutronKE*CLHEP::MeV << std::endl;
+    // 	  info << "neutronKE = " << neutronKE*CLHEP::MeV << newline;
     double energy = massNeutron + neutronKE;
-    // 	  std::cout << "energy = " << energy*CLHEP::MeV << std::endl;
+    // 	  info << "energy = " << energy*CLHEP::MeV << newline;
     // Generate momentum direction uniformly in phi and cos(theta).
     double phi = CLHEP::RandFlat::shoot(0., M_PI);
     double cosTheta = CLHEP::RandFlat::shoot(-1., 1.);
@@ -114,8 +115,8 @@ AmBeSource::AmBeSource() {
     double py = neutronP * sinTheta * sin(phi);
     double pz = neutronP * cosTheta;
 #ifdef DEBUG
-    std::cout << "AmBeSource::AmBeSource() - neutron energy " << nn << " = " << energy << ", KE=" << neutronKE
-              << ", (px,py,pz)=(" << px << "," << py << "," << pz << ")" << std::endl;
+    debug << "AmBeSource::AmBeSource() - neutron energy " << nn << " = " << energy << ", KE=" << neutronKE
+              << ", (px,py,pz)=(" << px << "," << py << "," << pz << ")" << newline;
 #endif
     CLHEP::HepLorentzVector momentum(px, py, pz, energy);
     neutronE.push_back(momentum);
@@ -137,8 +138,8 @@ AmBeSource::AmBeSource() {
   }
 
 #ifdef DEBUG
-  std::cout << "AmBeSource::AmBeSource - "
-            << "m=" << m << " => " << Ngamma << " photons" << std::endl;
+  debug << "AmBeSource::AmBeSource - "
+            << "m=" << m << " => " << Ngamma << " photons" << newline;
 #endif
   // pick a momentum for each gamma
   //
@@ -153,8 +154,8 @@ AmBeSource::AmBeSource() {
     double py = energy * sinTheta * sin(phi);
     double pz = energy * cosTheta;
 #ifdef DEBUG
-    std::cout << "AmBeSource::AmBeSource() - gamma energy " << nn << " = " << energy << ", (px,py,pz)=(" << px << ","
-              << py << "," << pz << ")" << std::endl;
+    debug << "AmBeSource::AmBeSource() - gamma energy " << nn << " = " << energy << ", (px,py,pz)=(" << px << ","
+              << py << "," << pz << ")" << newline;
 #endif
     CLHEP::HepLorentzVector momentum(px, py, pz, energy);
     gammaE.push_back(momentum);
@@ -163,7 +164,7 @@ AmBeSource::AmBeSource() {
     // consider the gammas is emitted instantaneously (10^-15 -ish decay time)
     Tgamma.push_back(0.);
   }
-  // std::cout << "          total energy = " << tote << std::endl;
+  // info << "          total energy = " << tote << newline;
 }
 
 AmBeSource::~AmBeSource() { ; }

--- a/src/gen/src/CCCrossSec.cc
+++ b/src/gen/src/CCCrossSec.cc
@@ -143,12 +143,12 @@ double CCCrossSec::Sigma(const double Enu) const {
 
 std::vector<double> CCCrossSec::CalcAllowedElectronKE(const double Enu) const {
   std::vector<double> allowed_ke;
-  // std::cout << "Neutrino energy: " << Enu << std::endl;
+  // info << "Neutrino energy: " << Enu << newline;
   for (unsigned int n = 0; n < fLevels.size(); n++) {
     double energy = Enu - fLevels[n];
     if (energy > fMe) {
-      // std::cout << "Allowed e- kinetic energy: " << energy - fMe <<
-      // std::endl;
+      // info << "Allowed e- kinetic energy: " << energy - fMe <<
+      // newline;
       allowed_ke.push_back(energy - fMe);
     }
   }
@@ -157,13 +157,13 @@ std::vector<double> CCCrossSec::CalcAllowedElectronKE(const double Enu) const {
 
 std::vector<double> CCCrossSec::CalcAllowedNuclearEx(const double Enu) const {
   std::vector<double> allowed_nuclear;
-  // std::cout << "Neutrino energy: " << Enu << std::endl;
+  // info << "Neutrino energy: " << Enu << newline;
 
   for (unsigned int n = 0; n < fLevels.size(); n++) {
     double energy = Enu - fLevels[n];
     if (energy > fMe) {
-      // std::cout << "Allowed nuclear excitation: " << fLevels[n] - 0.350 <<
-      // std::endl;
+      // info << "Allowed nuclear excitation: " << fLevels[n] - 0.350 <<
+      // newline;
       allowed_nuclear.push_back(fLevels[n] - 0.350);
     }
   }

--- a/src/gen/src/CCgen.cc
+++ b/src/gen/src/CCgen.cc
@@ -24,6 +24,7 @@
 #include <RAT/CCCrossSec.hh>
 #include <RAT/CCgen.hh>
 #include <RAT/DB.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <cmath>
 
@@ -136,8 +137,8 @@ void CCgen::LoadGenerator() {
 
   // If it reaches this point without failing then everything should be fine
   fGenLoaded = true;
-  std::cout << "Rate per target for CC of " << fNuType.c_str() << " flux on Li7 is: " << GetRatePerTarget()
-            << std::endl;
+  info << "Rate per target for CC of " << fNuType.c_str() << " flux on Li7 is: " << GetRatePerTarget()
+            << newline;
 }
 
 CCgen::~CCgen() {
@@ -250,8 +251,8 @@ void CCgen::Reset() {
 }
 
 void CCgen::Show() {
-  std::cout << "Charged Current Settings:\n";
-  std::cout << "NuType : " << fNuType.c_str() << "\n";
+  info << "Charged Current Settings:" << newline;
+  info << "NuType : " << fNuType.c_str() << newline;
 }
 
 //
@@ -395,8 +396,8 @@ G4double CCgen::GetRatePerTarget() {
       intRate += integ;
     }
   }
-  std::cout << "Interaction rate: " << intRate << " XS norm: " << fXS->CrossSecNorm() << " Total Flux: " << fTotalFlux
-            << std::endl;
+  info << "Interaction rate: " << intRate << " XS norm: " << fXS->CrossSecNorm() << " Total Flux: " << fTotalFlux
+            << newline;
   // don't forget the scale factor from the cross section
   // nor the total flux
   return intRate * fXS->CrossSecNorm() * fTotalFlux;

--- a/src/gen/src/CfGen.cc
+++ b/src/gen/src/CfGen.cc
@@ -19,6 +19,7 @@
 #include <RAT/GLG4PosGen.hh>
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/GLG4TimeGen.hh>
+#include <RAT/Log.hh>
 #include <string>
 
 #undef DEBUG
@@ -54,8 +55,8 @@ void CfGen::GenerateEvent(G4Event *event) {
   int numberGammas = cfSource.GetNumGamma();
 
 #ifdef DEBUG
-  std::cout << "RAT::CfGen::GenerateEvent: " << numberNeutrons << " neutrons, " << numberGammas << " photons"
-            << std::endl;
+  debug << "RAT::CfGen::GenerateEvent: " << numberNeutrons << " neutrons, " << numberGammas << " photons"
+            << newline;
 #endif
 
   // For each neutron...
@@ -75,10 +76,10 @@ void CfGen::GenerateEvent(G4Event *event) {
     event->AddPrimaryVertex(vertex);
 
 #ifdef DEBUG
-    std::cout << "RAT::CfGen::GenerateEvent: "
+    debug << "RAT::CfGen::GenerateEvent: "
               << "Neutron " << i << " of " << numberNeutrons << "    time=" << G4BestUnit(time, "Time")
               << ", position=" << G4BestUnit(position, "Length") << ", momentum=" << G4BestUnit(p, "Energy")
-              << std::endl;
+              << newline;
 #endif
 
   }  // for each neutron
@@ -101,10 +102,10 @@ void CfGen::GenerateEvent(G4Event *event) {
     event->AddPrimaryVertex(vertex);
 
 #ifdef DEBUG
-    std::cout << "RAT::CfGen::GenerateEvent: "
+    debug << "RAT::CfGen::GenerateEvent: "
               << "Gamma " << i << " of " << numberGammas << "    time=" << G4BestUnit(time, "Time")
               << ", position=" << G4BestUnit(position, "Length") << ", momentum=" << G4BestUnit(p, "Energy")
-              << std::endl;
+              << newline;
 #endif
 
   }  // for each prompt photon
@@ -114,15 +115,15 @@ void CfGen::ResetTime(double offset) {
   double eventTime = timeGen->GenerateEventTime();
   nextTime = eventTime + offset;
 #ifdef DEBUG
-  std::cout << "RAT::CfGen::ResetTime:"
+  debug << "RAT::CfGen::ResetTime:"
             << " eventTime=" << G4BestUnit(eventTime, "Time") << ", offset=" << G4BestUnit(offset, "Time")
-            << ", nextTime=" << G4BestUnit(nextTime, "Time") << std::endl;
+            << ", nextTime=" << G4BestUnit(nextTime, "Time") << newline;
 #endif
 }
 
 void CfGen::SetState(G4String state) {
 #ifdef DEBUG
-  std::cout << "RAT::CfGen::SetState called with state='" << state << "'" << std::endl;
+  debug << "RAT::CfGen::SetState called with state='" << state << "'" << newline;
 #endif
 
   // Break the argument to the this generator into sub-std::strings
@@ -132,7 +133,7 @@ void CfGen::SetState(G4String state) {
   size_t nArgs = parts.size();
 
 #ifdef DEBUG
-  std::cout << "RAT::CfGen::SetState: nArgs=" << nArgs << std::endl;
+  debug << "RAT::CfGen::SetState: nArgs=" << nArgs << newline;
 #endif
 
   try {
@@ -149,7 +150,7 @@ void CfGen::SetState(G4String state) {
       isotope = util_to_int(parts[0]);
 
       if (isotope != 252) {
-        std::cerr << "RAT::CfGen::SetState: Only cf 252 is supported" << std::endl;
+        warn << "RAT::CfGen::SetState: Only cf 252 is supported" << newline;
       }
 
       // The second argument is a position generator.
@@ -163,7 +164,7 @@ void CfGen::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -173,7 +174,7 @@ void CfGen::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "CfGen error: Cannot set time state, no time generator selected" << std::endl;
+    warn << "CfGen error: Cannot set time state, no time generator selected" << newline;
 }
 
 G4String CfGen::GetTimeState() const {
@@ -187,9 +188,9 @@ void CfGen::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "CfGen error: Cannot set position state, no position generator "
+    warn << "CfGen error: Cannot set position state, no position generator "
                  "selected"
-              << std::endl;
+              << newline;
 }
 
 G4String CfGen::GetPosState() const {

--- a/src/gen/src/CfSource.cc
+++ b/src/gen/src/CfSource.cc
@@ -14,6 +14,7 @@
 #include <G4Neutron.hh>
 #include <G4ParticleDefinition.hh>
 #include <RAT/CfSource.hh>
+#include <RAT/Log.hh>
 #include <cmath>
 #include <fstream>  // file I/O
 #include <iomanip>  // format manipulation
@@ -74,7 +75,7 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
       double gspace[probDensSize];
 
 #ifdef DEBUG
-      std::cout << "CfSource initialization" << std::endl;
+      debug << "CfSource initialization" << newline;
 #endif
       // Find function values at bin centers.
       for (size_t i = 0; i != probDensSize; i++) {
@@ -85,7 +86,7 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
         value = (float(i) + 0.5) * (ghigh - glow) / (float)probDensSize;
         gspace[i] = Cf252GammaSpectrum(value);
 #ifdef DEBUG
-        std::cout << "   i=" << i << " f,m,g=" << fspace[i] << "," << mspace[i] << "," << gspace[i] << std::endl;
+        debug << "   i=" << i << " f,m,g=" << fspace[i] << "," << mspace[i] << "," << gspace[i] << newline;
 #endif
       }
 
@@ -95,11 +96,11 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
       gGenerate = new CLHEP::RandGeneral(gspace, probDensSize);
 
 #ifdef DEBUG
-      std::cout << " Random generator test (f,m,g):" << std::endl;
+      debug << " Random generator test (f,m,g):" << newline;
       for (size_t i = 0; i != 20; i++) {
-        std::cout << i << ": " << fGenerate->shoot() * (fhigh - flow) + flow << ", "
+        debug << i << ": " << fGenerate->shoot() * (fhigh - flow) + flow << ", "
                   << mGenerate->shoot() * (mhigh - mlow) + mlow << ", " << gGenerate->shoot() * (ghigh - glow) + glow
-                  << std::endl;
+                  << newline;
       }
 
 #endif
@@ -123,7 +124,7 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
         }
       }
     }
-    // std::cout << "   " << Nneutron << " neutrons" << std::endl;
+    // info << "   " << Nneutron << " neutrons" << newline;
     //
     //  pick a momentum direction for each neutron
     //
@@ -140,8 +141,8 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
       double py = neutronP * sinTheta * sin(phi);
       double pz = neutronP * cosTheta;
 #ifdef DEBUG
-      std::cout << "CfSource::CfSource() - neutron energy " << nn << " = " << energy << ", KE=" << neutronKE
-                << ", (px,py,pz)=(" << px << "," << py << "," << pz << ")" << std::endl;
+      debug << "CfSource::CfSource() - neutron energy " << nn << " = " << energy << ", KE=" << neutronKE
+                << ", (px,py,pz)=(" << px << "," << py << "," << pz << ")" << newline;
 #endif
       CLHEP::HepLorentzVector momentum(px, py, pz, energy);
       neutronE.push_back(momentum);
@@ -171,8 +172,8 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
     Ngamma = (int)m;
 
 #ifdef DEBUG
-    std::cout << "CfSource::CfSource - "
-              << "m=" << m << " => " << Ngamma << " photons" << std::endl;
+    debug << "CfSource::CfSource - "
+              << "m=" << m << " => " << Ngamma << " photons" << newline;
 #endif
     // pick a momentum for each gamma
     //
@@ -187,8 +188,8 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
       double py = energy * sinTheta * sin(phi);
       double pz = energy * cosTheta;
 #ifdef DEBUG
-      std::cout << "CfSource::CfSource() - gamma energy " << nn << " = " << energy << ", (px,py,pz)=(" << px << ","
-                << py << "," << pz << ")" << std::endl;
+      debug << "CfSource::CfSource() - gamma energy " << nn << " = " << energy << ", (px,py,pz)=(" << px << ","
+                << py << "," << pz << ")" << newline;
 #endif
       CLHEP::HepLorentzVector momentum(px, py, pz, energy);
       gammaE.push_back(momentum);
@@ -207,7 +208,7 @@ CfSource::CfSource(int newIsotope) : Isotope(newIsotope) {
         halflife = 1.0;
       Tgamma.push_back(halflife * log(1 / rv[1]));
     }
-    // std::cout << "          total energy = " << tote << std::endl;
+    // info << "          total energy = " << tote << newline;
 
   }  // done with Cf 252
 
@@ -251,14 +252,14 @@ float CfSource::Cf252NeutronSpectrum(const float &x) {
   float N = 0.;
 
   float scale = 1 / (2 * M_PI * 0.359);
-  // std::cout << "scale " << scale << std::endl;
+  // info << "scale " << scale << newline;
 
   float fminus = exp(-(sqrt(x) - sqrt(0.359)) * (sqrt(x) - sqrt(0.359)) / 1.175);
   float fplus = exp(-(sqrt(x) + sqrt(0.359)) * (sqrt(x) + sqrt(0.359)) / 1.175);
 
   N = scale * (fminus - fplus);
 
-  // std::cout << "N " << N << std::endl;
+  // info << "N " << N << newline;
   return N;
 }
 
@@ -272,7 +273,7 @@ float CfSource::Cf252GammaMultiplicity(const int &x) {
 
   M = C1 * pow(C2, x) * exp(-C2) / factorial(x) + (1 - C1) * pow(C3, x) * exp(-C3) / factorial(x);
 
-  // std::cout << "M(" << x << ") " << M << std::endl;
+  // info << "M(" << x << ") " << M << newline;
 
   return M;
 }
@@ -298,7 +299,7 @@ float CfSource::Cf252GammaMultiplicityFit(const float &x) {
     M = exponential;
   }
 
-  // std::cout << "M(" << x << ") " << M << std::endl;
+  // info << "M(" << x << ") " << M << newline;
 
   return M;
 }
@@ -316,7 +317,7 @@ float CfSource::Cf252GammaSpectrum(const float &x) {
     N = exponential;
   }
 
-  // std::cout << "N " << N << std::endl;
+  // info << "N " << N << newline;
   return N;
 }
 

--- a/src/gen/src/Coincidence_Gen.cc
+++ b/src/gen/src/Coincidence_Gen.cc
@@ -139,9 +139,9 @@ void Coincidence_Gen::GenerateEvent(G4Event *event) {
     hi = fHiEnergy - sumLo;
     if (lo < 0) lo = 0;
     if (hi < 0) {
-      std::cerr << "Coincidence_Gen: cannot achieve selected energy range with "
+      warn << "Coincidence_Gen: cannot achieve selected energy range with "
                    "these generators."
-                << std::endl;
+                << newline;
     }
     if (vertexGen->ELimitable()) {
       vertexGen->LimitEnergies(lo, hi);
@@ -166,7 +166,7 @@ void Coincidence_Gen::GenerateEvent(G4Event *event) {
       }
       if (count == 100) {
         // Jump out of what could have been infinite loop
-        std::cerr << "No luck finding correct energy ! " << std::endl;
+        warn << "No luck finding correct energy ! " << newline;
       }
       // got a good vertex so add it to the real event
       event->AddPrimaryVertex(vtemp);
@@ -218,7 +218,7 @@ void Coincidence_Gen::GenerateEvent(G4Event *event) {
         }
         if (count == 100 || count == 1) {
           // Jump out of what could have been infinite loop
-          std::cerr << "No luck finding correct energy ! " << std::endl;
+          warn << "No luck finding correct energy ! " << newline;
         }
         // got a good vertex so add it to the real event
         event->AddPrimaryVertex(vtemp);
@@ -278,7 +278,7 @@ void Coincidence_Gen::SetState(G4String state) {
     }
     stateStr = state;  // Save for later call to GetState()
   } catch (RAT::FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -289,13 +289,13 @@ void Coincidence_Gen::SetEnergyRange(G4String newValues) {
   newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
     // Print help and current state
-    std::cout << " Current limits on Coincidence_Gen generated energy range = " << fLoEnergy << " - " << fHiEnergy
-              << " MeV\n"
-              << " To change use syntax:  Elo  Ehi \n"
+    info << " Current limits on Coincidence_Gen generated energy range = " << fLoEnergy << " - " << fHiEnergy
+              << " MeV" << newline
+              << " To change use syntax:  Elo  Ehi " << newline
               << " Elo = lower energy limit in MeV, Ehi = upper energy limit in MeV"
               << " !!!! But note that this option will be very slow for vertex "
                  "generators whose energy cannot be limited !!! "
-              << std::endl;
+              << newline;
   }
   std::istringstream is(newValues.c_str());
   double Elo, Ehi;
@@ -303,14 +303,14 @@ void Coincidence_Gen::SetEnergyRange(G4String newValues) {
   if (Elo < Ehi) {
     fLoEnergy = Elo;
     fHiEnergy = Ehi;
-    std::cout << "Coincidence_Gen: Restricting generated energy range to " << Elo << " - " << Ehi << " MeV\n"
+    info << "Coincidence_Gen: Restricting generated energy range to " << Elo << " - " << Ehi << " MeV" << newline
               << " !!!! But note that this option will be very slow for vertex "
                  "generators whose energy cannot be limited !!!! "
               << " !!!! And does not work when event energy comes from "
                  "radioactive decay !!!! "
-              << std::endl;
+              << newline;
   } else {
-    std::cerr << "Coincidence_Gen error: Elo must be less than Ehi!" << std::endl;
+    warn << "Coincidence_Gen error: Elo must be less than Ehi!" << newline;
   }
 }
 
@@ -319,9 +319,9 @@ void Coincidence_Gen::SetTimeState(G4String state) {
   if (timeGen) {
     timeGen->SetState(state);
   } else {
-    std::cerr << "Coincidence_Gen error: Cannot set time state, no time generator "
+    warn << "Coincidence_Gen error: Cannot set time state, no time generator "
                  "selected"
-              << std::endl;
+              << newline;
   }
 }
 
@@ -340,9 +340,9 @@ void Coincidence_Gen::SetPosState(G4String state) {
   if (posGen) {
     posGen->SetState(state);
   } else {
-    std::cerr << "Coincidence_Gen error: Cannot set position state, no position "
+    warn << "Coincidence_Gen error: Cannot set position state, no position "
                  "generator selected"
-              << std::endl;
+              << newline;
   }
 }
 
@@ -362,9 +362,9 @@ void Coincidence_Gen::SetVertexState(G4String state) {
   if (vertexGen) {
     vertexGen->SetState(state);
   } else {
-    std::cerr << "Coincidence_Gen error: Cannot set vertex state, no vertex "
+    warn << "Coincidence_Gen error: Cannot set vertex state, no vertex "
                  "generator selected"
-              << std::endl;
+              << newline;
   }
 }
 
@@ -392,7 +392,7 @@ void Coincidence_Gen::AddExtra(G4String state) {
   try {
     switch (parts.size()) {
       case 2:
-        std::cout << "adding new interaction " << nExtra + 1 << " " << parts[0] << " " << parts[1] << std::endl;
+        info << "adding new interaction " << nExtra + 1 << " " << parts[0] << " " << parts[1] << newline;
 
         delete posGenExtra[nExtra];
         posGenExtra[nExtra] = 0;
@@ -410,7 +410,7 @@ void Coincidence_Gen::AddExtra(G4String state) {
     }
     stateStrExtra[nExtra - 1] = state;  // Save for later call to GetState()
   } catch (RAT::FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -429,11 +429,11 @@ void Coincidence_Gen::SetExtraPosState(G4String state) {
   // interaction
   if (nExtra > 0) {  // check we have added an extra interaction
     posGenExtra[nExtra - 1]->SetState(state);
-    std::cout << "Setting extra interaction " << nExtra << ", position type to " << state << std::endl;
+    info << "Setting extra interaction " << nExtra << ", position type to " << state << newline;
   } else {
-    std::cerr << "Coincidence_Gen error: Cannot set extra position state, no "
+    warn << "Coincidence_Gen error: Cannot set extra position state, no "
                  "extra interaction selected"
-              << std::endl;
+              << newline;
   }
 }
 
@@ -452,11 +452,11 @@ void Coincidence_Gen::SetExtraVertexState(G4String state) {
   // Set the vertex generator fo the most recently added in interaction
   if (nExtra > 0) {
     vertexGenExtra[nExtra - 1]->SetState(state);
-    std::cout << "Setting extra interaction " << nExtra << ", vertex type to " << state << std::endl;
+    info << "Setting extra interaction " << nExtra << ", vertex type to " << state << newline;
   } else {
-    std::cerr << "Coincidence_Gen error: Cannot set extra vertex state, no extra "
+    warn << "Coincidence_Gen error: Cannot set extra vertex state, no extra "
                  "interaction selected"
-              << std::endl;
+              << newline;
   }
 }
 
@@ -482,13 +482,13 @@ void Coincidence_Gen::SetExponentials(G4String newValues) {
   for (int i = 0; i < nExtra; ++i) {
     is >> fExponent[i];
     if (is.good()) {
-      std::cout << "Coincidence_Gen: Setting extra interaction " << i + 1 << " exponential time constant to "
-                << fExponent[i] << std::endl;
+      info << "Coincidence_Gen: Setting extra interaction " << i + 1 << " exponential time constant to "
+                << fExponent[i] << newline;
     } else {
-      std::cerr << "Coincidence_Gen error: "
+      warn << "Coincidence_Gen error: "
                 << "Exponential timing selected, but insufficient time constants "
                    "provided "
-                << std::endl;
+                << newline;
     }
   }
 }

--- a/src/gen/src/ESgen.cc
+++ b/src/gen/src/ESgen.cc
@@ -23,6 +23,7 @@
 #include <RAT/DB.hh>
 #include <RAT/ESCrossSec.hh>
 #include <RAT/ESgen.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <cmath>
 
@@ -212,8 +213,8 @@ void ESgen::Reset() {
 }
 
 void ESgen::Show() {
-  std::cout << "Elastic Scattering Settings:\n";
-  std::cout << "NuType : " << fNuType.c_str() << "\n";
+  info << "Elastic Scattering Settings:" << newline;
+  info << "NuType : " << fNuType.c_str() << newline;
 }
 
 //

--- a/src/gen/src/GLG4DeferTrackProc.cc
+++ b/src/gen/src/GLG4DeferTrackProc.cc
@@ -20,12 +20,13 @@ class G4UImessenger;  // for G4ProcessTable.hh
 
 #include "G4ProcessTable.hh"
 #include "RAT/GLG4PrimaryGeneratorAction.hh"
+#include <RAT/Log.hh>
 
 ////////////////////////////////////////////////////////////////
 
 GLG4DeferTrackProc::GLG4DeferTrackProc(const G4String &aName) : G4VProcess(aName) {
   if (verboseLevel > 0) {
-    std::cout << GetProcessName() << " is created " << std::endl;
+    RAT::info << GetProcessName() << " is created " << newline;
   }
 
   _generator = GLG4PrimaryGeneratorAction::GetTheGLG4PrimaryGeneratorAction();

--- a/src/gen/src/GLG4Gen.cc
+++ b/src/gen/src/GLG4Gen.cc
@@ -7,6 +7,7 @@
 #include <G4Track.hh>
 #include <RAT/DB.hh>
 #include <RAT/Factory.hh>
+#include <RAT/Log.hh>
 
 #include "RAT/GLG4PosGen.hh"
 #include "RAT/GLG4StringUtil.hh"
@@ -61,7 +62,7 @@ void GLG4Gen_Combo::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (RAT::FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    RAT::warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -71,9 +72,9 @@ void GLG4Gen_Combo::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "GLG4Gen_Combo error: Cannot set vertex state, no vertex "
+    RAT::warn << "GLG4Gen_Combo error: Cannot set vertex state, no vertex "
                  "generator selected"
-              << std::endl;
+              << newline;
 }
 
 G4String GLG4Gen_Combo::GetTimeState() const {
@@ -87,9 +88,9 @@ void GLG4Gen_Combo::SetVertexState(G4String state) {
   if (vertexGen)
     vertexGen->SetState(state);
   else
-    std::cerr << "GLG4Gen_Combo error: Cannot set vertex state, no vertex "
+    RAT::warn << "GLG4Gen_Combo error: Cannot set vertex state, no vertex "
                  "generator selected"
-              << std::endl;
+              << newline;
 }
 
 G4String GLG4Gen_Combo::GetVertexState() const {
@@ -103,9 +104,9 @@ void GLG4Gen_Combo::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "GLG4Gen_Combo error: Cannot set position state, no position "
+    RAT::warn << "GLG4Gen_Combo error: Cannot set position state, no position "
                  "generator selected"
-              << std::endl;
+              << newline;
 }
 
 G4String GLG4Gen_Combo::GetPosState() const {
@@ -223,7 +224,7 @@ void GLG4Gen_External::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (RAT::FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    RAT::warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -233,9 +234,9 @@ void GLG4Gen_External::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "GLG4Gen_External error: Cannot set vertex state, no vertex "
+    RAT::warn << "GLG4Gen_External error: Cannot set vertex state, no vertex "
                  "generator selected"
-              << std::endl;
+              << newline;
 }
 
 G4String GLG4Gen_External::GetTimeState() const {
@@ -249,9 +250,9 @@ void GLG4Gen_External::SetVertexState(G4String state) {
   if (vertexGen)
     vertexGen->SetState(state);
   else
-    std::cerr << "GLG4Gen_External error: Cannot set vertex state, no vertex "
+    RAT::warn << "GLG4Gen_External error: Cannot set vertex state, no vertex "
                  "generator selected"
-              << std::endl;
+              << newline;
 }
 
 G4String GLG4Gen_External::GetVertexState() const {
@@ -265,9 +266,9 @@ void GLG4Gen_External::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "GLG4Gen_External error: Cannot set position state, no position "
+    RAT::warn << "GLG4Gen_External error: Cannot set position state, no position "
                  "generator selected"
-              << std::endl;
+              << newline;
 }
 
 G4String GLG4Gen_External::GetPosState() const {

--- a/src/gen/src/GLG4TimeGen.cc
+++ b/src/gen/src/GLG4TimeGen.cc
@@ -5,18 +5,19 @@
 #include <Randomize.hh>
 
 #include "RAT/GLG4StringUtil.hh"
+#include <RAT/Log.hh>
 
 void GLG4TimeGen_Uniform::SetState(G4String state) {
   state = util_strip_default(state);
   if (state.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this GLG4TimeGen:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to GLG4TimeGen::SetState: \n"
-                 " \"rate\"\n"
-                 " where rate is in 1/sec."
-              << std::endl;
+    RAT::info << "Current state of this GLG4TimeGen:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    RAT::info << "Format of argument to GLG4TimeGen::SetState: " << newline
+              << " \"rate\"\n"
+              << " where rate is in 1/sec."
+              << newline;
     return;
   }
 

--- a/src/gen/src/GLG4VertexGen.cc
+++ b/src/gen/src/GLG4VertexGen.cc
@@ -145,7 +145,7 @@ void GLG4VertexGen_Gun::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVector &
 }
 
 /** Set state of the GLG4VertexGen_Gun, or show current state and
-    explanation of state syntax if empty std::string provided.
+    explanation of state syntax if empty string provided.
 
     Format of argument to GLG4VertexGen_Gun::SetState:
        "pname  momx_MeV momy_MeV momz_MeV  KE_MeV  polx poly polz mult",
@@ -162,20 +162,20 @@ void GLG4VertexGen_Gun::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this GLG4VertexGen_Gun:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to GLG4VertexGen_Gun::SetState: \n"
-                 " \"pname  momx_MeV momy_MeV momz_MeV  KE_MeV  polx poly polz "
-                 "mult\"\n"
-                 " where pname is the name of a particle type (e-, mu-, U238, ...)\n"
-                 " mom*_MeV is a momentum in MeV/c\n"
-                 " KE_MeV is an optional override for kinetic energy\n"
-                 " pol* is an optional polarization std::vector.\n"
-                 " mult is an optional multiplicity of the particles.\n"
-                 "mom*_MeV==0 and KE_MeV!=0 --> random isotropic directions chosen\n"
-                 "pol*==0 --> random transverse polarization for photons.\n"
-              << std::endl;
+    RAT::info << "Current state of this GLG4VertexGen_Gun:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    RAT::info << "Format of argument to GLG4VertexGen_Gun::SetState: " << newline
+              <<  " \"pname  momx_MeV momy_MeV momz_MeV  KE_MeV  polx poly polz "
+              <<  "mult\"\n"
+              <<  " where pname is the name of a particle type (e-, mu-, U238, ...)\n"
+              <<  " mom*_MeV is a momentum in MeV/c\n"
+              <<  " KE_MeV is an optional override for kinetic energy\n"
+              <<  " pol* is an optional polarization std::vector.\n"
+              <<  " mult is an optional multiplicity of the particles.\n"
+              <<  "mom*_MeV==0 and KE_MeV!=0 --> random isotropic directions chosen\n"
+              <<  "pol*==0 --> random transverse polarization for photons.\n"
+              << newline;
     return;
   }
 
@@ -204,9 +204,9 @@ void GLG4VertexGen_Gun::SetState(G4String newValues) {
       if (Z <= numberOfElements) newTestGunG4Code = G4IonTable::GetIonTable()->GetIon(Z, A, 0.0);
     }
     if (newTestGunG4Code == NULL) {
-      std::cerr << "test gun particle type not changed! Could not"
+      RAT::warn << "test gun particle type not changed! Could not"
                    " find "
-                << pname << std::endl;
+                << pname << newline;
       return;
     }
   }
@@ -380,7 +380,7 @@ void GLG4VertexGen_Gun2::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVector 
 }
 
 /** Set state of the GLG4VertexGen_Gun, or show current state and
-    explanation of state syntax if empty std::string provided.
+    explanation of state syntax if empty string provided.
 
     Format of argument to GLG4VertexGen_Gun::SetState:
        "pname  momx_MeV momy_MeV momz_MeV  KE_MeV  polx poly polz mult",
@@ -397,22 +397,22 @@ void GLG4VertexGen_Gun2::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this GLG4VertexGen_Gun:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to GLG4VertexGen_Gun::SetState: \n"
-                 " \"pname  momx_MeV momy_MeV momz_MeV angle KE1_MeV  KE2_MeV polx "
-                 "ply polz multiplicity\"\n"
-                 " where pname is the name of a particle type (e-, mu-, U238, ...)\n"
-                 " mom*_MeV is a momentum in MeV/c\n"
-                 " angle is the aperture of the shooting cone\n"
-                 " KE1_MeV is the minimum kinetic energy\n"
-                 " KE2_MeV is the maximum kinetic energy\n"
-                 " pol* is a polarization\n"
-                 " multiplicity = (optional) no. of primaries shot at once\n"
-                 " mom*_MeV==0  --> random isotropic directions chosen\n"
-                 " pol*==0  --> random isotropic polarizations\n"
-              << std::endl;
+    RAT::info << "Current state of this GLG4VertexGen_Gun:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    RAT::info << "Format of argument to GLG4VertexGen_Gun::SetState: " << newline
+              << " \"pname  momx_MeV momy_MeV momz_MeV angle KE1_MeV  KE2_MeV polx "
+              << "ply polz multiplicity\"\n"
+              << " where pname is the name of a particle type (e-, mu-, U238, ...)\n"
+              << " mom*_MeV is a momentum in MeV/c\n"
+              << " angle is the aperture of the shooting cone\n"
+              << " KE1_MeV is the minimum kinetic energy\n"
+              << " KE2_MeV is the maximum kinetic energy\n"
+              << " pol* is a polarization\n"
+              << " multiplicity = (optional) no. of primaries shot at once\n"
+              << " mom*_MeV==0  --> random isotropic directions chosen\n"
+              << " pol*==0  --> random isotropic polarizations\n"
+              << newline;
     return;
   }
 
@@ -441,9 +441,9 @@ void GLG4VertexGen_Gun2::SetState(G4String newValues) {
       if (Z <= numberOfElements) newTestGunG4Code = G4IonTable::GetIonTable()->GetIon(Z, A, 0.0);
     }
     if (newTestGunG4Code == NULL) {
-      std::cerr << "test gun particle type not changed! Could not"
+      RAT::warn << "test gun particle type not changed! Could not"
                    " find "
-                << pname << std::endl;
+                << pname << newline;
       return;
     }
   }
@@ -498,7 +498,7 @@ GLG4VertexGen_HEPEvt::~GLG4VertexGen_HEPEvt() { Close(); }
 
 void GLG4VertexGen_HEPEvt::Open(const char *argFilename) {
   if (argFilename == NULL || argFilename[0] == '\0') {
-    std::cerr << "GLG4VertexGen_HEPEvt::Open(): null filename" << std::endl;
+    RAT::warn << "GLG4VertexGen_HEPEvt::Open(): null filename" << newline;
     return;
   }
   if (_file != 0) Close();
@@ -531,7 +531,7 @@ void GLG4VertexGen_HEPEvt::Close() {
     if (_isPipe) {
       int status = pclose(_file);
       if (status != 0) {
-        std::cerr << "HEPEvt input pipe from " << _filename << " gave status " << status << " on close." << std::endl;
+        RAT::warn << "HEPEvt input pipe from " << _filename << " gave status " << status << " on close." << newline;
       }
       _file = 0;
       _isPipe = false;
@@ -552,22 +552,22 @@ void GLG4VertexGen_HEPEvt::GetDataLine(char *buffer, size_t size) {
     buffer[0] = '\0';
     if (fgets(buffer, size, _file) != buffer) {
       // try from beginning of file on failure
-      std::cerr << (feof(_file) ? "End-of_file reached" : "Failure") << " on " << _filename << " at " << ftell(_file);
-      std::cerr << " Executive decision to end at end of file, soft closing." << std::endl;
+      RAT::warn << (feof(_file) ? "End-of_file reached" : "Failure") << " on " << _filename << " at " << ftell(_file);
+      RAT::warn << " Executive decision to end at end of file, soft closing." << newline;
       G4RunManager::GetRunManager()->AbortRun(true);
       if (rewind_count == 0) {
         if (_isPipe == false) {
-          std::cerr << ", rewinding." << std::endl;
+          RAT::warn << ", rewinding." << newline;
           rewind(_file);
         } else {
-          std::cerr << ", reopening." << std::endl;
+          RAT::warn << ", reopening." << newline;
           pclose(_file);
           _file = popen(_filename.substr(0, _filename.length() - 1).c_str(), "r");
         }
         rewind_count++;
         continue;
       } else {
-        std::cerr << ", closing." << std::endl;
+        RAT::warn << ", closing." << newline;
         Close();
         return;
       }
@@ -592,7 +592,7 @@ void GLG4VertexGen_HEPEvt::GetDataLine(char *buffer, size_t size) {
               "revision history");  // db[ ((_dbname+".")+firstword).c_str() ]=
                                     // value;
         else {
-          std::cout << "Warning, bad STATE line in " << _filename << ": " << buffer << std::endl;
+          RAT::info << "Warning, bad STATE line in " << _filename << ": " << buffer << newline;
         }
       }
       continue;
@@ -601,7 +601,7 @@ void GLG4VertexGen_HEPEvt::GetDataLine(char *buffer, size_t size) {
       sentinel[0] = '\0';
       sscanf(buffer, " HEPEVT DATA SENTINEL IS %19s", sentinel);
       if (sentinel[0] == '\0') {
-        std::cerr << "Warning, line starting with word HEPEVT ignored" << std::endl;
+        RAT::warn << "Warning, line starting with word HEPEVT ignored" << newline;
         continue;
       }
       // skip until sentinel found
@@ -614,13 +614,13 @@ void GLG4VertexGen_HEPEvt::GetDataLine(char *buffer, size_t size) {
     }
 
     // not comment, blank line, STATE, or numeric data
-    std::cerr << "Warning, ignoring garbage line in " << _filename << std::endl << buffer;
+    RAT::warn << "Warning, ignoring garbage line in " << _filename << newline << buffer;
   }
   // Peak at next word
   long posnot = ftell(_file);
   char buff2[400];
   if (fgets(buff2, sizeof(buff2), _file) != buff2) {
-    std::cerr << " Executive decision to end at end of file, soft closing." << std::endl;
+    RAT::warn << " Executive decision to end at end of file, soft closing." << newline;
     G4RunManager::GetRunManager()->AbortRun(true);
   }
   fseek(_file, posnot, SEEK_SET);
@@ -679,9 +679,9 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
   // (which itself may be a modified and adapted version of CLHEP/StdHep++...)
 
   if (_file == 0) {
-    std::cerr << "GLG4VertexGen_HEPEvt::GeneratePrimaryVertex: "
+    RAT::warn << "GLG4VertexGen_HEPEvt::GeneratePrimaryVertex: "
                  "Error, no file open!"
-              << std::endl;
+              << newline;
     return;
   }
 
@@ -690,7 +690,7 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
   int NHEP;  // number of entries
   GetDataLine(buffer, sizeof(buffer));
   if (_file == 0) {
-    std::cerr << "Unexpected end of file in " << _filename << ", expecting NHEP." << std::endl;
+    RAT::warn << "Unexpected end of file in " << _filename << ", expecting NHEP." << newline;
     Close();
     return;
   }
@@ -698,8 +698,8 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
   if (istat != 1) {
     // this should never happen: GetDataLine() should make sure integer is ok
     // -- but the test above is cheap and a good cross-check, so leave it.
-    std::cerr << "Bad data in " << _filename << ", expecting NHEP but got:\n"
-              << buffer << " --> closing file." << std::endl;
+    RAT::warn << "Bad data in " << _filename << ", expecting NHEP but got:" << newline
+              << buffer << " --> closing file." << newline;
     Close();
     return;
   }
@@ -734,8 +734,8 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
 
     GetDataLine(buffer, sizeof(buffer));
     if (_file == 0) {
-      std::cerr << "Unexpected end of file in " << _filename << ", expecting particle " << IHEP << "/" << NHEP
-                << std::endl;
+      RAT::warn << "Unexpected end of file in " << _filename << ", expecting particle " << IHEP << "/" << NHEP
+                << newline;
       Close();
       return;
     }
@@ -749,10 +749,10 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
       // print an error and Close() if request was made to use external
       // positions, but they are not present in ascii input
       if (req_vertexX == req_novalue && req_vertexY == req_novalue && req_vertexZ == req_novalue) {
-        std::cerr << "GLG4VertexGen: Request was made to use external position "
+        RAT::warn << "GLG4VertexGen: Request was made to use external position "
                      "for event,\n"
-                  << " but no positions were found in this line of ascii input.\n"
-                  << " No events will be generated for this line.\n";
+                  << " but no positions were found in this line of ascii input." << newline
+                  << " No events will be generated for this line." << newline;
         return;
       }
     } else {  // use positions from a different position generator,
@@ -766,9 +766,9 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
     // frobnicate IDHEP if ISTHEP != 1
     if (ISTHEP != kISTHEP_ParticleForTracking) {
       if (ISTHEP <= 0 || ISTHEP > kISTHEP_Max) {
-        std::cerr << "Error in GLG4VertexGen_HEPEvt[" << _filename << "]: ISTHEP=" << ISTHEP
+        RAT::warn << "Error in GLG4VertexGen_HEPEvt[" << _filename << "]: ISTHEP=" << ISTHEP
                   << " not allowed: valid range is 1 to 213"
-                  << " --> set to 213" << std::endl;
+                  << " --> set to 213" << newline;
         ISTHEP = kISTHEP_Max;
       }
       if (IDHEP < 0)
@@ -785,7 +785,7 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
       int Z = (IDHEP / 1000) % 100;
       G4ParticleDefinition *g4code = G4IonTable::GetIonTable()->GetIon(Z, A, 0.0);
       if (g4code == 0) {
-        std::cerr << "Warning: GLG4HEPEvt could not find Ion Z=" << Z << " A=" << A << " code=" << IDHEP << std::endl;
+        RAT::warn << "Warning: GLG4HEPEvt could not find Ion Z=" << Z << " A=" << A << " code=" << IDHEP << newline;
         particle = new G4PrimaryParticle(IDHEP, PHEP1 * energy_unit, PHEP2 * energy_unit, PHEP3 * energy_unit);
       } else {
         particle = new G4PrimaryParticle(g4code, PHEP1 * energy_unit, PHEP2 * energy_unit, PHEP3 * energy_unit);
@@ -858,9 +858,9 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
             mother->SetDaughter(daughter);
             HPlist[j]->Done();
           } else {
-            std::cerr << "Error in  GLG4VertexGen_HEPEvt[" << _filename << "]: mother " << i << " and daughter " << j
+            RAT::warn << "Error in  GLG4VertexGen_HEPEvt[" << _filename << "]: mother " << i << " and daughter " << j
                       << " are at different vertices, and this cannot be"
-                      << " done in Geant4! Must divorce mother and daughter." << std::endl;
+                      << " done in Geant4! Must divorce mother and daughter." << newline;
           }
         }
       }
@@ -893,18 +893,18 @@ void GLG4VertexGen_HEPEvt::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVecto
 
 /** Set source of HEPEVT ascii data for this generator, or print
     current source and help.
-    Format of std::string: either "filename" or "shell_command (arguments) |".
+    Format of string: either "filename" or "shell_command (arguments) |".
 */
 void GLG4VertexGen_HEPEvt::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this GLG4VertexGen_HEPEvt:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to GLG4VertexGen_HEPEvt::SetState: \n"
-              << "either \"filename\" or \"shell_command (arguments) |\"\n"
-              << std::endl;
+    RAT::info << "Current state of this GLG4VertexGen_HEPEvt:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    RAT::info << "Format of argument to GLG4VertexGen_HEPEvt::SetState: " << newline
+              << "either \"filename\" or \"shell_command (arguments) |\"" << newline
+              << newline;
     return;
   }
 
@@ -958,10 +958,10 @@ SetState(G4String newValues)
   newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this GLG4VertexGen_XXX:\n"
-	   << " \"" << GetState() << "\"\n" << std::endl;
-    std::cout << "Format of argument to GLG4VertexGen_XXX::SetState: \n"
-	   << std::endl;
+    RAT::info << "Current state of this GLG4VertexGen_XXX:" << newline
+	   << " \"" << GetState() << "\"" << newline << newline;
+    RAT::info << "Format of argument to GLG4VertexGen_XXX::SetState: " << newline
+	   << newline;
     return;
   }
 

--- a/src/gen/src/GdGen.cc
+++ b/src/gen/src/GdGen.cc
@@ -19,6 +19,7 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/GLG4TimeGen.hh>
 #include <RAT/GdGen.hh>
+#include <RAT/Log.hh>
 #include <string>
 
 #include "Randomize.hh"
@@ -129,15 +130,15 @@ void GdGen::ResetTime(double offset) {
   double eventTime = timeGen->GenerateEventTime();
   nextTime = eventTime + offset;
 #ifdef DEBUG
-  std::cout << "RAT::GdGen::ResetTime:"
+  debug << "RAT::GdGen::ResetTime:"
             << " eventTime=" << G4BestUnit(eventTime, "Time") << ", offset=" << G4BestUnit(offset, "Time")
-            << ", nextTime=" << G4BestUnit(nextTime, "Time") << std::endl;
+            << ", nextTime=" << G4BestUnit(nextTime, "Time") << newline;
 #endif
 }
 
 void GdGen::SetState(G4String state) {
 #ifdef DEBUG
-  std::cout << "RAT::GdGen::SetState called with state='" << state << "'" << std::endl;
+  debug << "RAT::GdGen::SetState called with state='" << state << "'" << newline;
 #endif
 
   // Break the argument to the this generator into sub-std::strings
@@ -147,7 +148,7 @@ void GdGen::SetState(G4String state) {
   size_t nArgs = parts.size();
 
 #ifdef DEBUG
-  std::cout << "RAT::GdGen::SetState: nArgs=" << nArgs << std::endl;
+  debug << "RAT::GdGen::SetState: nArgs=" << nArgs << newline;
 #endif
 
   try {
@@ -164,7 +165,7 @@ void GdGen::SetState(G4String state) {
       isotope = util_to_int(parts[0]);
 
       if (isotope != 158) {
-        std::cerr << "RAT::GdGen::SetState: Only gd 158 is supported" << std::endl;
+        warn << "RAT::GdGen::SetState: Only gd 158 is supported" << newline;
       }
 
       // The second argument is a position generator.
@@ -178,7 +179,7 @@ void GdGen::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -188,7 +189,7 @@ void GdGen::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "GdGen error: Cannot set time state, no time generator selected" << std::endl;
+    warn << "GdGen error: Cannot set time state, no time generator selected" << newline;
 }
 
 G4String GdGen::GetTimeState() const {
@@ -202,9 +203,9 @@ void GdGen::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "GdGen error: Cannot set position state, no position generator "
+    warn << "GdGen error: Cannot set position state, no position generator "
                  "selected"
-              << std::endl;
+              << newline;
 }
 
 G4String GdGen::GetPosState() const {

--- a/src/gen/src/Gen_LED.cc
+++ b/src/gen/src/Gen_LED.cc
@@ -81,7 +81,7 @@ void Gen_LED::GenerateEvent(G4Event *event) {
           theta = rand_angles[iLED]->shoot() * (angle_maxs[iLED] - angle_mins[iLED]) + angle_mins[iLED];
         else {
           warn << "Warning: missing " << next_led << "-th angular distr., only " << rand_angles.size()
-               << " exist! Reusing last distrib.\n";
+               << " exist! Reusing last distrib." << newline;
           theta = rand_angles[rand_angles.size() - 1]->shoot() *
                       (angle_maxs[rand_angles.size() - 1] - angle_mins[rand_angles.size() - 1]) +
                   angle_mins[rand_angles.size() - 1];
@@ -133,7 +133,7 @@ void Gen_LED::GenerateEvent(G4Event *event) {
         theta = rand_angles[next_led]->shoot() * (angle_maxs[next_led] - angle_mins[next_led]) + angle_mins[next_led];
       else {
         warn << "Warning: missing " << next_led << "-th angular distr., only " << rand_angles.size()
-             << " exist! Reusing last distrib.\n";
+             << " exist! Reusing last distrib." << newline;
         theta = rand_angles[rand_angles.size() - 1]->shoot() *
                     (angle_maxs[rand_angles.size() - 1] - angle_mins[rand_angles.size() - 1]) +
                 angle_mins[rand_angles.size() - 1];
@@ -195,7 +195,7 @@ void Gen_LED::SetLEDParameters(G4String state) {
     intensity_mode = lled->GetS("intensity_mode");
   } catch (DBNotFoundError &e) {
   };
-  info << intensity_mode.data() << " LED mode\n";
+  info << intensity_mode.data() << " LED mode" << newline;
   if (intensity_mode == "single")
     oneLED = true;
   else if (intensity_mode == "chain")
@@ -230,7 +230,7 @@ void Gen_LED::SetLEDParameters(G4String state) {
     multi_ang_dist_mode = true;
   else
     Log::Die(dformat("Gen_LED: LED.angle_mode = \"%s\" is invalid.", angle_mode.c_str()));
-  info << "LED angle mode: " << angle_mode.data() << "\n";
+  info << "LED angle mode: " << angle_mode.data() << newline;
 
   std::string wl_mode = lled->GetS("wl_mode");
   if (wl_mode == "mono")
@@ -280,7 +280,7 @@ void Gen_LED::SetLEDParameters(G4String state) {
       rand_angle = new CLHEP::RandGeneral(dist_angle_intensity, nbins);
     } else {
       if (int(led_x.size()) != lled->GetI("n_ang_dists"))
-        warn << lled->GetI("n_ang_dists") << " angular distributions, but " << led_x.size() << " LEDs...!\n";
+        warn << lled->GetI("n_ang_dists") << " angular distributions, but " << led_x.size() << " LEDs...!" << newline;
       double step = -.1;
       angle_maxs.clear();
       angle_mins.clear();
@@ -311,7 +311,7 @@ void Gen_LED::SetLEDParameters(G4String state) {
       }
       if (int(rand_angles.size()) != lled->GetI("n_ang_dists"))
         warn << "Loaded " << rand_angles.size() << " angular distributions. Should be " << lled->GetI("n_ang_dists")
-             << "... Data file needs to be rechecked!\n";
+             << "... Data file needs to be rechecked!" << newline;
       for (int iangs = 0; iangs < int(rand_angles.size()); iangs++) {
         Log::Assert(rand_angles[iangs] != NULL, dformat("Failed loading an angular distribution for %d-th LED", iangs));
       }
@@ -342,7 +342,7 @@ void Gen_LED::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "Gen_LED error: Cannot set time state, no time generator selected" << std::endl;
+    warn << "Gen_LED error: Cannot set time state, no time generator selected" << newline;
 }
 
 G4String Gen_LED::GetTimeState() const {
@@ -353,13 +353,13 @@ G4String Gen_LED::GetTimeState() const {
 }
 
 void Gen_LED::SetVertexState(G4String /*state*/) {
-  std::cerr << "Gen_LED error: Cannot set vertex state." << std::endl;
+  warn << "Gen_LED error: Cannot set vertex state." << newline;
 }
 
 G4String Gen_LED::GetVertexState() const { return G4String("Gen_LED error: no vertex generator"); }
 
 void Gen_LED::SetPosState(G4String /*state*/) {
-  std::cerr << "Gen_LED error: Cannot set position state, no position generator" << std::endl;
+  warn << "Gen_LED error: Cannot set position state, no position generator" << newline;
 }
 
 G4String Gen_LED::GetPosState() const { return G4String("Gen_LED error: no pos generator"); }

--- a/src/gen/src/Gen_RandomTrigger.cc
+++ b/src/gen/src/Gen_RandomTrigger.cc
@@ -3,6 +3,7 @@
 #include <G4Event.hh>
 #include <RAT/EventInfo.hh>
 #include <RAT/Factory.hh>
+#include <RAT/Log.hh>
 
 #include "RAT/GLG4StringUtil.hh"
 #include "RAT/GLG4TimeGen.hh"
@@ -23,9 +24,9 @@ void Gen_RandomTrigger::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "Gen_RandomTrigger error: Cannot set vertex state, no vertex "
+    RAT::warn << "Gen_RandomTrigger error: Cannot set vertex state, no vertex "
                  "generator selected"
-              << std::endl;
+              << newline;
 }
 
 G4String Gen_RandomTrigger::GetTimeState() const {

--- a/src/gen/src/HeGen.cc
+++ b/src/gen/src/HeGen.cc
@@ -21,6 +21,7 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/GLG4TimeGen.hh>
 #include <RAT/HeGen.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <numeric>
 #include <string>
@@ -218,15 +219,15 @@ void HeGen::ResetTime(double offset) {
   double eventTime = timeGen->GenerateEventTime();
   nextTime = eventTime + offset;
 #ifdef DEBUG
-  std::cout << "RAT::HeGen::ResetTime:"
+  debug << "RAT::HeGen::ResetTime:"
             << " eventTime=" << G4BestUnit(eventTime, "Time") << ", offset=" << G4BestUnit(offset, "Time")
-            << ", nextTime=" << G4BestUnit(nextTime, "Time") << std::endl;
+            << ", nextTime=" << G4BestUnit(nextTime, "Time") << newline;
 #endif
 }
 
 void HeGen::SetState(G4String state) {
 #ifdef DEBUG
-  std::cout << "RAT::HeGen::SetState called with state='" << state << "'" << std::endl;
+  debug << "RAT::HeGen::SetState called with state='" << state << "'" << newline;
 #endif
 
   // Break the argument to the this generator into sub-std::strings
@@ -236,7 +237,7 @@ void HeGen::SetState(G4String state) {
   size_t nArgs = parts.size();
 
 #ifdef DEBUG
-  std::cout << "RAT::HeGen::SetState: nArgs=" << nArgs << std::endl;
+  debug << "RAT::HeGen::SetState: nArgs=" << nArgs << newline;
 #endif
 
   try {
@@ -253,7 +254,7 @@ void HeGen::SetState(G4String state) {
       isotope = util_to_int(parts[0]);
 
       if (isotope != 8) {
-        std::cerr << "RAT::HeGen::SetState: Only He 8 is supported" << std::endl;
+        warn << "RAT::HeGen::SetState: Only He 8 is supported" << newline;
       }
 
       // The second argument is a position generator.
@@ -267,7 +268,7 @@ void HeGen::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -277,7 +278,7 @@ void HeGen::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "HeGen error: Cannot set time state, no time generator selected" << std::endl;
+    warn << "HeGen error: Cannot set time state, no time generator selected" << newline;
 }
 
 G4String HeGen::GetTimeState() const {
@@ -291,9 +292,9 @@ void HeGen::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "HeGen error: Cannot set position state, no position generator "
+    warn << "HeGen error: Cannot set position state, no position generator "
                  "selected"
-              << std::endl;
+              << newline;
 }
 
 G4String HeGen::GetPosState() const {

--- a/src/gen/src/LiGen.cc
+++ b/src/gen/src/LiGen.cc
@@ -21,6 +21,7 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/GLG4TimeGen.hh>
 #include <RAT/LiGen.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <numeric>
 #include <string>
@@ -180,15 +181,15 @@ void LiGen::ResetTime(double offset) {
   double eventTime = timeGen->GenerateEventTime();
   nextTime = eventTime + offset;
 #ifdef DEBUG
-  std::cout << "RAT::LiGen::ResetTime:"
+  debug << "RAT::LiGen::ResetTime:"
             << " eventTime=" << G4BestUnit(eventTime, "Time") << ", offset=" << G4BestUnit(offset, "Time")
-            << ", nextTime=" << G4BestUnit(nextTime, "Time") << std::endl;
+            << ", nextTime=" << G4BestUnit(nextTime, "Time") << newline;
 #endif
 }
 
 void LiGen::SetState(G4String state) {
 #ifdef DEBUG
-  std::cout << "RAT::LiGen::SetState called with state='" << state << "'" << std::endl;
+  debug << "RAT::LiGen::SetState called with state='" << state << "'" << newline;
 #endif
 
   // Break the argument to the this generator into sub-std::strings
@@ -198,7 +199,7 @@ void LiGen::SetState(G4String state) {
   size_t nArgs = parts.size();
 
 #ifdef DEBUG
-  std::cout << "RAT::LiGen::SetState: nArgs=" << nArgs << std::endl;
+  debug << "RAT::LiGen::SetState: nArgs=" << nArgs << newline;
 #endif
 
   try {
@@ -215,7 +216,7 @@ void LiGen::SetState(G4String state) {
       isotope = util_to_int(parts[0]);
 
       if (isotope != 9) {
-        std::cerr << "RAT::LiGen::SetState: Only Li 9 is supported" << std::endl;
+        warn << "RAT::LiGen::SetState: Only Li 9 is supported" << newline;
       }
 
       // The second argument is a position generator.
@@ -229,7 +230,7 @@ void LiGen::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -239,7 +240,7 @@ void LiGen::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "LiGen error: Cannot set time state, no time generator selected" << std::endl;
+    warn << "LiGen error: Cannot set time state, no time generator selected" << newline;
 }
 
 G4String LiGen::GetTimeState() const {
@@ -253,9 +254,9 @@ void LiGen::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "LiGen error: Cannot set position state, no position generator "
+    warn << "LiGen error: Cannot set position state, no position generator "
                  "selected"
-              << std::endl;
+              << newline;
 }
 
 G4String LiGen::GetPosState() const {

--- a/src/gen/src/NGen.cc
+++ b/src/gen/src/NGen.cc
@@ -22,6 +22,7 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/GLG4TimeGen.hh>
 #include <RAT/NGen.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <numeric>
 #include <string>
@@ -178,15 +179,15 @@ void NGen::ResetTime(double offset) {
   double eventTime = timeGen->GenerateEventTime();
   nextTime = eventTime + offset;
 #ifdef DEBUG
-  std::cout << "RAT::NGen::ResetTime:"
+  debug << "RAT::NGen::ResetTime:"
             << " eventTime=" << G4BestUnit(eventTime, "Time") << ", offset=" << G4BestUnit(offset, "Time")
-            << ", nextTime=" << G4BestUnit(nextTime, "Time") << std::endl;
+            << ", nextTime=" << G4BestUnit(nextTime, "Time") << newline;
 #endif
 }
 
 void NGen::SetState(G4String state) {
 #ifdef DEBUG
-  std::cout << "RAT::NGen::SetState called with state='" << state << "'" << std::endl;
+  debug << "RAT::NGen::SetState called with state='" << state << "'" << newline;
 #endif
 
   // Break the argument to the this generator into sub-std::strings
@@ -196,7 +197,7 @@ void NGen::SetState(G4String state) {
   size_t nArgs = parts.size();
 
 #ifdef DEBUG
-  std::cout << "RAT::NGen::SetState: nArgs=" << nArgs << std::endl;
+  debug << "RAT::NGen::SetState: nArgs=" << nArgs << newline;
 #endif
 
   try {
@@ -213,7 +214,7 @@ void NGen::SetState(G4String state) {
       isotope = util_to_int(parts[0]);
 
       if (isotope != 17) {
-        std::cerr << "RAT::NGen::SetState: Only N 17 is supported" << std::endl;
+        warn << "RAT::NGen::SetState: Only N 17 is supported" << newline;
       }
 
       // The second argument is a position generator.
@@ -227,7 +228,7 @@ void NGen::SetState(G4String state) {
 
     stateStr = state;  // Save for later call to GetState()
   } catch (FactoryUnknownID &unknown) {
-    std::cerr << "Unknown generator \"" << unknown.id << "\"" << std::endl;
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
   }
 }
 
@@ -237,7 +238,7 @@ void NGen::SetTimeState(G4String state) {
   if (timeGen)
     timeGen->SetState(state);
   else
-    std::cerr << "NGen error: Cannot set time state, no time generator selected" << std::endl;
+    warn << "NGen error: Cannot set time state, no time generator selected" << newline;
 }
 
 G4String NGen::GetTimeState() const {
@@ -251,9 +252,9 @@ void NGen::SetPosState(G4String state) {
   if (posGen)
     posGen->SetState(state);
   else
-    std::cerr << "NGen error: Cannot set position state, no position generator "
+    warn << "NGen error: Cannot set position state, no position generator "
                  "selected"
-              << std::endl;
+              << newline;
 }
 
 G4String NGen::GetPosState() const {

--- a/src/gen/src/PosGen_FillShell.cc
+++ b/src/gen/src/PosGen_FillShell.cc
@@ -37,10 +37,10 @@ void PosGen_FillShell::SetState(G4String newValues) {
   // it is a GLG4 convention that SetState with a null std::string argument
   // should print usage information
   if (newValues.length() == 0) {
-    std::cout << "Current state of this GLG4PosGen_PointPaintFill:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Usage: x_mm y_mm z_mm r_in r_out volname" << std::endl;
+    info << "Current state of this GLG4PosGen_PointPaintFill:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Usage: x_mm y_mm z_mm r_in r_out volname" << newline;
     return;
   }
 
@@ -90,7 +90,7 @@ void PosGen_FillShell::SetState(G4String newValues) {
   pos = G4ThreeVector(x, y, z);
 
   if (ri > ro) {
-    info << "Inner radius is greater than outer radius, flipping them.\n";
+    info << "Inner radius is greater than outer radius, flipping them." << newline;
     double radius_temp = ro;
     ro = ri;
     ri = radius_temp;
@@ -134,7 +134,7 @@ void PosGen_FillShell::GeneratePosition(G4ThreeVector &argResult) {
   } while (!(gNavigator->LocateGlobalPointAndSetup(rpos, 0, true)->GetName() == pVolume->GetName()));
 
   debug << "PosGen_FillShell::GeneratePosition: Point in volume " << pVolume->GetName() << " found in " << iterations
-        << " tries.\n";
+        << " tries." << newline;
 
   argResult = rpos;
 }

--- a/src/gen/src/PosGen_Line.cc
+++ b/src/gen/src/PosGen_Line.cc
@@ -1,5 +1,6 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/PosGen_Line.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <sstream>
 
@@ -18,12 +19,10 @@ void PosGen_Line::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this GLG4PosGen_Line:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to PosGen_Line::SetState: \n"
-                 " \"x1_mm y1_mm z1_mm x2_mm y2_mm z2_mm\""
-              << std::endl;
+    info << "Current state of this GLG4PosGen_Line:" << newline
+              << " \"" << GetState() << "\"" << newline << newline;
+    info << "Format of argument to PosGen_Line::SetState: " << newline
+              <<  " \"x1_mm y1_mm z1_mm x2_mm y2_mm z2_mm\"" << newline;
     return;
   }
 
@@ -33,9 +32,7 @@ void PosGen_Line::SetState(G4String newValues) {
   G4double x1, y1, z1, x2, y2, z2;
   is >> x1 >> y1 >> z1 >> x2 >> y2 >> z2;
   if (is.fail()) {
-    std::cerr << "PosGen_Line::SetState: "
-                 "Could not parse six floats from input std::string"
-              << std::endl;
+    warn << "PosGen_Line::SetState: Could not parse six floats from input string" << newline;
     return;
   }
   fPoint1 = G4ThreeVector(x1, y1, z1);

--- a/src/gen/src/PosGen_Multipoint.cc
+++ b/src/gen/src/PosGen_Multipoint.cc
@@ -23,14 +23,14 @@ void PosGen_Multipoint::SetState(G4String newValues) {
   newValues = strip_default(newValues);
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this PosGen_Multipoint:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to PosGen_Multipoint::SetState: \n"
-                 " \"uniform [# of points] [inner radius] [outer radius]\""
-              << std::endl;
-    std::cout << "   or" << std::endl;
-    std::cout << "\"table [name of table]\"" << std::endl;
+    info << "Current state of this PosGen_Multipoint:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to PosGen_Multipoint::SetState: " << newline
+              << " \"uniform [# of points] [inner radius] [outer radius]\""
+              << newline;
+    info << "   or" << newline;
+    info << "\"table [name of table]\"" << newline;
     RAT::Log::Die("PosGen_Multipoint requres arguments");
   }
 
@@ -46,9 +46,7 @@ void PosGen_Multipoint::SetState(G4String newValues) {
     is >> numPoints >> fInnerRadius >> fOuterRadius;
 
     if (is.fail()) {
-      RAT::Log::Die(
-          "PosGen_Multipoint: Could not parse one int and two "
-          "doubles from config std::string");
+      RAT::Log::Die("PosGen_Multipoint: Could not parse one int and two doubles from config string");
     }
 
     // Swap to make radius range physical
@@ -65,8 +63,7 @@ void PosGen_Multipoint::SetState(G4String newValues) {
 
     if (is.fail()) {
       RAT::Log::Die(
-          "PosGen_Multipoint: Could not parse a table name from "
-          "config std::string.");
+          "PosGen_Multipoint: Could not parse a table name from config string.");
     }
 
     // Extract table name and index

--- a/src/gen/src/PosGen_Radial.cc
+++ b/src/gen/src/PosGen_Radial.cc
@@ -1,5 +1,6 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/PosGen_Radial.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <sstream>
 
@@ -20,12 +21,11 @@ void PosGen_Radial::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this PosGen_Radial:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to PosGen_Radial::SetState: \n"
-                 " \"x_mm y_mm z_mm R_mm\""
-              << std::endl;
+    info << "Current state of this PosGen_Radial:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to PosGen_Radial::SetState: " << newline
+              << " \"x_mm y_mm z_mm R_mm\"" << newline;
     return;
   }
 
@@ -35,9 +35,7 @@ void PosGen_Radial::SetState(G4String newValues) {
   G4double x, y, z, R;
   is >> x >> y >> z >> R;
   if (is.fail()) {
-    std::cerr << "PosGen_Radial::SetState: "
-                 "Could not parse four floats from input std::string"
-              << std::endl;
+    warn << "PosGen_Radial::SetState: Could not parse four floats from input string" << newline;
     return;
   }
   fCenter = G4ThreeVector(x, y, z);

--- a/src/gen/src/PosGen_TriMeshSurface.cc
+++ b/src/gen/src/PosGen_TriMeshSurface.cc
@@ -38,12 +38,12 @@ void PosGen_TriMeshSurface::SetState(G4String newValues) {
   // complain if there are no arguments
   newValues = strip_default(newValues);
   if (newValues.length() == 0) {
-    std::cout << "Current state of this PosGen_TriMeshSurface:\n"
-              << "\"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of arguments to run PosGen_TriMeshSurface: \n"
-                 "\"tableIndex optionalThickness_mm optionalDirection\""
-              << std::endl;
+    info << "Current state of this PosGen_TriMeshSurface:" << newline
+              << "\"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of arguments to run PosGen_TriMeshSurface: " << newline
+              << "\"tableIndex optionalThickness_mm optionalDirection\""
+              << newline;
     return;
   }
   // read the new values

--- a/src/gen/src/ReacIBDgen.cc
+++ b/src/gen/src/ReacIBDgen.cc
@@ -5,6 +5,7 @@
 #include <RAT/DB.hh>
 #include <RAT/ReacIBDgen.hh>
 #include <RAT/ReacIBDgenMessenger.hh>
+#include <RAT/Log.hh>
 #include <fstream>
 #include <iostream>
 
@@ -92,7 +93,7 @@ void ReacIBDgen::GenInteraction(float &E, float &CosThetaLab) {
 
 void ReacIBDgen::SetU235Amplitude(double U235Am) {
   if ((U235Am < 0.) || (U235Am > 1.)) {
-    std::cerr << "Set your U235 Amplitude between 0 and 1." << std::endl;
+    warn << "Set your U235 Amplitude between 0 and 1." << newline;
     return;
   }
   U235Amp = U235Am;
@@ -107,7 +108,7 @@ void ReacIBDgen::Reset() {
 
 void ReacIBDgen::SetU238Amplitude(double U238Am) {
   if ((U238Am < 0.) || (U238Am > 1.)) {
-    std::cerr << "Set your U238 Amplitude between 0 and 1." << std::endl;
+    warn << "Set your U238 Amplitude between 0 and 1." << newline;
     return;
   }
   U238Amp = U238Am;
@@ -115,7 +116,7 @@ void ReacIBDgen::SetU238Amplitude(double U238Am) {
 
 void ReacIBDgen::SetPu239Amplitude(double Pu239Am) {
   if ((Pu239Am < 0.) || (Pu239Am > 1.)) {
-    std::cerr << "Set your Pu239 Amplitude between 0 and 1." << std::endl;
+    warn << "Set your Pu239 Amplitude between 0 and 1." << newline;
     return;
   }
   Pu239Amp = Pu239Am;
@@ -123,7 +124,7 @@ void ReacIBDgen::SetPu239Amplitude(double Pu239Am) {
 
 void ReacIBDgen::SetPu241Amplitude(double Pu241Am) {
   if ((Pu241Am < 0.) || (Pu241Am > 1.)) {
-    std::cerr << "Set your Pu241 Amplitude between 0 and 1." << std::endl;
+    warn << "Set your Pu241 Amplitude between 0 and 1." << newline;
     return;
   }
   Pu241Amp = Pu241Am;
@@ -160,7 +161,7 @@ float ReacIBDgen::GetNuEnergy() {
       fspace[i] = IBDESpectrum(flow + value);
 
 #ifdef DEBUG
-      std::cout << "   i=" << i << " f=" << fspace[i] << "," << std::endl;
+      debug << "   i=" << i << " f=" << fspace[i] << "," << newline;
 
 #endif
 
@@ -168,11 +169,11 @@ float ReacIBDgen::GetNuEnergy() {
       // Let's write the fspace prob. density function to a text file.
       std::ofstream fout("TheProbFunc.txt");
       if (fout.is_open()) {
-        std::cout << "Your file is open.  Let's put the probability density "
+        debug << "Your file is open.  Let's put the probability density "
                      "function into it..."
-                  << std::endl;
+                  << newline;
         for (int i = 0; i < probDensSize; i++) {
-          fout << i << " " << fspace[i] << std::endl;
+          fout << i << " " << fspace[i] << newline;
         }
         fout.close();
       }
@@ -185,9 +186,9 @@ float ReacIBDgen::GetNuEnergy() {
     fGenerate = new CLHEP::RandGeneral(fspace, probDensSize);
 
 #ifdef DEBUG
-    std::cout << " Random generator test (f):" << std::endl;
+    debug << " Random generator test (f):" << newline;
     for (int i = 0; i != 20; i++) {
-      std::cout << i << ": " << fGenerate->shoot() * (fhigh - flow) + flow << ", " << std::endl;
+      debug << i << ": " << fGenerate->shoot() * (fhigh - flow) + flow << ", " << newline;
     }
 
 #endif
@@ -196,7 +197,7 @@ float ReacIBDgen::GetNuEnergy() {
   float nuE = fGenerate->shoot() * (fhigh - flow) + flow;
 
 #ifdef DEBUG
-  std::cout << "Your generated neutrino energy is..." << nuE << std::endl;
+  debug << "Your generated neutrino energy is..." << nuE << newline;
 #endif
 
   return nuE;
@@ -212,7 +213,7 @@ double ReacIBDgen::IBDESpectrum(float x) {
   double EnergyVal = NuReacSpectrum(x) * XC * sqrt(XC * XC - mElectron * mElectron);
 
 #ifdef DEBUG
-  std::cout << EnergyVal << " and " << XC << std::endl;
+  debug << EnergyVal << " and " << XC << newline;
 #endif
 
   return EnergyVal;

--- a/src/gen/src/SNgen.cc
+++ b/src/gen/src/SNgen.cc
@@ -24,6 +24,7 @@
 #include <RAT/DB.hh>
 #include <RAT/SNgen.hh>
 #include <RAT/SNgenMessenger.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <cmath>
 
@@ -177,7 +178,7 @@ void SNgen::Reset() {
 
 void SNgen::SetIBDAmplitude(double IBDAm) {
   if ((IBDAm < 0.) || (IBDAm > 1.)) {
-    std::cerr << "Set your IBD Amplitude between 0 and 1." << std::endl;
+    warn << "Set your IBD Amplitude between 0 and 1." << newline;
     return;
   }
   IBDAmp = IBDAm;
@@ -185,7 +186,7 @@ void SNgen::SetIBDAmplitude(double IBDAm) {
 
 void SNgen::SetESAmplitude(double ESAm) {
   if ((ESAm < 0.) || (ESAm > 1.)) {
-    std::cerr << "Set your ES Amplitude between 0 and 1." << std::endl;
+    warn << "Set your ES Amplitude between 0 and 1." << newline;
     return;
   }
   ESAmp = ESAm;
@@ -193,7 +194,7 @@ void SNgen::SetESAmplitude(double ESAm) {
 
 void SNgen::SetCCAmplitude(double CCAm) {
   if ((CCAm < 0.) || (CCAm > 1.)) {
-    std::cerr << "Set your CC Amplitude between 0 and 1." << std::endl;
+    warn << "Set your CC Amplitude between 0 and 1." << newline;
     return;
   }
   CCAmp = CCAm;
@@ -201,7 +202,7 @@ void SNgen::SetCCAmplitude(double CCAm) {
 
 void SNgen::SetICCAmplitude(double ICCAm) {
   if ((ICCAm < 0.) || (ICCAm > 1.)) {
-    std::cerr << "Set your ICC Amplitude between 0 and 1." << std::endl;
+    warn << "Set your ICC Amplitude between 0 and 1." << newline;
     return;
   }
   ICCAmp = ICCAm;
@@ -209,7 +210,7 @@ void SNgen::SetICCAmplitude(double ICCAm) {
 
 void SNgen::SetNCAmplitude(double NCAm) {
   if ((NCAm < 0.) || (NCAm > 1.)) {
-    std::cerr << "Set your NC Amplitude between 0 and 1." << std::endl;
+    warn << "Set your NC Amplitude between 0 and 1." << newline;
     return;
   }
   NCAmp = NCAm;
@@ -217,21 +218,21 @@ void SNgen::SetNCAmplitude(double NCAm) {
 
 void SNgen::SetModel(double ModelTm) {
   if ((ModelTm < 1.) || (ModelTm > 2.)) {
-    std::cerr << "Set your model between 1 (livermore) and 2. (gvkm)" << std::endl;
+    warn << "Set your model between 1 (livermore) and 2. (gvkm)" << newline;
     return;
   }
   ModelTmp = ModelTm;
 }
 
 void SNgen::Show() {
-  std::cout << "Elastic Scatteing Settings:" << std::endl;
-  std::cout << "Weak Mixing Angle (sinsq(ThetaW)):" << GetMixingAngle() << std::endl;
-  std::cout << "Neutrino Magnetic Moment: " << GetMagneticMoment() << std::endl;
+  info << "Elastic Scatteing Settings:" << newline;
+  info << "Weak Mixing Angle (sinsq(ThetaW)):" << GetMixingAngle() << newline;
+  info << "Neutrino Magnetic Moment: " << GetMagneticMoment() << newline;
 }
 
 void SNgen::SetMixingAngle(double sin2thw) {
   if ((sin2thw < 0.) || (sin2thw > 1.)) {
-    std::cerr << "Error in value setting." << std::endl;
+    warn << "Error in value setting." << newline;
     return;
   }
   SinSqThetaW = sin2thw;
@@ -239,7 +240,7 @@ void SNgen::SetMixingAngle(double sin2thw) {
 
 void SNgen::SetNeutrinoMoment(double vMu) {
   if (vMu < 0.) {
-    std::cerr << "Error in value setting." << std::endl;
+    warn << "Error in value setting." << newline;
     return;
   }
   MagneticMoment = vMu;
@@ -542,14 +543,14 @@ void SNgen::LoadSpectra() {
   int model = GetModel();
   Double_t magsumTot, totIBD, totES, totCC, totICC, totNC, x, y;
 
-  std::cout << "\n===================== Supernova information ======================" << std::endl;
+  info << "\n===================== Supernova information ======================" << newline;
 
   // Load in the Livermore model
   if (model == 1) {
-    std::cout << "\nUsing the livermore model. Within the this model the "
+    info << "\nUsing the livermore model. Within the this model the "
                  "following rates are present.\nThese rates are not used in the "
                  "processing of these events, but may be set by the user\nmanualy "
-              << std::endl;
+              << newline;
 
     //////////////////////////// IBD
     /////////////////////////////////////////////////////////
@@ -566,7 +567,7 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphIBD->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    std::cout << "Total IBD integrate spectra is  " << magsumTot << std::endl;
+    info << "Total IBD integrate spectra is  " << magsumTot << newline;
     totIBD = magsumTot;
 
     //////////////////////////// CC
@@ -584,7 +585,7 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphCC->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    std::cout << "Total CC integrate spectra is  " << magsumTot << std::endl;
+    info << "Total CC integrate spectra is  " << magsumTot << newline;
     totCC = magsumTot;
 
     //////////////////////////// ICC
@@ -602,7 +603,7 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphICC->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    std::cout << "Total ICC integrate spectra is  " << magsumTot << std::endl;
+    info << "Total ICC integrate spectra is  " << magsumTot << newline;
     totICC = magsumTot;
 
     //////////////////////////// NC
@@ -621,8 +622,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    //            std::cout << "Total NC integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total NC integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nc_numu_O16");
@@ -637,8 +638,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nc_nutau_O16");
@@ -653,8 +654,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nc_nuebar_O16");
@@ -669,8 +670,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nc_numubar_O16");
@@ -685,8 +686,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nc_nutaubar_O16");
@@ -701,8 +702,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     //////////////////////////// ES
@@ -719,11 +720,11 @@ void SNgen::LoadSpectra() {
     for (unsigned int istep = 0; istep < spec_E.size(); ++istep) {
       magsumTot += (spec_mag[istep]);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep]);
-      // std::cout << "ES nue " << spec_E[istep]  << " " <<spec_mag[istep] <<
-      // std::endl;
+      // info << "ES nue " << spec_E[istep]  << " " <<spec_mag[istep] <<
+      // newline;
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nuebar_e");
@@ -737,12 +738,12 @@ void SNgen::LoadSpectra() {
       graphES->GetPoint(istep, x, y);
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
-      // std::cout << "ES nuebar x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
+      // info << "ES nuebar x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
       // spec_mag[istep] << " + " << y <<" = " << spec_mag[istep]+y << ")"
-      // <<std::endl;
+      // <<newline;
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_numu_e");
@@ -757,12 +758,12 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
 
-      // std::cout << "ES numu x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
+      // info << "ES numu x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
       // spec_mag[istep] << " + " << y <<" = " << spec_mag[istep]+y << ")"
-      // <<std::endl;
+      // <<newline;
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_numubar_e");
@@ -776,12 +777,12 @@ void SNgen::LoadSpectra() {
       graphES->GetPoint(istep, x, y);
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
-      // std::cout << "ES numubar x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
+      // info << "ES numubar x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
       // spec_mag[istep] << " + " << y <<" = " << spec_mag[istep]+y << ")"
-      // <<std::endl;
+      // <<newline;
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nutau_e");
@@ -795,12 +796,12 @@ void SNgen::LoadSpectra() {
       graphES->GetPoint(istep, x, y);
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
-      // std::cout << "ES nutau x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
+      // info << "ES nutau x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
       // spec_mag[istep] << " + " << y <<" = " << spec_mag[istep]+y << ")"
-      // <<std::endl;
+      // <<newline;
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "livermore_nutaubar_e");
@@ -814,27 +815,27 @@ void SNgen::LoadSpectra() {
       graphES->GetPoint(istep, x, y);
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
-      // std::cout << "ES nutaubar x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
+      // info << "ES nutaubar x:(" << spec_E[istep]  << ", " <<x << "), E:("<<
       // spec_mag[istep] << " + " << y <<" = " << spec_mag[istep]+y << ")"
-      // <<std::endl;
+      // <<newline;
     }
-    std::cout << "Total ES integrate spectra is  " << magsumTot << std::endl;
+    info << "Total ES integrate spectra is  " << magsumTot << newline;
     totES = magsumTot;
 
     //////////////////////////// TALLY
     /////////////////////////////////////////////////////////
 
     Double_t tot = totIBD + totES + totCC + totICC + totNC;
-    std::cout << "(ibd,es,cc,icc,nc): "
+    info << "(ibd,es,cc,icc,nc): "
               << "(" << totIBD / tot << ", " << totES / tot << ", " << totCC / tot << ", " << totICC / tot << ", "
-              << totNC / tot << ")\n"
-              << std::endl;
+              << totNC / tot << ")" << newline
+              << newline;
   }  // GVKM MODELgvkm
   else if (model == 2) {
-    std::cout << "\nUsing the gvkm model. Within the this model the following "
+    info << "\nUsing the gvkm model. Within the this model the following "
                  "rates are present.\nThese rates are not used in the processing "
                  "of these events, but may be set by the user\nmanualy  "
-              << std::endl;
+              << newline;
 
     //////////////////////////// IBD
     /////////////////////////////////////////////////////////
@@ -851,7 +852,7 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphIBD->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    std::cout << "Total IBD integrate spectra is  " << magsumTot << std::endl;
+    info << "Total IBD integrate spectra is  " << magsumTot << newline;
     totIBD = magsumTot;
 
     //////////////////////////// CC
@@ -869,7 +870,7 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphCC->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    std::cout << "Total CC integrate spectra is  " << magsumTot << std::endl;
+    info << "Total CC integrate spectra is  " << magsumTot << newline;
     totCC = magsumTot;
 
     //////////////////////////// ICC
@@ -887,7 +888,7 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphICC->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    std::cout << "Total ICC integrate spectra is  " << magsumTot << std::endl;
+    info << "Total ICC integrate spectra is  " << magsumTot << newline;
     totICC = magsumTot;
 
     //////////////////////////// NC
@@ -906,8 +907,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    //            std::cout << "Total NC integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total NC integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nc_numu_O16");
@@ -922,8 +923,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nc_nutau_O16");
@@ -938,8 +939,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nc_nuebar_O16");
@@ -954,8 +955,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nc_numubar_O16");
@@ -970,8 +971,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nc_nutaubar_O16");
@@ -986,8 +987,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphNCRate->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totNC = magsumTot;
 
     //////////////////////////// ES
@@ -1005,8 +1006,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep]);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep]);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nuebar_e");
@@ -1021,8 +1022,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_numu_e");
@@ -1037,8 +1038,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_numubar_e");
@@ -1053,8 +1054,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nutau_e");
@@ -1069,8 +1070,8 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    //            std::cout << "Total ES integrate spectra is  " <<
-    //            magsumTot<<std::endl;
+    //            info << "Total ES integrate spectra is  " <<
+    //            magsumTot<<newline;
     totES = magsumTot;
 
     _lspec = DB::Get()->GetLink("SN_SPECTRUM", "gvkm_nutaubar_e");
@@ -1085,17 +1086,17 @@ void SNgen::LoadSpectra() {
       magsumTot += (spec_mag[istep] + y);
       graphES->SetPoint(istep, spec_E[istep], spec_mag[istep] + y);
     }
-    std::cout << "Total ES integrate spectra is  " << magsumTot << std::endl;
+    info << "Total ES integrate spectra is  " << magsumTot << newline;
     totES = magsumTot;
 
     //////////////////////////// TALLY
     /////////////////////////////////////////////////////////
 
     Double_t tot = totIBD + totES + totCC + totICC + totNC;
-    std::cout << "(ibd,es,cc,icc,nc): "
+    info << "(ibd,es,cc,icc,nc): "
               << "(" << totIBD / tot << ", " << totES / tot << ", " << totCC / tot << ", " << totICC / tot << ", "
-              << totNC / tot << ")\n"
-              << std::endl;
+              << totNC / tot << ")" << newline
+              << newline;
   }
 
   // Neutral current event get a special treatment.

--- a/src/gen/src/VertexGen_CC.cc
+++ b/src/gen/src/VertexGen_CC.cc
@@ -20,6 +20,7 @@
 #include <RAT/PrimaryVertexInformation.hh>
 #include <RAT/StringUtil.hh>
 #include <RAT/VertexGen_CC.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <cmath>
 #include <globals.hh>
@@ -109,16 +110,16 @@ void VertexGen_CC::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);  // from GLG4StringUtil
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_CC:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_CC::SetState: \n"
-                 " \"nu_dir_x nu_dir_y nu_dir_z [db_name:][db_flux:nu_flavor]\"\n"
-                 " where fNuDir is the initial direction of the incoming neutrino.\n"
-                 " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
-                 "isotropic\n"
-                 " neutrino direction."
-              << std::endl;
+    info << "Current state of this VertexGen_CC:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_CC::SetState: " << newline
+              << " \"nu_dir_x nu_dir_y nu_dir_z [db_name:][db_flux:nu_flavor]\"\n"
+              << " where fNuDir is the initial direction of the incoming neutrino.\n"
+              << " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
+              << "isotropic\n"
+              << " neutrino direction."
+              << newline;
     return;
   }
 
@@ -127,7 +128,7 @@ void VertexGen_CC::SetState(G4String newValues) {
   std::string rest;
   is >> x >> y >> z >> rest;
   if (is.fail()) {
-    std::cout << "VertexGen_CC : Failed to extract state from input std::string.\n";
+    info << "VertexGen_CC : Failed to extract state from input string." << newline;
     return;
   }
 
@@ -157,7 +158,7 @@ void VertexGen_CC::SetState(G4String newValues) {
     case 1:
       this->SetDBName(params[0]);
     default:
-      std::cout << "VertexGen_CC : Detected only " << params.size() << " neutrino state terms (1,2, or 3 expected).\n";
+      info << "VertexGen_CC : Detected only " << params.size() << " neutrino state terms (1,2, or 3 expected)." << newline;
       return;
   }
 }

--- a/src/gen/src/VertexGen_CRY.cc
+++ b/src/gen/src/VertexGen_CRY.cc
@@ -14,6 +14,7 @@
 #include <G4ThreeVector.hh>
 #include <RAT/DB.hh>
 #include <RAT/EventInfo.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <string>
 
@@ -113,7 +114,7 @@ void VertexGen_CRY::GeneratePrimaryVertex(G4Event *event, G4ThreeVector &dx, G4d
 void VertexGen_CRY::SetState(G4String newValues) {
   // newValues = util_strip_default(newValues);
   if (newValues.length() == 0) {
-    std::cout << "Current state of this VertexGen_CRY: " << GetState() << std::endl;
+    info << "Current state of this VertexGen_CRY: " << GetState() << newline;
   }
 }
 

--- a/src/gen/src/VertexGen_ES.cc
+++ b/src/gen/src/VertexGen_ES.cc
@@ -20,6 +20,7 @@
 #include <RAT/PrimaryVertexInformation.hh>
 #include <RAT/StringUtil.hh>
 #include <RAT/VertexGen_ES.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <cmath>
 #include <globals.hh>
@@ -101,16 +102,16 @@ void VertexGen_ES::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);  // from GLG4StringUtil
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_ES:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_ES::SetState: \n"
-                 " \"nu_dir_x nu_dir_y nu_dir_z [db_name:][db_flux:nu_flavor]\"\n"
-                 " where fNuDir is the initial direction of the incoming neutrino.\n"
-                 " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
-                 "isotropic\n"
-                 " neutrino direction."
-              << std::endl;
+    info << "Current state of this VertexGen_ES:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_ES::SetState: " << newline
+              << " \"nu_dir_x nu_dir_y nu_dir_z [db_name:][db_flux:nu_flavor]\"\n"
+              << " where fNuDir is the initial direction of the incoming neutrino.\n"
+              << " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
+              << "isotropic\n"
+              << " neutrino direction."
+              << newline;
     return;
   }
 
@@ -119,7 +120,7 @@ void VertexGen_ES::SetState(G4String newValues) {
   std::string rest;
   is >> x >> y >> z >> rest;
   if (is.fail()) {
-    std::cout << "VertexGen_ES : Failed to extract state from input std::string.\n";
+    info << "VertexGen_ES : Failed to extract state from input string." << newline;
     return;
   }
 
@@ -149,7 +150,7 @@ void VertexGen_ES::SetState(G4String newValues) {
     case 1:
       this->SetDBName(params[0]);
     default:
-      std::cout << "VertexGen_ES : Detected only " << params.size() << " neutrino state terms (1,2, or 3 expected).\n";
+      info << "VertexGen_ES : Detected only " << params.size() << " neutrino state terms (1,2, or 3 expected)." << newline;
       return;
   }
 }

--- a/src/gen/src/VertexGen_FastNeutron.cc
+++ b/src/gen/src/VertexGen_FastNeutron.cc
@@ -80,9 +80,9 @@ void VertexGen_FastNeutron::GeneratePrimaryVertex(G4Event *event, G4ThreeVector 
   double massN = n->GetPDGMass();
   double totNeutronMomentum = sqrt(pow(neutronEnergy + massN, 2) - pow(massN, 2));
   G4ThreeVector momentum = neutronDirection * totNeutronMomentum;
-  //        std::cout << "( " << muCosTheta << ", "<< phi << ") (" << cosTheta <<
+  //        info << "( " << muCosTheta << ", "<< phi << ") (" << cosTheta <<
   //        ", " << phi2 <<") " << ev_mu_dir << " " << ev_n_dir << " " <<
-  //        neutronDirection<< "\n";
+  //        neutronDirection<< newline;
 
   // Generate the geant4 neutron_particle vertex
   G4PrimaryVertex *vertex = new G4PrimaryVertex(dx, dt);
@@ -100,17 +100,14 @@ void VertexGen_FastNeutron::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);  // from GLG4StringUtil
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_ES:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_ES::SetState: \n"
-                 " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
-                 " where nu_dir is the initial direction of the reactor "
-                 "antineutrino.\n"
-                 " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
-                 "isotropic\n"
-                 " neutrino direction."
-              << std::endl;
+    info << "Current state of this VertexGen_ES:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_ES::SetState: " << newline
+              << " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
+              << " where nu_dir is the initial direction of the reactor antineutrino.\n"
+              << " Does not have to be normalized.  Set to \"0. 0. 0.\" for isotropic\n"
+              << " neutrino direction." << newline;
     return;
   }
 
@@ -139,7 +136,7 @@ G4String VertexGen_FastNeutron::GetState() {
 
 void VertexGen_FastNeutron::SetDepth(double _tmpVal) {
   if ((_tmpVal < 0.) || (_tmpVal > 8000.)) {
-    std::cerr << "Set your depth between 0 and 8000." << std::endl;
+    warn << "Set your depth between 0 and 8000." << newline;
     return;
   }
   valueD = _tmpVal;
@@ -147,7 +144,7 @@ void VertexGen_FastNeutron::SetDepth(double _tmpVal) {
 
 void VertexGen_FastNeutron::SetEnThreshold(double _tmpVal) {
   if ((_tmpVal < 1.) || (_tmpVal > 1000.)) {
-    std::cerr << "Set your energy threshold between 1 and 1000." << std::endl;
+    warn << "Set your energy threshold between 1 and 1000." << newline;
     return;
   }
   valueE = _tmpVal;
@@ -155,7 +152,7 @@ void VertexGen_FastNeutron::SetEnThreshold(double _tmpVal) {
 
 void VertexGen_FastNeutron::SetSideBool(double _tmpVal) {
   if ((_tmpVal < 0) || (_tmpVal > 1)) {
-    std::cerr << "Set your wall to either at 0 or 1" << std::endl;
+    warn << "Set your wall to either at 0 or 1" << newline;
     return;
   }
   valueSB = _tmpVal;
@@ -199,8 +196,8 @@ void VertexGen_FastNeutron::GetMeiHimeParameters(double depth, double emin, doub
 
   MeiHimeCosDistribution->Delete();
 
-  //        std::cout << energy << " " << cosTheta << " " << B0 << " " << C0 <<
-  //        std::endl;
+  //        info << energy << " " << cosTheta << " " << B0 << " " << C0 <<
+  //        newline;
 
   //        return energy;
 }

--- a/src/gen/src/VertexGen_IBD.cc
+++ b/src/gen/src/VertexGen_IBD.cc
@@ -11,6 +11,7 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/IBDgen.hh>
 #include <RAT/VertexGen_IBD.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <globals.hh>
 #include <sstream>
@@ -72,17 +73,14 @@ void VertexGen_IBD::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);  // from GLG4StringUtil
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_IBD:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_IBD::SetState: \n"
-                 " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
-                 " where nu_dir is the initial direction of the reactor "
-                 "antineutrino.\n"
-                 " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
-                 "isotropic\n"
-                 " neutrino direction."
-              << std::endl;
+    info << "Current state of this VertexGen_IBD:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_IBD::SetState: " << newline
+              << " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
+              << " where nu_dir is the initial direction of the reactor antineutrino.\n"
+              << " Does not have to be normalized.  Set to \"0. 0. 0.\" for isotropic\n"
+              << " neutrino direction." << newline;
     return;
   }
 

--- a/src/gen/src/VertexGen_Isotope.cc
+++ b/src/gen/src/VertexGen_Isotope.cc
@@ -54,14 +54,14 @@ void VertexGen_Isotope::GeneratePrimaryVertex(G4Event *event, G4ThreeVector &dx,
 void VertexGen_Isotope::SetState(G4String newValues) {
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_Isotope:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_Isotope::SetState: \n"
-              << " \"pname  specname  (Elo Ehi)\"\n"
-              << " pname = particle name \n"
-              << " specname = Isotope name as given in ratdb \n"
-              << " Elo Ehi = optional limits on energy range of generated particles " << std::endl;
+    info << "Current state of this VertexGen_Isotope:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_Isotope::SetState: " << newline
+              << " \"pname  specname  (Elo Ehi)\"" << newline
+              << " pname = particle name " << newline
+              << " specname = Isotope name as given in ratdb " << newline
+              << " Elo Ehi = optional limits on energy range of generated particles " << newline;
     return;
   }
 
@@ -90,17 +90,17 @@ void VertexGen_Isotope::SetState(G4String newValues) {
         if (elementName == GLG4VertexGen_Gun::theElementNames[Z - 1]) break;
         if (Z <= GLG4VertexGen_Gun::numberOfElements) {
           newTestGunG4Code = G4IonTable::GetIonTable()->GetIon(Z, A, 0.0);
-          std::cout << " Isotope Vertex: Setting ion with A = " << A << " Z = " << Z << std::endl;
+          info << " Isotope Vertex: Setting ion with A = " << A << " Z = " << Z << newline;
         }
       }
     }
     if (newTestGunG4Code == NULL) {
-      std::cerr << "Isotope Vertex: Could not find particle type " << pname << " defaulting to electron " << std::endl;
+      warn << "Isotope Vertex: Could not find particle type " << pname << " defaulting to electron " << newline;
       _particle = "e-";
       return;
     }
   } else {
-    std::cout << "Isotope Vertex: Setting particle = " << pname << std::endl;
+    info << "Isotope Vertex: Setting particle = " << pname << newline;
   }
   // so store the name and the particle definition
   _particle = pname;
@@ -113,11 +113,11 @@ void VertexGen_Isotope::SetState(G4String newValues) {
   //        DBLinkPtr lspec = DB::Get()->GetLink("Isotope", specname);
   //        if(lspec){
   //            _Isotope = specname;
-  //            std::cout << "Isotope Vertex: Setting Isotope " << specname <<
-  //            std::endl;
+  //            info << "Isotope Vertex: Setting Isotope " << specname <<
+  //            newline;
   //        }else{
-  //            std::cerr << "Could not find Isotope " << specname << " using
-  //            default, flat Isotope " << std::endl;
+  //            warn << "Could not find Isotope " << specname << " using
+  //            default, flat Isotope " << newline;
   //        }
 
   // finally ready to initialise the Isotope!
@@ -138,7 +138,7 @@ G4String VertexGen_Isotope::GetState() {
 
 void VertexGen_Isotope::SetIsotopeA(double IBDAm) {
   if ((IBDAm < 0.) || (IBDAm > 400.)) {
-    std::cerr << "Set your IBD Amplitude between 0 and 400." << std::endl;
+    warn << "Set your IBD Amplitude between 0 and 400." << newline;
     return;
   }
   valueA = IBDAm;
@@ -146,7 +146,7 @@ void VertexGen_Isotope::SetIsotopeA(double IBDAm) {
 
 void VertexGen_Isotope::SetIsotopeZ(double IBDAm) {
   if ((IBDAm < 0.) || (IBDAm > 400.)) {
-    std::cerr << "Set your IBD Amplitude between 0 and 400." << std::endl;
+    warn << "Set your IBD Amplitude between 0 and 400." << newline;
     return;
   }
   valueZ = IBDAm;
@@ -154,7 +154,7 @@ void VertexGen_Isotope::SetIsotopeZ(double IBDAm) {
 
 void VertexGen_Isotope::SetIsotopeE(double IBDAm) {
   if ((IBDAm < 0.) || (IBDAm > 400.)) {
-    std::cerr << "Set your IBD Amplitude between 0 and 400." << std::endl;
+    warn << "Set your IBD Amplitude between 0 and 400." << newline;
     return;
   }
   valueE = IBDAm;

--- a/src/gen/src/VertexGen_PhotonBomb.cc
+++ b/src/gen/src/VertexGen_PhotonBomb.cc
@@ -61,12 +61,12 @@ void VertexGen_PhotonBomb::GeneratePrimaryVertex(G4Event *event, G4ThreeVector &
 void VertexGen_PhotonBomb::SetState(G4String newValues) {
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_PhotonBomb:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_PhotonBomb::SetState: \n"
-                 " \"num_photons wavelength_nm\"\n"
-              << std::endl;
+    info << "Current state of this VertexGen_PhotonBomb:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_PhotonBomb::SetState: " << newline
+              << " \"num_photons wavelength_nm\"\n"
+              << newline;
     return;
   }
 

--- a/src/gen/src/VertexGen_ReacIBD.cc
+++ b/src/gen/src/VertexGen_ReacIBD.cc
@@ -9,6 +9,7 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/ReacIBDgen.hh>
 #include <RAT/VertexGen_ReacIBD.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <globals.hh>
 #include <sstream>
@@ -64,17 +65,14 @@ void VertexGen_ReacIBD::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);  // from GLG4StringUtil
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_ReacIBD:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_ReacIBD::SetState: \n"
-                 " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
-                 " where nu_dir is the initial direction of the reactor "
-                 "antineutrino.\n"
-                 " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
-                 "isotropic\n"
-                 " neutrino direction."
-              << std::endl;
+    info << "Current state of this VertexGen_ReacIBD:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_ReacIBD::SetState: " << newline
+           << " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
+           << " where nu_dir is the initial direction of the reactor antineutrino.\n"
+           << " Does not have to be normalized.  Set to \"0. 0. 0.\" for isotropic\n"
+           << " neutrino direction." << newline;
     return;
   }
 

--- a/src/gen/src/VertexGen_SN.cc
+++ b/src/gen/src/VertexGen_SN.cc
@@ -18,6 +18,7 @@
 #include <RAT/GLG4StringUtil.hh>
 #include <RAT/SNgen.hh>
 #include <RAT/VertexGen_SN.hh>
+#include <RAT/Log.hh>
 #include <Randomize.hh>
 #include <cmath>
 #include <globals.hh>
@@ -53,9 +54,9 @@ void VertexGen_SN::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVector &dx, G
     G4double theta = acos(2.0 * G4UniformRand() - 1.0);
     G4double phi = 2.0 * G4UniformRand() * CLHEP::pi;
     nu_dir.setRThetaPhi(1.0, theta, phi);  // Changed such that nu_dir is changed, not e_nu_dir
-    std::cout << "You have chosen an isotropic configuration, for supernovae this "
-                 "does not make sense.\n Picking a new direction for you. ("
-              << theta << " " << phi << ")" << std::endl;
+    info << "You have chosen an isotropic configuration, for supernovae this "
+           << "does not make sense.\n Picking a new direction for you. ("
+           << theta << " " << phi << ")" << newline;
   }
 
   // Pick an interaction for the supernova and then randomly pick a neutrino
@@ -89,7 +90,7 @@ void VertexGen_SN::GeneratePrimaryVertex(G4Event *argEvent, G4ThreeVector &dx, G
     }
 
   } else {
-    std::cout << "No interactions was chosen, something is wrong with the code" << std::endl;
+    info << "No interactions was chosen, something is wrong with the code" << newline;
     G4PrimaryVertex *vertex = new G4PrimaryVertex(dx, dt);
     argEvent->AddPrimaryVertex(vertex);
   }
@@ -100,17 +101,14 @@ void VertexGen_SN::SetState(G4String newValues) {
   newValues = util_strip_default(newValues);  // from GLG4StringUtil
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_SN:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_SN::SetState: \n"
-                 " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
-                 " where nu_dir is the initial direction of the reactor "
-                 "antineutrino.\n"
-                 " Does not have to be normalized.  Set to \"0. 0. 0.\" for "
-                 "isotropic\n"
-                 " neutrino direction."
-              << std::endl;
+    info << "Current state of this VertexGen_SN:" << newline
+            << " \"" << GetState() << "\"" << newline
+            << newline;
+    info << "Format of argument to VertexGen_SN::SetState: " << newline
+            << " \"nu_dir_x nu_dir_y nu_dir_z\"\n"
+            << " where nu_dir is the initial direction of the reactor antineutrino.\n"
+            << " Does not have to be normalized.  Set to \"0. 0. 0.\" for isotropic\n"
+            << " neutrino direction." << newline;
     return;
   }
 
@@ -145,7 +143,7 @@ int VertexGen_SN::ChooseInteraction() {
   double a4 = a3 + sngen.GetICCAmplitude();
   double a5 = a4 + sngen.GetNCAmplitude();
   if (std::abs(a5 - 1.0) > 0.01) {
-    std::cout << "Something is wrong " << a1 << " " << a2 << " " << a3 << " " << a4 << " " << a5 << std::endl;
+    info << "Something is wrong " << a1 << " " << a2 << " " << a3 << " " << a4 << " " << a5 << newline;
   }
   if (rand < a1) {
     return 1;
@@ -168,9 +166,9 @@ void VertexGen_SN::GenerateIBDVertex(G4Event *argEvent, G4ThreeVector &dx, G4dou
   Eval2BodyKinematicIBD(e_nu, ev_nu_dir);
 
 #ifdef DEBUG
-  std::cout << "Neutrino " << ev_nu_dir << "" << std::endl;
-  std::cout << "Positron " << primair << "" << std::endl;
-  std::cout << "Neutron " << secondaire << "" << std::endl;
+  debug << "Neutrino " << ev_nu_dir << "" << newline;
+  debug << "Positron " << primair << "" << newline;
+  debug << "Neutron " << secondaire << "" << newline;
 #endif
 
   // -- Create particles
@@ -211,8 +209,8 @@ void VertexGen_SN::GenerateESVertex(G4Event *argEvent, G4ThreeVector &dx, G4doub
   CLHEP::HepLorentzVector mom_electron = GetEmomentum(e_nu, energyElectron, ev_nu_dir);
 
 #ifdef DEBUG
-  std::cout << "Energies (" << e_nu << ", " << energyElectron << ")" << std::endl;
-  std::cout << "Momentum (" << mom_electron2 << ")" << std::endl;
+  debug << "Energies (" << e_nu << ", " << energyElectron << ")" << newline;
+  debug << "Momentum (" << mom_electron2 << ")" << newline;
 #endif
 
   // Generate elastic-scattering interaction using ESgen.
@@ -244,9 +242,9 @@ void VertexGen_SN::GenerateCCVertex(G4Event *argEvent, G4ThreeVector &dx, G4doub
   Eval2BodyKinematicCC(e_nu, ev_nu_dir);
 
 #ifdef DEBUG
-  std::cout << "Neutrino " << ev_nu_dir << "" << std::endl;
-  std::cout << "Positron " << primair << "" << std::endl;
-  std::cout << "Neutron " << secondaire << "" << std::endl;
+  debug << "Neutrino " << ev_nu_dir << "" << newline;
+  debug << "Positron " << primair << "" << newline;
+  debug << "Neutron " << secondaire << "" << newline;
 #endif
 
   // -- Create particles
@@ -286,12 +284,12 @@ void VertexGen_SN::GenerateICCVertex(G4Event *argEvent, G4ThreeVector &dx, G4dou
   G4ThreeVector ev_nu_dir(nu_dir);  // By default use specified direction
 
   Eval2BodyKinematicICC(e_nu, ev_nu_dir);
-  // std::cout << "Breakpoint 4 ICC" << e_nu << std::endl;
+  // info << "Breakpoint 4 ICC" << e_nu << newline;
 
 #ifdef DEBUG
-  std::cout << "Neutrino " << ev_nu_dir << "" << std::endl;
-  std::cout << "Positron " << primair << "" << std::endl;
-  std::cout << "Neutron " << secondaire << "" << std::endl;
+  debug << "Neutrino " << ev_nu_dir << "" << newline;
+  debug << "Positron " << primair << "" << newline;
+  debug << "Neutron " << secondaire << "" << newline;
 #endif
 
   // -- Create particles
@@ -303,11 +301,11 @@ void VertexGen_SN::GenerateICCVertex(G4Event *argEvent, G4ThreeVector &dx, G4dou
                                                             primair.pz());  // z component of momentum
   eplus_particle->SetMass(eplus->GetPDGMass());                             // Geant4 is silly.
   vertex->SetPrimary(eplus_particle);
-  // std::cout << "Breakpoint 5 ICC" << e_nu << std::endl;
+  // info << "Breakpoint 5 ICC" << e_nu << newline;
 
   // Due to issues with Nitrogen 16, Nitrogen 15 (stable) is used instead
   G4ParticleDefinition *f16N = G4IonTable::GetIonTable()->GetIon(7, 16, 0.0);
-  // std::cout << "Breakpoint 6 ICC" << e_nu << std::endl;
+  // info << "Breakpoint 6 ICC" << e_nu << newline;
 
   G4PrimaryParticle *n_particle = new G4PrimaryParticle(f16N,              // particle code
                                                         secondaire.px(),   // x component of momentum
@@ -340,8 +338,8 @@ void VertexGen_SN::GenerateNCVertex(G4Event *argEvent, G4ThreeVector &dx, G4doub
   eg_nu_dir.setRThetaPhi(1.0, theta, phi);
 
 #ifdef DEBUG
-  std::cout << "Neutrino " << ev_nu_dir << "" << std::endl;
-  std::cout << "Neutron " << secondaire << "" << std::endl;
+  debug << "Neutrino " << ev_nu_dir << "" << newline;
+  debug << "Neutron " << secondaire << "" << newline;
 #endif
 
   // Need to find a way to split the recoil and excitation energy
@@ -402,8 +400,8 @@ void VertexGen_SN::GenerateINCVertex(G4Event *argEvent, G4ThreeVector &dx, G4dou
   eg_nu_dir.setRThetaPhi(1.0, theta, phi);
 
 #ifdef DEBUG
-  std::cout << "Neutrino " << ev_nu_dir << "" << std::endl;
-  std::cout << "Neutron " << secondaire << "" << std::endl;
+  debug << "Neutrino " << ev_nu_dir << "" << newline;
+  debug << "Neutron " << secondaire << "" << newline;
 #endif
 
   // Need to find a way to split the recoil and excitation energy
@@ -463,7 +461,7 @@ G4double VertexGen_SN::GetElectronEnergy(G4double enu) {
   G4double g_2 = 0.73;
 
 #ifdef DEBUG
-  std::cout << "eee enu is " << enu << "\n";
+  debug << "eee enu is " << enu << newline;
 #endif
   // Define the maximum allowable scattered electron energy based off the
   // antineutrino energy
@@ -489,14 +487,14 @@ G4double VertexGen_SN::GetElectronEnergy(G4double enu) {
   G4double E_electron = sigma_Te->GetRandom();
 
 #ifdef DEBUG
-  std::cout << "Electron energy = " << E_electron << " MeV\n";
+  debug << "Electron energy = " << E_electron << " MeV" << newline;
 #endif
 
   delete sigma_Te;
 
 #ifdef DEBUG
-  std::cout << "eee E_electron is " << E_electron << "\n";
-  if (E_electron > 14.0) std::cout << "eee99 E_electron is " << E_electron << "\n";
+  debug << "eee E_electron is " << E_electron << newline;
+  if (E_electron > 14.0) debug << "eee99 E_electron is " << E_electron << newline;
 #endif
   return E_electron;
 }
@@ -513,9 +511,9 @@ CLHEP::HepLorentzVector VertexGen_SN::GetEmomentum(G4double enu, G4double eelect
       acos((sqrt(((eelectron * (pow((m_e + enu), 2))) / ((2 * m_e * (pow(enu, 2))) + ((pow(enu, 2)) * eelectron))))));
 
 #ifdef DEBUG
-  std::cout << "Neutrino std::vector = {" << neutrino_dir.x() << ", " << neutrino_dir.y() << ", " << neutrino_dir.z()
-            << "}\n";
-  std::cout << "Cosine scattering angle (cos(theta)) = " << cos(theta) << "\n";
+  debug << "Neutrino std::vector = {" << neutrino_dir.x() << ", " << neutrino_dir.y() << ", " << neutrino_dir.z()
+            << "}" << newline;
+  debug << "Cosine scattering angle (cos(theta)) = " << cos(theta) << newline;
 #endif
 
   // Randomly sample phi from 0 to 2pi
@@ -535,9 +533,9 @@ CLHEP::HepLorentzVector VertexGen_SN::GetEmomentum(G4double enu, G4double eelect
   e_momentum.setE(eelectron + m_e);
 
 #ifdef DEBUG
-  std::cout << "Electron std::vector = {" << e_direction.x() << ", " << e_direction.y() << ", " << e_direction.z()
-            << "}\n";
-  std::cout << "-----------------------------------------\n";
+  debug << "Electron std::vector = {" << e_direction.x() << ", " << e_direction.y() << ", " << e_direction.z()
+            << "}" << newline;
+  debug << "-----------------------------------------" << newline;
 #endif
 
   return (e_momentum);
@@ -549,7 +547,7 @@ void VertexGen_SN::Eval2BodyKinematicIBD(G4double enu, G4ThreeVector ev_nu_dir) 
   G4double recoilMass = CLHEP::neutron_mass_c2;
   // Taken from IBDGen.cc
   G4double DELTA = recoilMass - targetMass;
-  //        std::cout << "Delta value " << DELTA << std::endl;
+  //        info << "Delta value " << DELTA << newline;
   //        double GFERMI = 1.16639e-11 / CLHEP::MeV / CLHEP::MeV;
 
   //        G4double CosThetaLab = -1.0+2.0*CLHEP::HepUniformRand();
@@ -599,7 +597,7 @@ void VertexGen_SN::Eval2BodyKinematicCC(G4double enu, G4ThreeVector ev_nu_dir) {
   // Taken from IBDGen.cc
   G4double DELTA = recoilMass - targetMass;
 
-  //        std::cout << "Delta value CC " << DELTA << std::endl;
+  //        info << "Delta value CC " << DELTA << newline;
 
   //        double GFERMI = 1.16639e-11 / CLHEP::MeV / CLHEP::MeV;
 
@@ -650,7 +648,7 @@ void VertexGen_SN::Eval2BodyKinematicICC(G4double enu, G4ThreeVector ev_nu_dir) 
   // Taken from IBDGen.cc
   G4double DELTA = recoilMass - targetMass;
 
-  //        std::cout << "Delta value ICC " << DELTA << std::endl;
+  //        info << "Delta value ICC " << DELTA << newline;
 
   //        double GFERMI = 1.16639e-11 / CLHEP::MeV / CLHEP::MeV;
 
@@ -668,7 +666,7 @@ void VertexGen_SN::Eval2BodyKinematicICC(G4double enu, G4ThreeVector ev_nu_dir) 
   G4double Ysquared = (DELTA * DELTA - CLHEP::electron_mass_c2 * CLHEP::electron_mass_c2) / 2;
   G4double E1 = E0 * (1 - enu / targetMass * (1 - v0 * CosThetaLab)) - Ysquared / targetMass;
   G4double p1 = sqrt(E1 * E1 - CLHEP::electron_mass_c2 * CLHEP::electron_mass_c2);
-  // std::cout << "Breakpoint 1 ICC" << DELTA << std::endl;
+  // info << "Breakpoint 1 ICC" << DELTA << newline;
 
   // Compute nu 4-momentum
   CLHEP::HepLorentzVector neutrino;
@@ -685,7 +683,7 @@ void VertexGen_SN::Eval2BodyKinematicICC(G4double enu, G4ThreeVector ev_nu_dir) 
   rotation_axis.rotate(phi, ev_nu_dir);
   pos_momentum.rotate(theta, rotation_axis);
 
-  // std::cout << "Breakpoint 2 ICC" << DELTA << std::endl;
+  // info << "Breakpoint 2 ICC" << DELTA << newline;
 
   primair.setVect(pos_momentum);
   primair.setE(E1);
@@ -694,8 +692,8 @@ void VertexGen_SN::Eval2BodyKinematicICC(G4double enu, G4ThreeVector ev_nu_dir) 
   secondaire.setVect(neutrino.vect() - primair.vect());
   secondaire.setE(sqrt(secondaire.vect().mag2() + recoilMass * recoilMass));
 
-  // std::cout << "Breakpoint 3 ICC" << sqrt(secondaire.vect().mag2() +
-  // recoilMass*recoilMass) << std::endl;
+  // info << "Breakpoint 3 ICC" << sqrt(secondaire.vect().mag2() +
+  // recoilMass*recoilMass) << newline;
 }
 
 double VertexGen_SN::FindCosTheta(G4double Enu, G4double target_mass_c2, G4double recoil_mass_c2) {

--- a/src/gen/src/VertexGen_Spectrum.cc
+++ b/src/gen/src/VertexGen_Spectrum.cc
@@ -82,14 +82,14 @@ void VertexGen_Spectrum::GeneratePrimaryVertex(G4Event *event, G4ThreeVector &dx
 void VertexGen_Spectrum::SetState(G4String newValues) {
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_Spectrum:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_Spectrum::SetState: \n"
-              << " \"pname  specname  (Elo Ehi)\"\n"
-              << " pname = particle name \n"
-              << " specname = spectrum name as given in ratdb \n"
-              << " Elo Ehi = optional limits on energy range of generated particles " << std::endl;
+    info << "Current state of this VertexGen_Spectrum:" << newline
+              << " \"" << GetState() << "\"" << newline
+              << newline;
+    info << "Format of argument to VertexGen_Spectrum::SetState: " << newline
+              << " \"pname  specname  (Elo Ehi)\"" << newline
+              << " pname = particle name " << newline
+              << " specname = spectrum name as given in ratdb " << newline
+              << " Elo Ehi = optional limits on energy range of generated particles " << newline;
     return;
   }
 
@@ -118,17 +118,17 @@ void VertexGen_Spectrum::SetState(G4String newValues) {
         if (elementName == GLG4VertexGen_Gun::theElementNames[Z - 1]) break;
         if (Z <= GLG4VertexGen_Gun::numberOfElements) {
           newTestGunG4Code = G4IonTable::GetIonTable()->GetIon(Z, A, 0.0);
-          std::cout << " Spectrum Vertex: Setting ion with A = " << A << " Z = " << Z << std::endl;
+          info << " Spectrum Vertex: Setting ion with A = " << A << " Z = " << Z << newline;
         }
       }
     }
     if (newTestGunG4Code == NULL) {
-      std::cerr << "Spectrum Vertex: Could not find particle type " << pname << " defaulting to electron " << std::endl;
+      warn << "Spectrum Vertex: Could not find particle type " << pname << " defaulting to electron " << newline;
       _particle = "e-";
       return;
     }
   } else {
-    std::cout << "Spectrum Vertex: Setting particle = " << pname << std::endl;
+    info << "Spectrum Vertex: Setting particle = " << pname << newline;
   }
   // so store the name and the particle definition
   _particle = pname;
@@ -142,9 +142,9 @@ void VertexGen_Spectrum::SetState(G4String newValues) {
   if (lspec) {
     _lspec = lspec;
     _spectrum = specname;
-    std::cout << "Spectrum Vertex: Setting spectrum " << specname << std::endl;
+    info << "Spectrum Vertex: Setting spectrum " << specname << newline;
   } else {
-    std::cerr << "Could not find spectrum " << specname << " using default, flat spectrum " << std::endl;
+    warn << "Could not find spectrum " << specname << " using default, flat spectrum " << newline;
   }
 
   // Has the user supplied energy limits too?
@@ -158,7 +158,7 @@ void VertexGen_Spectrum::SetState(G4String newValues) {
     // user has selected universal limits
     Elim_Ulo = Elo;
     Elim_Uhi = Ehi;
-    std::cout << "Limiting spectrum to range " << Elim_Ulo << " - " << Elim_Uhi << std::endl;
+    info << "Limiting spectrum to range " << Elim_Ulo << " - " << Elim_Uhi << newline;
   }
 
   // finally ready to initialise the spectrum!
@@ -213,7 +213,7 @@ void VertexGen_Spectrum::InitialiseSpectrum() {
   // and finally make sure temporary limits are set to universal ones
   Elim_Tlo = Elim_Ulo;
   Elim_Thi = Elim_Uhi;
-  std::cout << "Spectrum " << _spectrum << " initialised " << std::endl;
+  info << "Spectrum " << _spectrum << " initialised " << newline;
 }
 
 ///-------------------------------------------------------------------------
@@ -251,7 +251,7 @@ float VertexGen_Spectrum::SampleEnergy() {
     int istep = spec_E.size() - 1;
     while (spec_E[istep] > Ehi) {
       stop = spec_cummag[istep];
-      std::cout << "* " << istep << " " << stop << " " << spec_E[istep] << " " << Ehi << std::endl;
+      info << "* " << istep << " " << stop << " " << spec_E[istep] << " " << Ehi << newline;
       istep--;
     }
     // and interpolate the last bit
@@ -293,10 +293,10 @@ void VertexGen_Spectrum::LimitEnergies(float Elo, float Ehi) {
   // Set the limits for the generated energy range
   // first check this makes sense
   if ((Elo > _emax) || (Elo > Elim_Uhi) || (Ehi < _emin) || (Ehi < Elim_Ulo) || ((Ehi - Elo) <= 0)) {
-    std::cout << "Spectrum Vertex: temporary energy limits " << Elo << " - " << Ehi
-              << " don't make sense, not applied \n"
+    info << "Spectrum Vertex: temporary energy limits " << Elo << " - " << Ehi
+              << " don't make sense, not applied " << newline
               << "spectrum in range " << _emin << " - " << _emax << " MeV with universal limits " << Elim_Ulo << " - "
-              << Elim_Uhi << std::endl;
+              << Elim_Uhi << newline;
     return;
   }
   Elim_Tlo = Elo;

--- a/src/gen/src/VertexGen_WIMP.cc
+++ b/src/gen/src/VertexGen_WIMP.cc
@@ -44,12 +44,11 @@ void VertexGen_WIMP::GeneratePrimaryVertex(G4Event *event, G4ThreeVector &dx, G4
 void VertexGen_WIMP::SetState(G4String newValues) {
   if (newValues.length() == 0) {
     // print help and current state
-    std::cout << "Current state of this VertexGen_WIMP:\n"
-              << " \"" << GetState() << "\"\n"
-              << std::endl;
-    std::cout << "Format of argument to VertexGen_WIMP::SetState: \n"
-                 " \"nucleus_name WIMP_mass_in_GeV\"\n"
-              << std::endl;
+    info << "Current state of this VertexGen_WIMP:" << newline
+           << " \"" << GetState() << "\"" << newline
+           << newline;
+    info << "Format of argument to VertexGen_WIMP::SetState: " << newline
+           << " \"nucleus_name WIMP_mass_in_GeV\"\n" << newline;
     return;
   }
 
@@ -89,15 +88,15 @@ double VertexGen_WIMP::Helmff(double E, double mA) {
 // Eq. (19) of C. Savage, G. Gelmini, P. Gondolo, K. Freese, JCAP 0904:010, 2009
 double VertexGen_WIMP::VelIntegral(double vmin, double v0, double vE, double vesc) {
   if (v0 == 0) {
-    std::cout << "VertexGen_WIMP error: zero most likely WIMP velocity relative "
+    info << "VertexGen_WIMP error: zero most likely WIMP velocity relative "
                  "to the Milky Way. Returning -1\n";
     return -1;
   }
   double xmin = vmin / v0, xE = vE / v0, xesc = vesc / v0;
   if (xesc < xE)
-    std::cout << "VertexGen_WIMP warning (we are not escaping the galaxy): our "
+    info << "VertexGen_WIMP warning (we are not escaping the galaxy): our "
                  "velocity is "
-              << vE << ", the local Milky Way escape velocity is " << vesc << ". The results will be unphysical.\n";
+              << vE << ", the local Milky Way escape velocity is " << vesc << ". The results will be unphysical." << newline;
   // no extragalactic WIMPs
   if (xesc + xE <= xmin) return 0;
   // normal case: we're looking where we expect a good signal

--- a/src/geo/src/BWVetGenericChamberHit.cc
+++ b/src/geo/src/BWVetGenericChamberHit.cc
@@ -11,6 +11,7 @@
 #include <G4VisAttributes.hh>
 #include <G4ios.hh>
 #include <RAT/BWVetGenericChamberHit.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 
@@ -59,7 +60,7 @@ void BWVetGenericChamberHit::Draw() {
 
 void BWVetGenericChamberHit::Print() {
   int deb = 0;
-  if (deb != 0) std::cout << "  BWVetGenericChamber[" << id << "] " << time / CLHEP::ns << " (nsec)" << std::endl;
+  if (deb != 0) info << "  BWVetGenericChamber[" << id << "] " << time / CLHEP::ns << " (nsec)" << newline;
 }
 
 }  // namespace RAT

--- a/src/geo/src/GLG4PMTSD.cc
+++ b/src/geo/src/GLG4PMTSD.cc
@@ -24,6 +24,7 @@
 #include "RAT/GLG4Scint.hh"  // for doScintilllation and total energy deposition info
 #include "RAT/GLG4VEventAction.hh"
 #include "Randomize.hh"
+#include <RAT/Log.hh>
 
 GLG4PMTSD::GLG4PMTSD(G4String name, int arg_max_pmts, int arg_pmt_no_offset, int arg_my_id_pmt_size)
     : G4VSensitiveDetector(name) {
@@ -59,8 +60,8 @@ void GLG4PMTSD::SimpleHit(G4int ipmt, G4double time, G4double kineticEnergy, con
                           G4int iHitPhotonCount, G4int trackID, G4bool prepulse) {
   G4int pmt_index = ipmt - pmt_no_offset;
   if (pmt_index < 0 || pmt_index >= max_pmts) {
-    std::cerr << "Error: GLG4PMTSD::SimpleHit [" << GetName() << "] passed ipmt=" << ipmt
-              << ", but max_pmts=" << max_pmts << " and offset=" << pmt_no_offset << " !" << std::endl;
+    RAT::warn << "Error: GLG4PMTSD::SimpleHit [" << GetName() << "] passed ipmt=" << ipmt
+              << ", but max_pmts=" << max_pmts << " and offset=" << pmt_no_offset << " !" << newline;
     return;
   }
 

--- a/src/geo/src/GeoCalibrationStickFactory.cc
+++ b/src/geo/src/GeoCalibrationStickFactory.cc
@@ -25,7 +25,7 @@
 namespace RAT {
 
 G4VPhysicalVolume *GeoCalibrationStickFactory::Construct(DBLinkPtr table) {
-  std::cout << "Building Calibration Stick" << std::endl;
+  info << "Building Calibration Stick" << newline;
   const std::string volumeName = table->GetIndex();
   const std::string motherName = table->GetS("mother");
 

--- a/src/geo/src/GeoCherenkovSourceFactory.cc
+++ b/src/geo/src/GeoCherenkovSourceFactory.cc
@@ -25,7 +25,7 @@
 namespace RAT {
 
 G4VPhysicalVolume *GeoCherenkovSourceFactory::Construct(DBLinkPtr table) {
-  std::cout << "Building Cherenkov Source" << std::endl;
+  info << "Building Cherenkov Source" << newline;
   const std::string volumeName = table->GetIndex();
   const std::string motherName = table->GetS("mother");
 

--- a/src/geo/src/Materials.cc
+++ b/src/geo/src/Materials.cc
@@ -171,7 +171,7 @@ void Materials::ConstructMaterials() {
       adb = table->GetD("a");
       new G4Element(namedb, csymbol, zdb, adb * CLHEP::g / CLHEP::mole);
     } catch (DBNotFoundError &e) {
-      std::cout << "Materials error: Could not construct elements" << std::endl;
+      info << "Materials error: Could not construct elements" << newline;
     }
   }
 
@@ -270,7 +270,7 @@ bool Materials::BuildMaterial(std::string namedb, DBLinkPtr table) {
     nelementsdb = table->GetI("nelements");
     nmaterialsdb = table->GetI("nmaterials");
   } catch (DBNotFoundError &e) {
-    std::cout << "Materials: Material read error" << std::endl;
+    info << "Materials: Material read error" << newline;
     return false;
   }
 
@@ -330,8 +330,8 @@ bool Materials::BuildMaterial(std::string namedb, DBLinkPtr table) {
     std::vector<double> elemprop = table->GetDArray("elemprop");
 
     if (elemname.size() != elemprop.size()) {
-      std::cout << "Death...oh Materials material reader, "
-                << " how you have forsaken me" << std::endl;  // fixme tk
+      info << "Death...oh Materials material reader, "
+                << " how you have forsaken me" << newline;  // fixme tk
       exit(-1);
     }
 
@@ -345,8 +345,8 @@ bool Materials::BuildMaterial(std::string namedb, DBLinkPtr table) {
     std::vector<double> elemprop = table->GetDArray("matprop");
 
     if (elemname.size() != elemprop.size()) {
-      std::cout << "Death...oh Materials material reader, "
-                << "how you have forsaken me" << std::endl;  // fixme tk
+      info << "Death...oh Materials material reader, "
+                << "how you have forsaken me" << newline;  // fixme tk
       exit(-1);
     }
 
@@ -397,13 +397,13 @@ G4MaterialPropertyVector *Materials::LoadProperty(DBLinkPtr table, std::string n
     val1 = table->GetDArray(name + "_value1");
     val2 = table->GetDArray(name + "_value2");
   } catch (DBNotFoundError &e) {
-    std::cout << "Could not read property " << name << " of " << table->GetIndex() << std::endl;
+    info << "Could not read property " << name << " of " << table->GetIndex() << newline;
     return nullptr;
   }
 
   if (val1.size() != val2.size()) {
-    std::cout << "Array size error in Materials: "
-              << "bad property value sizes" << std::endl;
+    info << "Array size error in Materials: "
+              << "bad property value sizes" << newline;
     return nullptr;
   }
 
@@ -429,7 +429,7 @@ G4MaterialPropertyVector *Materials::LoadProperty(DBLinkPtr table, std::string n
         E_value = CLHEP::twopi * CLHEP::hbarc / (lam * CLHEP::nanometer);
         if (wavelength_opt == 2) p_value *= lam / E_value;
       } else {
-        std::cerr << "Materials property std::vector zero wavelength!\n";
+        warn << "Materials property std::vector zero wavelength!" << newline;
       }
     }
     pv->InsertValues(E_value, p_value);
@@ -450,7 +450,7 @@ void Materials::BuildMaterialPropertiesTable(G4Material *material, DBLinkPtr tab
   try {
     props = table->GetSArray("PROPERTY_LIST");
   } catch (DBNotFoundError &e) {
-    std::cout << "Materials failed to get property list on: " << name << std::endl;
+    info << "Materials failed to get property list on: " << name << newline;
     return;
   }
 
@@ -545,12 +545,12 @@ void Materials::LoadOptics() {
   // Load everything in OPTICS
   for (DBLinkGroup::iterator iv = mats.begin(); iv != mats.end(); iv++) {
     std::string name = iv->first;
-    std::cout << "Loading optics: " << name << std::endl;
+    info << "Loading optics: " << name << newline;
 
     G4Material *material = G4Material::GetMaterial(name);
     if (material == nullptr) {
-      std::cout << "While loading optics in Materials, "
-                << "there was a bad material name: " << name << std::endl;
+      info << "While loading optics in Materials, "
+                << "there was a bad material name: " << name << newline;
       continue;
     }
 
@@ -567,7 +567,7 @@ void Materials::LoadOptics() {
     try {
       props = table->GetSArray("PROPERTY_LIST");
     } catch (DBNotFoundError &e) {
-      std::cout << "Materials failed to get property list on: " << name << std::endl;
+      info << "Materials failed to get property list on: " << name << newline;
       Log::Die("Materials unable to load property list");
       return;
     }
@@ -613,7 +613,7 @@ void Materials::LoadOptics() {
       ss << "FRACTION" << i + 1;
       mpt->AddConstProperty(ss.str().c_str(), fraction, true);
 
-      std::cout << " - Component " << i << ": " << compname << " (" << 100.0 * fraction << "%)" << std::endl;
+      info << " - Component " << i << ": " << compname << " (" << 100.0 * fraction << "%)" << newline;
 
       G4Material *component = G4Material::GetMaterial(compname);
       Log::Assert(material, "Materials: Unable to locate component material");
@@ -650,7 +650,7 @@ void Materials::LoadOptics() {
           //// Log::Assert(mpm->find(pname) == mpm->end(),
           ////             "Materials: Composite material cannot contain the
           /// same properties as components");
-          std::cout << compname << " has " << pname << "!" << std::endl;
+          info << compname << " has " << pname << "!" << newline;
           std::stringstream ss2;
           ss << pname << i + 1;
           //// mpt->AddProperty(ss2.str().c_str(), it->second);
@@ -725,7 +725,7 @@ void Materials::LoadOptics() {
                           materialConstPropertyNames.end(),
                       "Materials: Composite material cannot contain the same "
                       "properties as components");
-          std::cout << compname << " has " << cname << std::endl;
+          info << compname << " has " << cname << newline;
           std::stringstream ss2;
           ss2 << cname << i + 1;
           mpt->AddConstProperty(ss2.str().c_str(), cptConstProperties.at(propid).first);
@@ -733,17 +733,17 @@ void Materials::LoadOptics() {
       }
     }
 
-    std::cout << "----" << std::endl;
+    info << "----" << newline;
     //// const std::map<G4String,
     ////                G4MaterialPropertyVector*>* mpm =
     /// mpt->GetPropertiesMap(); / std::map<G4String, /
     /// G4MaterialPropertyVector*>::const_iterator it; / for (it=mpm->begin();
-    /// it!=mpm->end(); it++) { /   std::cout << it->first << std::endl; / } / const
+    /// it!=mpm->end(); it++) { /   info << it->first << newline; / } / const
     /// std::map<G4String, /                G4double>* mcpm =
     /// mpt->GetPropertiesCMap(); / std::map<G4String, /
     /// G4double>::const_iterator cit; / for (cit=mcpm->begin();
-    /// cit!=mcpm->end(); cit++) { /   std::cout << cit->first << std::endl; / }
-    std::cout << "----" << std::endl;
+    /// cit!=mcpm->end(); cit++) { /   info << cit->first << newline; / }
+    info << "----" << newline;
   }
 }
 

--- a/src/geo/src/pmt/PMTFactoryBase.cc
+++ b/src/geo/src/pmt/PMTFactoryBase.cc
@@ -77,7 +77,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
   if (nocorr)
     CorrBEpsiInput = false;
   else
-    std::cout << "Forcing B efficiency<= 1\n";
+    info << "Forcing B efficiency<= 1" << newline;
   bool HaveDynoData = false;
 
   if (BFieldOn) {
@@ -97,7 +97,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
     if (BFieldTableName == "" || BEffiTableName == "") {
       G4cout << "B field is on, but either B data or B PMT efficiency "
                 "correction missing.\n"
-             << "Turning B field off.\n";
+             << "Turning B field off." << newline;
       BFieldOn = 0;
       BEffiTable = NULL;
     } else {
@@ -107,13 +107,13 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
       std::ifstream Bdata(BFieldTableName1.data());
       if (!Bdata.is_open()) {
         BFieldTableName = static_cast<std::string>(getenv("RATSHARE")) + "/ratdb/" + BFieldTableName;
-        std::cout << "file " << BFieldTableName1 << " not found, trying " << BFieldTableName << "\n";
+        info << "file " << BFieldTableName1 << " not found, trying " << BFieldTableName << newline;
         Bdata.close();
         Bdata.open(BFieldTableName.data());
         if (!Bdata.is_open()) {
           BFieldOn = false;
           BEffiTable = NULL;
-          std::cout << "also file " << BFieldTableName << " not found, magnetic efficiency correction turned off\n";
+          info << "also file " << BFieldTableName << " not found, magnetic efficiency correction turned off" << newline;
         }
         if (!Bdata.good())
           Bdata.clear();  // for backwards compatibility: g++ 3.4 requires to
@@ -123,7 +123,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
       std::string header;
       getline(Bdata, header);
       double xr, yr, zr, bxr, byr, bzr;
-      std::cout << "about to load B field from file " << BFieldTableName << "\n";
+      info << "about to load B field from file " << BFieldTableName << newline;
       G4ThreeVector posi, field;
       while (!Bdata.rdstate()) {
         Bdata >> xr >> yr >> zr >> bxr >> byr >> bzr;
@@ -180,7 +180,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
       dynorfilename = static_cast<std::string>(getenv("RATSHARE")) + "/ratdb/" + ExpSubdir + "/" + dynorfilename;
       std::ifstream dynorfile(dynorfilename.data());
       if (!dynorfile.is_open()) {
-        std::cout << "Failed to open " << dynorfilename.data() << ", will assume random dynode orientations\n";
+        info << "Failed to open " << dynorfilename.data() << ", will assume random dynode orientations" << newline;
         dynorfile.close();
       } else {
         getline(dynorfile, header);
@@ -199,14 +199,14 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
       if (!Dorie.empty() && Dorie.size() == Dpos.size())
         HaveDynoData = true;
       else
-        std::cout << "No dynode orientation datafile or error in the data, "
+        info << "No dynode orientation datafile or error in the data, "
                      "randomizing dynode orientations\n";
     }
     try {
       BEffiModel = DB::Get()->GetLink("BField")->GetS("b_efficiency_model");
     } catch (DBNotFoundError &e) {
     }
-    std::cout << "\nSelected " << BEffiModel.data() << " B Efficiency Model\n";
+    info << "\nSelected " << BEffiModel.data() << " B Efficiency Model" << newline;
   } else
     BEffiTable = NULL;
 
@@ -245,7 +245,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
         }
       }
       if (jmin < 0)
-        std::cout << "can't find a point close to the " << id << "-th pmt; MinDist is " << MinDist << "\n";
+        info << "can't find a point close to the " << id << "-th pmt; MinDist is " << MinDist << newline;
       else {
         G4ThreeVector bfield = Bf[jmin].perpPart(pmtdir);
         G4ThreeVector dynorient;
@@ -258,9 +258,9 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
               minj = j;
             }
           if (minj < 0) {
-            std::cout << "can't find the orientation of the " << id << "-th pmt's dynode; MinDiff is " << MinDiff
-                      << "\n"
-                      << "Throwing a random dynode orientation\n";
+            info << "can't find the orientation of the " << id << "-th pmt's dynode; MinDiff is " << MinDiff
+                      << newline
+                      << "Throwing a random dynode orientation" << newline;
             dynorient = G4RandomDirection();
             dynorient = dynorient.perpPart(pmtdir);
           } else
@@ -277,10 +277,10 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
             dynorient = dynorient.perpPart(pmtdir);
           }
           if (dynorient.mag() == 0)
-            std::cout << "Warning: tried 100 times to generate a random dynode "
+            info << "Warning: tried 100 times to generate a random dynode "
                          "orientation for "
                       << id << "-th PMT and failed. dynorient " << dynorient(0) << "," << dynorient(1) << ","
-                      << dynorient(2) << "\n";
+                      << dynorient(2) << newline;
         }
         dynorient = dynorient.unit();
         // build EfficiencyCorrection table. PMT x axis is dynorient
@@ -311,7 +311,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
           else
             EfficiencyCorrection[id] *= BeffiComp;
         } else {
-          std::cout << "\nError: undefined B Efficiency Model\n";
+          info << "\nError: undefined B Efficiency Model" << newline;
         }
       }
     }

--- a/src/io/src/DSReader.cc
+++ b/src/io/src/DSReader.cc
@@ -1,5 +1,6 @@
 #include <RAT/DSReader.hh>
 #include <iostream>
+#include <RAT/Log.hh>
 
 namespace RAT {
 
@@ -12,8 +13,8 @@ DSReader::DSReader(const char *filename) : T("T"), runT("runT") {
   total = T.GetEntries();
 
 #ifdef DEBUG
-  std::cout << "DSReader::DSReader - "
-            << "filename='" << filename << "', total=" << total << std::endl;
+  debug << "DSReader::DSReader - "
+            << "filename='" << filename << "', total=" << total << newline;
 #endif
 
   ds = new DS::Root();
@@ -28,8 +29,8 @@ void DSReader::Add(const char *filename) {
   total = T.GetEntries();
 
 #ifdef DEBUG
-  std::cout << "DSReader::Add - "
-            << "filename='" << filename << "', total=" << total << std::endl;
+  debug << "DSReader::Add - "
+            << "filename='" << filename << "', total=" << total << newline;
 #endif
 }
 

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -14,6 +14,7 @@
 #include <RAT/DS/Run.hh>
 #include <RAT/DS/RunStore.hh>
 #include <RAT/OutNtupleProc.hh>
+#include <RAT/Log.hh>
 #include <iostream>
 #include <numeric>
 #include <sstream>
@@ -448,7 +449,7 @@ OutNtupleProc::~OutNtupleProc() {
       geo_index = ldetector->GetD("geo_index");
     }
     catch (DBNotFoundError& e) {
-      std::cout << "Geometry index not found." << std::endl;
+      info << "Geometry index not found." << newline;
       // Set invalid
       geo_index = -9999;
     }

--- a/src/io/src/TrackCursor.cc
+++ b/src/io/src/TrackCursor.cc
@@ -4,6 +4,7 @@
 #include <RAT/TrackNode.hh>
 #include <RAT/dprintf.hpp>
 #include <RAT/string_utilities.hpp>
+#include <RAT/Log.hh>
 #include <iostream>
 
 namespace RAT {
@@ -127,9 +128,9 @@ TrackNode *TrackCursor::GoParent() {
 }
 
 // Pretty printing
-void TrackCursor::Print() const { std::cout << Print(fCur); }
+void TrackCursor::Print() const { info << Print(fCur); }
 
-void TrackCursor::PrintTrack() const { std::cout << PrintTrack(fCur); }
+void TrackCursor::PrintTrack() const { info << PrintTrack(fCur); }
 
 std::string TrackCursor::PrintTrackIDs(TrackNode *node) {
   std::set<int> trackIDs;
@@ -264,7 +265,7 @@ TrackNode *TrackCursor::FindNextTrack(TrackTest *predicate) {
     Go(candidate);
   else {
     Go(origLocation);
-    if (fVerbose) std::cout << "Unable to find track.  Returned to original location.\n";
+    if (fVerbose) info << "Unable to find track.  Returned to original location." << newline;
   }
 
   return candidate;

--- a/src/io/src/TrackNav.cc
+++ b/src/io/src/TrackNav.cc
@@ -1,5 +1,6 @@
 #include <G4ThreeVector.hh>
 #include <RAT/TrackNav.hh>
+#include <RAT/Log.hh>
 #include <iostream>
 #include <map>
 #include <set>
@@ -20,17 +21,17 @@ void TrackNav::Load(DS::MC *mc, bool verbose) {
     int trackID = track->GetID();
     int parentID = track->GetParentID();
 
-    if (verbose) std::cerr << "\rReading in track " << i << " (id " << trackID << ")     ";
+    if (verbose) warn << "\rReading in track " << i << " (id " << trackID << ")     ";
 
     if (idYetToLoad.count(trackID) == 0) {
       idYetToLoad.insert(trackID);
       idToIndex[trackID] = i;
       idToDaughter.insert(std::pair<const int, int>(parentID, trackID));
     } else
-      std::cerr << "TrackNav: TrackID " << trackID << " duplicated!" << std::endl;
+      warn << "TrackNav: TrackID " << trackID << " duplicated!" << newline;
   }
 
-  if (verbose) std::cerr << std::endl;
+  if (verbose) warn << newline;
 
   // Set head node with appropriate markers
   fHead = new TrackNode();
@@ -54,7 +55,7 @@ void TrackNav::Load(DS::MC *mc, bool verbose) {
     // Fetch next track
     int trackID = readyToAdd.top();
 
-    if (verbose) std::cerr << "\rAdding " << trackID << " to tree.";
+    if (verbose) warn << "\rAdding " << trackID << " to tree.";
 
     readyToAdd.pop();
     DS::MCTrack *track = mc->GetMCTrack(idToIndex[trackID]);
@@ -142,10 +143,10 @@ void TrackNav::Load(DS::MC *mc, bool verbose) {
 
   // All done, let's make sure we are really done
   if (idYetToLoad.size() != 0) {
-    std::cerr << "TrackNav: Error! Not all tracks were reachable from initial "
+    warn << "TrackNav: Error! Not all tracks were reachable from initial "
                  "particles.\n"
                  "             Still "
-              << idYetToLoad.size() << " left in queue." << std::endl;
+              << idYetToLoad.size() << " left in queue." << newline;
   }
 }
 

--- a/src/physics/include/RAT/GLG4PMTOpticalModel.hh
+++ b/src/physics/include/RAT/GLG4PMTOpticalModel.hh
@@ -24,6 +24,7 @@
 #include "G4OpticalSurface.hh"
 #include "G4UImessenger.hh"
 #include "G4VFastSimulationModel.hh"
+#include <RAT/Log.hh>
 
 class G4UIcommand;
 class G4UIdirectory;
@@ -62,13 +63,13 @@ class GLG4PMTOpticalModel : public G4VFastSimulationModel, public G4UImessenger 
 
   void SetEfficiencyCorrection(std::map<int, double> _EffiCorr) {
     EfficiencyCorrection = _EffiCorr;
-    G4cout << GetName() << ": Individual efficiency correction table set\n";
+    G4cout << GetName() << ": Individual efficiency correction table set" << newline;
   }
   void DumpEfficiencyCorrectionTable() {
-    G4cout << "Individual correction table for the PMT efficiencies of " << GetName() << ":\nPMT ID  corr. factor\n";
+    G4cout << "Individual correction table for the PMT efficiencies of " << GetName() << ":\nPMT ID  corr. factor" << newline;
     for (std::map<int, double>::iterator iter = EfficiencyCorrection.begin(); iter != EfficiencyCorrection.end();
          iter++) {
-      G4cout << iter->first << "," << iter->second << "\n";
+      G4cout << iter->first << "," << iter->second << newline;
     }
   }
   void fillPMTVector(double code, double A, double An, double T, double R, double collection_eff, double N_pe, double x,

--- a/src/physics/include/RAT/GLG4Scint.hh
+++ b/src/physics/include/RAT/GLG4Scint.hh
@@ -40,6 +40,7 @@
 #include "local_g4compat.hh"
 #include "templates.hh"
 #include "vector"
+#include <RAT/Log.hh>
 
 // Dummy classes used as placeholders in new opticalphoton tracks so
 // that G4Track users can figure out the name of the process which
@@ -371,7 +372,7 @@ inline GLG4Scint::MyPhysicsTable *GLG4Scint::GetMyPhysicsTable() const { return 
 
 inline void GLG4Scint::DumpInfo() const {
   if (fMyPhysicsTable) {
-    G4cout << "GLG4Scint[" << *(fMyPhysicsTable->fName) << "] {\n"
+    G4cout << "GLG4Scint[" << *(fMyPhysicsTable->fName) << "] {" << newline
            << "  fLowerMassLimit=" << fLowerMassLimit << G4endl;
     if (fVerboseLevel >= 2) fMyPhysicsTable->Dump();
     G4cout << "}" << G4endl;

--- a/src/physics/src/BNLOpWLSData.cc
+++ b/src/physics/src/BNLOpWLSData.cc
@@ -4,6 +4,7 @@
 #include <sys/stat.h>
 
 #include <RAT/BNLOpWLSData.hh>
+#include <RAT/Log.hh>
 #include <iostream>
 #include <vector>
 
@@ -21,8 +22,8 @@ void BNLOpWLSData::SetExEmData(std::string fname) {
   // Check file is there
   struct stat buffer;
   if (stat(fname.c_str(), &buffer) != 0) {
-    std::cout << "BNLOpWLS::SetExEmData: Warning: Could not find Ex/Em data file "
-              << "for BNLOpWLS model" << std::endl;
+    RAT::info << "BNLOpWLS::SetExEmData: Warning: Could not find Ex/Em data file "
+              << "for BNLOpWLS model" << newline;
     return;
   }
 

--- a/src/physics/src/GLG4OpAttenuation.cc
+++ b/src/physics/src/GLG4OpAttenuation.cc
@@ -21,6 +21,7 @@
 #include "Randomize.hh"
 #include "globals.hh"
 #include "templates.hh"
+#include <RAT/Log.hh>
 
 /////////////////
 // Hidden static variables and functions

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -269,7 +269,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     G4cout << "> Enter GLG4PMTOpticalModel, ipmt=" << ipmt << (whereAmI == kInVacuum ? " vacuum" : " glass")
            << ", pos=" << pos << ", dir=" << dir << ", weight=" << weight << ", pol=" << pol
            << ", energy=" << _photon_energy << ", wavelength=" << _wavelength << ", (n1,n3,n2,k2,efficiency)=(" << _n1
-           << "," << _n3 << "," << _n2 << "," << _k2 << "," << _efficiency << ")\n";
+           << "," << _n3 << "," << _n2 << "," << _k2 << "," << _efficiency << ")" << newline;
   }
   _rho = sqrt(pow(pos.x(), 2) + pow(pos.y(), 2));
   _rhoAvg = (_photocathode_MINrho + _photocathode_MAXrho) / 2.0;
@@ -329,7 +329,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     _cos_theta1 = dir * norm;
     if (_cos_theta1 < 0.0) {
       G4cerr << "GLG4PMTOpticalModel::DoIt(): "
-             << " The normal points the wrong way!\n"
+             << " The normal points the wrong way!" << newline
              << "  norm: " << norm << G4endl << "  dir:  " << dir << G4endl << "  _cos_theta1:  " << _cos_theta1
              << G4endl << "  pos:  " << pos << G4endl << "  whereAmI:  " << (int)(whereAmI) << G4endl
              << " Reversing normal!" << G4endl;
@@ -356,7 +356,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
 
 #ifdef G4DEBUG
     if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || collection_eff > 1.0) {
-      G4cerr << "GLG4PMTOpticalModel::DoIt(): Strange coefficients!\n";
+      G4cerr << "GLG4PMTOpticalModel::DoIt(): Strange coefficients!" << newline;
       G4cout << "T, R, A, An, weight: " << T << " " << R << " " << A << " " << An << " " << weight << G4endl;
       G4cout << "collection eff, std QE: " << collection_eff << " " << _efficiency << G4endl;
       G4cout << "=========================================================" << G4endl;
@@ -379,7 +379,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
         mean_N_pe *= EfficiencyCorrection[ipmt];
       } else {
         G4cout << "GLG4PMTOpticalModel[" << GetName() << "] warning: individual efficiency correction for PMT " << ipmt
-               << " is " << EfficiencyCorrection[ipmt] << ", resetting to 1\n";
+               << " is " << EfficiencyCorrection[ipmt] << ", resetting to 1" << newline;
       }
     }
     G4double ranno_absorb = G4UniformRand();
@@ -417,7 +417,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
         hit_photon->SetPrepulse(prepulse);
         GLG4VEventAction::GetTheHitPMTCollection()->DetectPhoton(hit_photon);
         if (prepulse) break;
-        if (_verbosity >= 2) G4cout << "GLG4PMTOpticalModel made " << N_pe << " pe\n";
+        if (_verbosity >= 2) G4cout << "GLG4PMTOpticalModel made " << N_pe << " pe" << newline;
       }
     }
 
@@ -436,14 +436,14 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     // correct, assuming there are no bugs in the code.)
     if (ranno_absorb < A) {
       weight = 0;
-      if (_verbosity >= 2) G4cout << "GLG4PMTOpticalModel absorbed track\n";
+      if (_verbosity >= 2) G4cout << "GLG4PMTOpticalModel absorbed track" << newline;
       break;
     }
 
     // reflect or refract the unabsorbed track
     if (G4UniformRand() < R / (R + T)) {  // reflect
       Reflect(dir, pol, norm);
-      if (_verbosity >= 2) G4cout << "GLG4PMTOpticalModel reflects track\n";
+      if (_verbosity >= 2) G4cout << "GLG4PMTOpticalModel reflects track" << newline;
     } else {  // transmit
       Refract(dir, pol, norm);
       if (whereAmI == kInGlass)
@@ -480,7 +480,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     G4cout.flush();
     G4cout << "> Exit GLG4PMTOpticalModel, ipmt=" << ipmt << (whereAmI == kInVacuum ? " vacuum" : " glass")
            << ", pos=" << pos << ", dir=" << dir << ", weight=" << weight << ", pol=" << pol << ", iloop=" << iloop
-           << "\n";
+           << newline;
   }
 
   return;

--- a/src/physics/src/GLG4Scint.cc
+++ b/src/physics/src/GLG4Scint.cc
@@ -443,8 +443,7 @@ G4VParticleChange *GLG4Scint::PostPostStepDoIt(const G4Track &aTrack, const G4St
         }
 #ifdef RATDEBUG
         if (sampledMomentum > aTrack.GetKineticEnergy()) {
-          RAT::warn << "GLG4Scint: Error in GLG4Scint: sampled reemitted "
-                       "photon momentum "
+          RAT::warn << "GLG4Scint: Error in GLG4Scint: sampled reemitted photon momentum "
                     << sampledMomentum << " is greater than track energy " << aTrack.GetKineticEnergy() << newline;
         }
         if (fVerboseLevel > 1) {
@@ -693,8 +692,7 @@ GLG4Scint::MyPhysicsTable::MyPhysicsTable() {
 
 GLG4Scint::MyPhysicsTable::~MyPhysicsTable() {
   if (fUsedByCount != 0) {
-    RAT::warn << "GLG4Scint: Error, GLG4Scint::MyPhysicsTable is being deleted with "
-                 "used_by_count="
+    RAT::warn << "GLG4Scint: Error, GLG4Scint::MyPhysicsTable is being deleted with used_by_count="
               << fUsedByCount << newline;
     return;
   }
@@ -707,8 +705,7 @@ GLG4Scint::MyPhysicsTable::~MyPhysicsTable() {
 ////////////////
 
 void GLG4Scint::MyPhysicsTable::Dump(void) const {
-  G4cout << " GLG4Scint::MyPhysicsTable {\n"
-            "  fName="
+  G4cout << " GLG4Scint::MyPhysicsTable {" << newline << "  fName="
          << (*fName) << G4endl << "  fLength=" << fLength << G4endl << "  fUsedByCount=" << fUsedByCount << G4endl;
   for (G4int i = 0; i < fLength; i++) {
     G4cout << "  data[" << i << "]= { // " << (*G4Material::GetMaterialTable())[i]->GetName() << G4endl;
@@ -737,9 +734,9 @@ void GLG4Scint::MyPhysicsTable::Dump(void) const {
     if (fData[i].fQuenchingArray != nullptr)
       fData[i].fQuenchingArray->DumpValues();
     else
-      G4cout << "nullptr" << G4endl << "  }\n";
+      G4cout << "nullptr" << G4endl << "  }" << newline;
   }
-  G4cout << " }\n";
+  G4cout << " }" << newline;
 }
 
 GLG4Scint::MyPhysicsTable *GLG4Scint::MyPhysicsTable::FindOrBuild(const G4String &name) {

--- a/src/physics/src/PhysicsList.cc
+++ b/src/physics/src/PhysicsList.cc
@@ -24,6 +24,7 @@
 #include <RAT/OpRayleigh.hh>
 #include <RAT/PhysicsList.hh>
 #include <RAT/PhysicsListMessenger.hh>
+#include <RAT/Log.hh>
 
 namespace RAT {
 
@@ -71,17 +72,17 @@ void PhysicsList::EnableThermalNeutronScattering() {
     }
   }
   if (!n_elastic_process) {
-    std::cerr << "PhysicsList::EnableThermalNeutronScattering: "
-              << " couldn't find hadron elastic scattering process.\n";
+    warn << "PhysicsList::EnableThermalNeutronScattering: "
+              << " couldn't find hadron elastic scattering process." << newline;
     throw std::runtime_error(std::string("Missing") + " hadron elastic" + " scattering process in PhysicsList");
   }
 
   // Get the "regular" neutron HP elastic scattering model
   G4HadronicInteraction *n_elastic_hp = G4HadronicInteractionRegistry::Instance()->FindModel("NeutronHPElastic");
   if (!n_elastic_hp) {
-    std::cerr << "PhysicsList::EnableThermalNeutronScattering: "
+    warn << "PhysicsList::EnableThermalNeutronScattering: "
               << " couldn't find high-precision neutron elastic"
-              << " scattering interaction.\n";
+              << " scattering interaction." << newline;
     throw std::runtime_error(std::string("Missing") + " NeutronHPElastic" + " scattering interaction in PhysicsList");
   }
 
@@ -103,11 +104,11 @@ void PhysicsList::SetOpWLSModel(std::string model) {
   } else if (model == "bnl") {
     this->wlsModel = new BNLOpWLSBuilder();
   } else {
-    std::cerr << "PhysicsList::SetOpWLSModel: Unknown model \"" << model << "\"" << std::endl;
+    warn << "PhysicsList::SetOpWLSModel: Unknown model \"" << model << "\"" << newline;
     throw std::runtime_error("Unknown WLS model in PhysicsList");
   }
 
-  std::cout << "PhysicsList::SetOpWLSModel: Set WLS model to \"" << model << "\"" << std::endl;
+  info << "PhysicsList::SetOpWLSModel: Set WLS model to \"" << model << "\"" << newline;
 
   G4RunManager::GetRunManager()->PhysicsHasBeenModified();
 }

--- a/src/util/include/RAT/SimulatedAnnealing.hh
+++ b/src/util/include/RAT/SimulatedAnnealing.hh
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <iostream>
 #include <vector>
+#include <RAT/Log.hh>
 
 namespace RAT {
 
@@ -82,7 +83,7 @@ class SimulatedAnnealing {
     double dworst[D];    // vector from worst to centroid
     double try_pt[D];    // temporary vector for test point
 
-    // std::cout << "*******************************\n";
+    // info << "*******************************" << newline;
 
     for (; *iter > 0;) {
       // find best, worst, nextworst (can optomize a lot of this later)
@@ -90,7 +91,7 @@ class SimulatedAnnealing {
       val_best = DBL_MAX, val_worst = val_nextworst = -DBL_MAX;
       for (size_t i = 0; i <= D; i++) {
         const double val_thermal = val[i] - temp * log(gRandom->Rndm());
-        // std::cout << val[i] << ' ';
+        // info << val[i] << ' ';
         if (val_thermal < val_best) {
           i_best = i;
           val_best = val_thermal;
@@ -105,9 +106,9 @@ class SimulatedAnnealing {
           val_nextworst = val_thermal;
         }
       }
-      // std::cout << "~ " << i_best << '/' << i_nextworst << '/' << i_worst <<
-      // " & "; std::cout << val_best << '/' << val_nextworst << '/' <<
-      // val_worst << "\n";
+      // info << "~ " << i_best << '/' << i_nextworst << '/' << i_worst <<
+      // " & "; info << val_best << '/' << val_nextworst << '/' <<
+      // val_worst << newline;
 
       // update centroid, dworst
       for (size_t j = 0; j < D; j++) {
@@ -120,37 +121,37 @@ class SimulatedAnnealing {
         dworst[j] = centroid[j] - simplex[i_worst][j];
       }
 
-      // std::cout << "+++++++++++\n";
+      // info << "+++++++++++" << newline;
       // definitely replacing the worst point, try with reflecting
       val[i_worst] = replace_project(centroid, dworst, alpha, simplex[i_worst]);
       const double val_ref_therm = val[i_worst] + temp * log(gRandom->Rndm());
-      // std::cout << "\tRef: " << val_ref_therm << "\n";
+      // info << "\tRef: " << val_ref_therm << newline;
       (*iter)--;
       if (val_ref_therm < val_nextworst && val_ref_therm >= val_best) {
         // reflected point was better than the two worst and replaced
         // the worst point, so continue
-        // std::cout << "reflected (okay)" << std::endl;
+        // info << "reflected (okay)" << newline;
         continue;
       } else if (val_ref_therm < val_best) {
         // reflecting was really good, try further
         const double val_try = replace_project(centroid, dworst, gamma, try_pt);
-        // std::cout << "\tExp: " << val_try << "\n";
+        // info << "\tExp: " << val_try << newline;
         if (val_try + temp * log(gRandom->Rndm()) < val_ref_therm) {
           // further is better, replace
           for (size_t j = 0; j < D; j++) {
             simplex[i_worst][j] = try_pt[j];
           }
           val[i_worst] = val_try;
-          // std::cout << "expanded" << std::endl;
+          // info << "expanded" << newline;
         } else {
-          // std::cout << "reflected (best)" << std::endl;
+          // info << "reflected (best)" << newline;
         }
         (*iter)--;
       } else {
         // reflection didn't work so well, try contracting
         const double val_con = replace_project(centroid, dworst, rho, simplex[i_worst]);
         val[i_worst] = val_con;
-        // std::cout << "\tCon: " << val_con << "\n";
+        // info << "\tCon: " << val_con << newline;
         if (val_con + temp * log(gRandom->Rndm()) >= val_worst) {
           // contracting didn't replace worst
           // we're near the minimum, so shrink towards best
@@ -160,11 +161,11 @@ class SimulatedAnnealing {
               simplex[i][j] = (1.0 - sigma) * simplex[i_best][j] + sigma * simplex[i][j];
             }
             val[i] = (*funk)(simplex[i]);
-            // std::cout << "\tShr: " << val[i] << "\n";
+            // info << "\tShr: " << val[i] << newline;
           }
-          // std::cout << "shrink" << std::endl;
+          // info << "shrink" << newline;
         } else {
-          // std::cout << "contracted" << std::endl;
+          // info << "contracted" << newline;
         }
         (*iter)--;
       }


### PR DESCRIPTION
A lot of places in RAT-PAC2 currently don't use the logging system when they should. This PR is designed to alleviate that in part. The prioritization of streams (`info`, `warn`, `debug`, `detail`) was done such that anything going to `cout` in a debug guard block went to `debug`, anything going to `cerr` went to `warn`, everything else going to `cout` went to `info` and `detail` was unused. There was some trouble converting `G4cout` and `G4cerr` and a few other places, so I may go back to those in another PR.