### PR TITLE
Add photon creation time to MCPhoton

### DIFF
--- a/src/core/include/RAT/GLG4HitPhoton.hh
+++ b/src/core/include/RAT/GLG4HitPhoton.hh
@@ -33,6 +33,7 @@ class GLG4HitPhoton {
 
   void SetPMTID(int id) { fPMTID = id; }
   void SetTime(double t) { fTime = t; }
+  void SetCreationTime(double t) { fCreationTime= t; }
   void SetKineticEnergy(double KE);
   void SetWavelength(double wl);
   void SetPosition(double x, double y, double z);
@@ -46,6 +47,7 @@ class GLG4HitPhoton {
 
   int GetPMTID() const { return fPMTID; }
   double GetTime() const { return fTime; }
+  double GetCreationTime() const { return fCreationTime; }
   double GetKineticEnergy() const;
   double GetWavelength() const;
   template <class T>
@@ -63,6 +65,7 @@ class GLG4HitPhoton {
 
  private:
   double fTime;                 // time of hit
+  double fCreationTime;        /// creation time of the photon that created the hit
   int fPMTID;                   // ID number of PMT the HitPhoton hit
   float fKE;                    // kinetic energy
   float fPosition[3];           // x,y,z components of position

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -586,10 +586,11 @@ void Gsim::AddMCPhoton(DS::MCPMT *rat_mcpmt, const GLG4HitPhoton *photon,
 
   rat_mcphoton->SetTrackID(photon->GetTrackID());
   rat_mcphoton->SetHitTime(photon->GetTime());
+  rat_mcphoton->SetCreationTime(photon->GetCreationTime());
 
   rat_mcphoton->SetFrontEndTime(fPMTTime[fPMTInfo->GetModel(rat_mcpmt->GetID())]->PickTime(photon->GetTime()));
   rat_mcphoton->SetCharge(fPMTCharge[fPMTInfo->GetModel(rat_mcpmt->GetID())]->PickCharge());
-  rat_mcphoton->SetProcess(process);
+  rat_mcphoton->SetCreatorProcess(process);
 }
 
 void Gsim::SetStoreParticleTraj(const G4String &particleName, const bool &gDoStore) {

--- a/src/ds/include/RAT/DS/MCPhoton.hh
+++ b/src/ds/include/RAT/DS/MCPhoton.hh
@@ -40,8 +40,8 @@ class MCPhoton : public TObject {
   virtual void SetPosition(const TVector3 &_pos) { pos = _pos; }
 
   /** Wavelength of photon (mm). */
-  virtual Float_t GetLambda() const { return lambda; }
-  virtual void SetLambda(Float_t _lambda) { lambda = _lambda; }
+  virtual Double_t GetLambda() const { return lambda; }
+  virtual void SetLambda(Double_t _lambda) { lambda = _lambda; }
 
   /** Momentum of photon (MeV/c). */
   virtual TVector3 GetMomentum() const { return mom; }
@@ -56,8 +56,8 @@ class MCPhoton : public TObject {
    *  One pe is defined to be the peak of the single photoelectron
    *  charge distribution for this PMT.
    */
-  virtual Float_t GetCharge() const { return charge; }
-  virtual void SetCharge(Float_t _charge) { charge = _charge; }
+  virtual Double_t GetCharge() const { return charge; }
+  virtual void SetCharge(Double_t _charge) { charge = _charge; }
 
   /** Is this photoelectron due to a dark hit? */
   virtual void SetDarkHit(Bool_t _isDarkHit) { isDarkHit = _isDarkHit; }
@@ -75,23 +75,28 @@ class MCPhoton : public TObject {
    * that created this photon hit.
    */
   virtual std::string GetCreatorProcess() const { return process; }
-  virtual void SetProcess(const std::string &_process) { process = _process; }
+  virtual void SetCreatorProcess(const std::string &_process) { process = _process; }
+
+  /** Creation time of this PE */
+  virtual void SetCreationTime(Double_t _creationTime){ creationTime = _creationTime;}
+  virtual Double_t GetCreationTime() const { return creationTime; }
 
   /** Operator overload **/
   bool operator<(const MCPhoton &mcp) const { return (frontEndTime < mcp.frontEndTime); }
   bool operator>(const MCPhoton &mcp) const { return (frontEndTime > mcp.frontEndTime); }
 
-  ClassDef(MCPhoton, 3);
+  ClassDef(MCPhoton, 4);
 
  protected:
   Double_t hitTime;
   Double_t frontEndTime;
+  Double_t creationTime;
   Double_t lambda;
   TVector3 pos;
   TVector3 mom;
   TVector3 pol;
 
-  Float_t charge;
+  Double_t charge;
   Bool_t isDarkHit;
   Bool_t isAfterPulse;
   Int_t trackID;

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -433,6 +433,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
                 GLG4HitPhoton *hit_photon = new GLG4HitPhoton();
                 hit_photon->SetPMTID((int)ipmt);
                 hit_photon->SetTime((double)time);
+                hit_photon->SetCreationTime((double)(time - fastTrack.GetPrimaryTrack()->GetLocalTime())); //Local time counts from track creation, so Global - Local will be track origin time
                 hit_photon->SetKineticEnergy((double)energy);
                 hit_photon->SetPosition((double)pos.x(), (double)pos.y(), (double)pos.z());
                 hit_photon->SetMomentum((double)dir.x(), (double)dir.y(), (double)dir.z());


### PR DESCRIPTION
This PR adds functionality to track and store the photon creation time in MCPhoton, so that we can retain the time that photons that produce hits were created, in addition to when they hit the PMT and reach the front end. This can be used to calculate the true time of flights, time residuals, etc.

I also changed some types to Double_t from Float_t, since I think we don't want floats at this point in history. Though I now see there are still floats elsewhere...