### PR TITLE
Add utility to mute Geant4

### DIFF
--- a/src/physics/src/ThinnableG4Cerenkov.cc
+++ b/src/physics/src/ThinnableG4Cerenkov.cc
@@ -1,5 +1,6 @@
 #include <RAT/Log.hh>
 #include <RAT/ThinnableG4Cerenkov.hh>
+#include <RAT/MuteGeant4.hh>
 #include <vector>
 
 namespace RAT {
@@ -104,12 +105,9 @@ G4VParticleChange *ThinnableG4Cerenkov::PostStepDoIt(const G4Track &aTrack, cons
   // verbose flags but this is safe to ignore, though it will clutter the log
   // UPDATE: Going to just redirect the output to ignore this since we are intentionally
   // calling this function again and the prints at issue got removed in G4 11.1.0
-  std::ofstream devNull("/dev/null");
-  // Save cerr
-  std::streambuf* oldCerr = G4cerr.rdbuf();
-  G4cerr.rdbuf(devNull.rdbuf());
+  RAT::mute_g4mute();
   rv->SetNumberOfSecondaries(secondaries.size());
-  G4cerr.rdbuf(oldCerr);
+  RAT::mute_g4unmute();
   for (size_t i = 0; i < secondaries.size(); i++) {
     G4Track *secondary = secondaries[i];
     rv->AddSecondary(secondary);

--- a/src/util/include/RAT/MuteGeant4.hh
+++ b/src/util/include/RAT/MuteGeant4.hh
@@ -1,0 +1,34 @@
+#ifndef __RAT_MuteGeant4__
+#define __RAT_MuteGeant4__
+
+#include <G4ios.hh>
+
+namespace RAT {
+
+class discard_streambuf : public std::streambuf {
+public:
+  discard_streambuf() { };
+
+  virtual int_type overflow(int_type c) {
+    return c;
+  };
+};
+
+discard_streambuf discard;
+std::streambuf *g4cout_orig = G4cout.rdbuf();
+std::streambuf *g4cerr_orig = G4cerr.rdbuf();
+
+void mute_g4mute() {
+  G4cout.rdbuf(&discard);
+  G4cerr.rdbuf(&discard);
+}
+
+void mute_g4unmute() {
+  G4cout.rdbuf(g4cout_orig);
+  G4cerr.rdbuf(g4cerr_orig);
+}
+
+}  // namespace RAT
+
+#endif
+


### PR DESCRIPTION
Geant4 sometimes spams prints in an unguarded/inconvenient/unneeded way. This PR adds functionality from Chroma to temporarily redirect output, as discussed in #66. I basically just plopped this in and tested that it works and verified it works to turn on/off, but a few points remain:

- Since this is from Chroma, do we need the Chroma license now, or is this so small/non-specific as to be negligible?
- Is this the appropriate way to include this code? Again, I just dropped it in the RAT namespace and went off to the races, so it's possible there is a more proper/consistent way to implement this (on closer look I guess I've now initialized some variables in a header, which is probably very bad...)

So anyway, happy to take suggestions as to how to make this better integrated into RAT.