### PR TITLE
Hotfix for PMT pulse generation

### DIFF
--- a/src/daq/src/PMTWaveformGenerator.cc
+++ b/src/daq/src/PMTWaveformGenerator.cc
@@ -32,7 +32,7 @@ PMTWaveformGenerator::PMTWaveformGenerator(std::string modelName) {
   }
 
   fPMTPulseShape == "";
-  if (fPMTPulseShape == "analytic") {
+  if (fPMTPulseType == "analytic") {
       try {
           fPMTPulseShape = lpulse->GetS("pulse_shape");
           info << "PMTWaveformGenerator: Using " << fPMTPulseShape << " pulse for " << modelName << "." << newline;


### PR DESCRIPTION
In implementing Tanner's suggestions in #58, I accidentally was checking against the wrong database parameter when assigning the pulse shape type, leading to improperly generated pulses. This PR should fix that, and I have verified that the digitized waveforms go from looking like just noise to having pulses embedded in them. @tannerbk can you run the testing framework? 