### PR TITLE
More improvements to logging

### DIFF
--- a/src/cmd/src/CoincidenceMessenger.cc
+++ b/src/cmd/src/CoincidenceMessenger.cc
@@ -82,7 +82,7 @@ void CoincidenceMessenger::SetNewValue(G4UIcommand *command, G4String newValues)
     Co_gen->SetExpoForceWindow(ExpForceWinCmd->GetNewBoolValue(newValues));
   } else {
     // Error if we reach here.
-    G4cerr << "Error: CoincidenceMessenger invalic command" << G4endl;
+    RAT::warn << "Error: CoincidenceMessenger invalic command" << newline;
   }
 }
 G4String CoincidenceMessenger::GetCurrentValue(G4UIcommand * /*command*/) {

--- a/src/cmd/src/FastNeutronMessenger.cc
+++ b/src/cmd/src/FastNeutronMessenger.cc
@@ -52,7 +52,7 @@ void FastNeutronMessenger::SetNewValue(G4UIcommand *command, G4String newValue) 
     double st = STCmd->GetNewDoubleValue(newValue);
     fastneutron->SetSideBool(st);
   } else {
-    G4cerr << "Error: Invalid FastNeutronMessenger \"set\" command" << G4endl;
+    RAT::warn << "Error: Invalid FastNeutronMessenger \"set\" command" <<newline;
   }
 }
 

--- a/src/cmd/src/GLG4DebugMessenger.cc
+++ b/src/cmd/src/GLG4DebugMessenger.cc
@@ -49,7 +49,7 @@ GLG4DebugMessenger::GLG4DebugMessenger(RAT::DetectorConstruction *mydetector) : 
 
   // the dumpgeom command
   DumpGeomCmd = new G4UIcommand("/glg4debug/dumpgeom", this);
-  DumpGeomCmd->SetGuidance("Dump the geometry information for the entire detector");
+  DumpGeomCmd->SetGuidance("Dump the geometry RAT::information for the entire detector");
   aParam = new G4UIparameter("physicalVolume", 's', true);  // omittable
   DumpGeomCmd->SetParameter(aParam);
 
@@ -105,34 +105,33 @@ GLG4DebugMessenger::GLG4DebugMessenger(RAT::DetectorConstruction *mydetector) : 
 GLG4DebugMessenger::~GLG4DebugMessenger() {}
 
 static void DumpGeom(G4VPhysicalVolume *pv, const char *s) {
-  G4cout << "*******************************" << newline;
-  G4cout << "Physical volume dump for " << s << G4endl;
-  G4cout << " Name: " << pv->GetName() << G4endl;
+  RAT::info << "*******************************" << newline;
+  RAT::info << "Physical volume dump for " << s << newline;
+  RAT::info << " Name: " << pv->GetName() << newline;
 
   G4LogicalVolume *lv = pv->GetLogicalVolume();
-  G4cout << " Logical volume name: " << lv->GetName() << G4endl;
-  G4cout << " Solid name: " << lv->GetSolid()->GetName() << G4endl;
+  RAT::info << " Logical volume name: " << lv->GetName() << newline;
+  RAT::info << " Solid name: " << lv->GetSolid()->GetName() << newline;
 
   G4Material *m = lv->GetMaterial();
-  G4cout << " Material: " << m->GetName() << G4endl;
-  G4cout << (*m) << G4endl;
+  RAT::info << " Material: " << m->GetName() << newline;
+  G4cout << (*m) << newline;
 
   ///  G4PhysicalVolume::GetMother() was removed in Geant4 version 06.
   // G4VPhysicalVolume* mother= pv->GetMother();
   // if ( mother )
-  //   G4cout << "Mother volume is " << mother->GetName() << G4endl;
+  //   RAT::info << "Mother volume is " << mother->GetName() << newline;
   // else
-  //   G4cout << "Has no mother!" << G4endl;
+  //   RAT::info << "Has no mother!" << newline;
 
   G4int ndaught = lv->GetNoDaughters();
   if (ndaught == 0) {
-    G4cout << "Has no daughters." << G4endl;
+    RAT::info << "Has no daughters." << newline;
   } else {
-    G4cout << "Has " << ndaught << " daughters:" << newline;
-    for (G4int i = 0; i < ndaught; i++) G4cout << "\t" << lv->GetDaughter(i)->GetName();
-    G4cout << G4endl;
+    RAT::info << "Has " << ndaught << " daughters:" << newline;
+    for (G4int i = 0; i < ndaught; i++) RAT::info << "\t" << lv->GetDaughter(i)->GetName();
+    RAT::info << newline;
   }
-  G4cout.flush();
 }
 
 static void SetMaterial(G4String newValues) {
@@ -142,8 +141,7 @@ static void SetMaterial(G4String newValues) {
   G4String matName;
   iss >> lvName >> matName;
   if (iss.fail()) {
-    G4cerr << "Could not parse volume and material name from command args" << newline;
-    G4cerr.flush();
+    RAT::warn << "Could not parse volume and material name from command args" << newline;
     return;
   }
 
@@ -158,44 +156,39 @@ static void SetMaterial(G4String newValues) {
     if (lv->GetName() == lvName) break;
   }
   if (lv == NULL || ilv >= nlv) {  // not found
-    G4cerr << "Error, logical volume named \'" << lvName << "\' not found" << newline;
-    G4cerr.flush();
+    RAT::warn << "Error, logical volume named \'" << lvName << "\' not found" << newline;
     return;
   }
 
   // access the store of materials
   G4Material *mat = G4Material::GetMaterial(matName);
   if (mat == NULL) {
-    G4cerr << "Error, material named \'" << matName << "\' not found" << newline;
-    G4cerr.flush();
+    RAT::warn << "Error, material named \'" << matName << "\' not found" << newline;
     return;
   }
 
   // set the material
   lv->SetMaterial(mat);
-  G4cout << "Set material of " << lv->GetName() << " to " << mat->GetName() << G4endl;
-  G4cout.flush();
+  RAT::info << "Set material of " << lv->GetName() << " to " << mat->GetName() << newline;
 }
 
 void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
   // DumpMaterialsCmd
   if (command == DumpMaterialsCmd) {
     if (newValues == "") {
-      G4cout << *(G4Material::GetMaterialTable()) << G4endl;
+      G4cout << *(G4Material::GetMaterialTable()) << newline;
     } else {
       G4Material *m = G4Material::GetMaterial(newValues);
       if (m == NULL) {
-        G4cerr << "Unknown material " << newValues << G4endl << std::flush;
+        RAT::warn << "Unknown material " << newValues << newline;
         return;
       }
-      G4cout << (*m) << G4endl;
+      G4cout << (*m) << newline;
       G4MaterialPropertiesTable *mpt = m->GetMaterialPropertiesTable();
       if (mpt == NULL) {
-        G4cout << "This material has no material properties table." << G4endl;
+        RAT::info << "This material has no material properties table." << newline;
       } else {
-        G4cout.flush();
         mpt->DumpTable();
-        G4cout.flush();
       }
     }
   }
@@ -216,8 +209,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
         if (pv->GetName() == newValues) break;
       }
       if (pv == NULL || ipv >= npv) {  // not found
-        G4cerr << "Error, name \'" << newValues << "\' not found" << newline;
-        G4cerr.flush();
+        RAT::warn << "Error, name \'" << newValues << "\' not found" << newline;
       } else {
         DumpGeom(pv, newValues);
       }
@@ -239,13 +231,12 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
 
     // if no arguments or nloop==0, list the solids
     if (nloop == 0) {
-      G4cout << "Here is a list of solid names" << newline;
+      RAT::info << "Here is a list of solid names" << newline;
       for (isolid = 0; isolid < nsolid; isolid++) {
         G4VSolid *aSolid = (*theSolidStore)[isolid];
         if (!aSolid) break;
-        G4cout << aSolid->GetName() << G4endl;
+        RAT::info << aSolid->GetName() << newline;
       }
-      G4cout.flush();
     }
     // if arguments given, find the named solid and test it
     else {
@@ -256,18 +247,16 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
         if (aSolid->GetName() == nameptr) break;
       }
       if (aSolid == NULL || isolid >= nsolid) {  // solid not found
-        G4cerr << "Error, solid name \'" << nameptr << "\' not found" << newline;
-        G4cerr << "Enter command with no parameters to get list of names" << newline;
-        G4cerr.flush();
+        RAT::warn << "Error, solid name \'" << nameptr << "\' not found" << newline;
+        RAT::warn << "Enter command with no parameters to get list of names" << newline;
       } else {  // we found the solid, now test it
         G4Timer timer;
-        G4cout << "Testing " << nameptr << " with " << nloop << " loops " << G4endl;
+        RAT::info << "Testing " << nameptr << " with " << nloop << " loops " << newline;
         timer.Start();
-        G4cout << GLG4TestSolid::Test(*((*theSolidStore)[isolid]), nloop) << G4endl;
+        RAT::info << GLG4TestSolid::Test(*((*theSolidStore)[isolid]), nloop) << newline;
         timer.Stop();
-        G4cout << "Elapsed time: User=" << timer.GetUserElapsed() << " System=" << timer.GetSystemElapsed()
-               << " Real=" << timer.GetRealElapsed() << G4endl;
-        G4cout.flush();
+        RAT::info << "Elapsed time: User=" << timer.GetUserElapsed() << " System=" << timer.GetSystemElapsed()
+               << " Real=" << timer.GetRealElapsed() << newline;
       }
     }
   }
@@ -282,8 +271,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
     G4double new_value;
     iss >> parameterName;
     if (iss.fail()) {
-      G4cerr << "Could not parse parameter name from command args" << newline;
-      G4cerr.flush();
+      RAT::warn << "Could not parse parameter name from command args" << newline;
       return;
     }
     iss >> new_value;
@@ -303,9 +291,9 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
     }
   } else if (command->GetCommandName() == "dumpelem") {
     if (newValues == "") {
-      G4cout << *(G4Element::GetElementTable()) << G4endl;
+      G4cout << *(G4Element::GetElementTable()) << newline;
     } else {
-      G4cout << *(G4Element::GetElement(newValues)) << G4endl;
+      G4cout << *(G4Element::GetElement(newValues)) << newline;
     }
   } else if (command->GetCommandName() == "setseed") {
     std::istringstream iss(newValues.c_str());
@@ -316,7 +304,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
   } else if (command->GetCommandName() == "SetRunIDCounter") {
     int i = atoi(newValues);
     G4RunManager::GetRunManager()->SetRunIDCounter(i);
-    G4cout << "Set RunIDCounter to " << i << endl;
+    RAT::info << "Set RunIDCounter to " << i << newline;
   }
 #ifdef G4DEBUG
   else if (command->GetCommandName() == "dump_illumination_map") {
@@ -327,7 +315,7 @@ void GLG4DebugMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
 
   // invalid command
   else {
-    G4cerr << "invalid GLG4 \"set\" command" << newline << std::flush;
+    RAT::warn << "invalid GLG4 \"set\" command" << newline;
   }
 }
 

--- a/src/cmd/src/GLG4PrimaryGeneratorMessenger.cc
+++ b/src/cmd/src/GLG4PrimaryGeneratorMessenger.cc
@@ -151,13 +151,13 @@ void GLG4PrimaryGeneratorMessenger::SetNewValue(G4UIcommand *command, G4String n
   } else if (command == EventWindowCmd) {
     G4double newWindow = util_to_double(newValues);
     if (newWindow <= 0.0)
-      G4cerr << "Time window must be positive" << G4endl;
+      RAT::warn << "Time window must be positive" << newline;
     else
       myAction->SetEventWindow(newWindow * CLHEP::ns);
   } else if (command == GenClearCmd) {
     myAction->ClearGenerators();  // clear all event generators
   } else {
-    G4cerr << "invalid GLG4 \"set\" command";
+    RAT::warn << "invalid GLG4 \"set\" command" << newline;
   }
 }
 

--- a/src/cmd/src/GLG4VisMessenger.cc
+++ b/src/cmd/src/GLG4VisMessenger.cc
@@ -53,7 +53,7 @@ void GLG4VisMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
 
   G4VViewer *currentViewer = pVMan->GetCurrentViewer();
   if (!currentViewer) {
-    G4cerr << "GLG4VisMessenger::SetNewValue: no current viewer." << G4endl;
+    RAT::warn << "GLG4VisMessenger::SetNewValue: no current viewer." << newline;
     return;
   }
   G4ViewParameters vp = currentViewer->GetViewParameters();
@@ -64,24 +64,26 @@ void GLG4VisMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
     vp.SetDolly(0.);
     vp.SetViewpointDirection(G4Vector3D(0., 1., 0.));
     vp.SetUpVector(G4Vector3D(0., 0., 1.));
-    G4cout << "Target point reset to (0.0,0.0,0.0)" << newline;
-    G4cout << "Zoom factor reset to 1." << newline;
-    G4cout << "Dolly distance reset to 0." << newline;
-    G4cout << "Viewpoint direction reset to +y." << newline;
-    G4cout << "Up vector set to +z.";
-    G4cout << G4endl;
+    RAT::info << "Target point reset to (0.0,0.0,0.0)" << newline;
+    RAT::info << "Zoom factor reset to 1." << newline;
+    RAT::info << "Dolly distance reset to 0." << newline;
+    RAT::info << "Viewpoint direction reset to +y." << newline;
+    RAT::info << "Up vector set to +z.";
+    RAT::info << newline;
   } else if (commandname == "upvector") {
     G4double x, y, z;
     is >> x >> y >> z;
     if (is.fail()) {
       G4cerr << "GLG4VisMessaneger::SetNewValue: "
-             << "Could not understand arguments, up vector left as " << vp.GetUpVector() << G4endl << std::flush;
+             << "Could not understand arguments, up vector left as " << vp.GetUpVector() << newline;
       return;
-    } else {
+    }
+    else {
       vp.SetUpVector(G4Vector3D(x, y, z));
     }
-  } else {
-    G4cerr << "GLG4VisMessaneger::SetNewValue: I do not recognize this command: " << commandname << G4endl;
+  }
+  else {
+    RAT::warn << "GLG4VisMessaneger::SetNewValue: I do not recognize this command: " << commandname << newline;
     return;
   }
 

--- a/src/cmd/src/IBDgenMessenger.cc
+++ b/src/cmd/src/IBDgenMessenger.cc
@@ -43,7 +43,7 @@ void IBDgenMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
   } else if (command == PositronUseCmd) {
     ibdgen->SetPositronState(PositronUseCmd->GetNewBoolValue(newValue));
   } else {
-    G4cerr << "Error: Invalid IBDgenMessenger \"set\" command" << G4endl;
+    RAT::warn << "Error: Invalid IBDgenMessenger \"set\" command" << newline;
   }
 }
 

--- a/src/cmd/src/IsotopeMessenger.cc
+++ b/src/cmd/src/IsotopeMessenger.cc
@@ -50,7 +50,7 @@ void IsotopeMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
     double e = ECmd->GetNewDoubleValue(newValue);
     isotope->SetIsotopeE(e);
   } else {
-    G4cerr << "Error: Invalid IsotopeMessenger \"set\" command" << G4endl;
+    RAT::warn << "Error: Invalid IsotopeMessenger \"set\" command" << newline;
   }
 }
 

--- a/src/cmd/src/ReacIBDgenMessenger.cc
+++ b/src/cmd/src/ReacIBDgenMessenger.cc
@@ -55,7 +55,7 @@ void ReacIBDgenMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
     G4double Pu241Ampl = Pu241AmpCmd->GetNewDoubleValue(newValue);
     reacibdgen->SetPu241Amplitude(Pu241Ampl);
   } else {
-    G4cerr << "Error: Invalid ReacIBDgenMessenger \"set\" command" << G4endl;
+    RAT::warn << "Error: Invalid ReacIBDgenMessenger \"set\" command" << newline;
   }
 }
 

--- a/src/cmd/src/SNgenMessenger.cc
+++ b/src/cmd/src/SNgenMessenger.cc
@@ -90,7 +90,7 @@ void SNgenMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
     int MAmpl = int(ModelCmd->GetNewDoubleValue(newValue));
     sngen->SetModel(MAmpl);
   } else {
-    G4cerr << "Error: Invalid SNgenMessenger \"set\" command" << G4endl;
+    RAT::warn << "Error: Invalid SNgenMessenger \"set\" command" << newline;
   }
 }
 

--- a/src/core/src/GLG4HitPMT.cc
+++ b/src/core/src/GLG4HitPMT.cc
@@ -13,6 +13,8 @@
 #include <algorithm>
 #include <limits>
 
+#include "RAT/Log.hh"
+
 #ifdef G4DEBUG
 #define IFDEBUG(A) A
 #else
@@ -81,17 +83,17 @@ void GLG4HitPMT::DetectPhoton(GLG4HitPhoton *new_photon) {
       it1--;  // it1 photon should be earlier than photon to be added
       if (new_photon->GetTime() - (*it1)->GetTime() < kMergeTime) {
         // close to earlier photon -- merge with earlier photon
-        IFDEBUG(if (new_photon->GetTime() - (*it1)->GetTime() < 0.0) G4cerr
+        IFDEBUG(if (new_photon->GetTime() - (*it1)->GetTime() < 0.0) RAT::debug
                 << "GLG4HitPMT STRANGE merge " << new_photon->GetTime() << " with non-earlier photon "
-                << (*it1)->GetTime() << G4endl);
+                << (*it1)->GetTime() << newline);
         (*it1)->AddCount(new_photon->GetCount());
         delete new_photon;
         new_photon = 0;
       } else if (it2 != fPhotons.end() && (*it2)->GetTime() - new_photon->GetTime() < kMergeTime) {
         // not after last photon, and close to later photon
-        IFDEBUG(if ((*it2)->GetTime() - new_photon->GetTime() < 0.0) G4cerr
+        IFDEBUG(if ((*it2)->GetTime() - new_photon->GetTime() < 0.0) RAT::debug
                 << "GLG4HitPMT STRANGE merge " << new_photon->GetTime() << " with non-later photon "
-                << (*it2)->GetTime() << G4endl);
+                << (*it2)->GetTime() << newline);
         (*it2)->AddCount(new_photon->GetCount());
         (*it2)->SetTime(new_photon->GetTime());
         delete new_photon;
@@ -111,22 +113,22 @@ void GLG4HitPMT::SortTimeAscending() {
 
 /// print out HitPhotons.
 void GLG4HitPMT::Print(std::ostream &os, bool fullDetailsMode) {
-  os << " PMTID= " << fID << "  number of HitPhotons = " << fPhotons.size() << G4endl;
+  os << " PMTID= " << fID << "  number of HitPhotons = " << fPhotons.size() << newline;
   if (fullDetailsMode == false) {
     for (size_t i = 0; i < fPhotons.size(); i++)
-      os << "  Hit time= " << fPhotons[i]->GetTime() << " count= " << fPhotons[i]->GetCount() << G4endl;
+      os << "  Hit time= " << fPhotons[i]->GetTime() << " count= " << fPhotons[i]->GetCount() << newline;
   } else {
     for (size_t i = 0; i < fPhotons.size(); i++) {
-      os << "  Hit time= " << fPhotons[i]->GetTime() << G4endl;
-      os << "      count= " << fPhotons[i]->GetCount() << G4endl;
-      os << "      wavelength= " << fPhotons[i]->GetWavelength() << G4endl;
+      os << "  Hit time= " << fPhotons[i]->GetTime() << newline;
+      os << "      count= " << fPhotons[i]->GetCount() << newline;
+      os << "      wavelength= " << fPhotons[i]->GetWavelength() << newline;
       double x, y, z;
       fPhotons[i]->GetPosition(x, y, z);
-      os << "      position= " << x << " " << y << " " << z << G4endl;
+      os << "      position= " << x << " " << y << " " << z << newline;
       fPhotons[i]->GetMomentum(x, y, z);
-      os << "      momentum= " << x << " " << y << " " << z << G4endl;
+      os << "      momentum= " << x << " " << y << " " << z << newline;
       fPhotons[i]->GetPolarization(x, y, z);
-      os << "      polarization= " << x << " " << y << " " << z << G4endl;
+      os << "      polarization= " << x << " " << y << " " << z << newline;
     }
   }
 }

--- a/src/core/src/GLG4SteppingAction.cc
+++ b/src/core/src/GLG4SteppingAction.cc
@@ -67,8 +67,7 @@ G4double GLG4SteppingAction_internal_time = 0.0;
 int GLG4SteppingAction_dump_times(void) {
   for (GLG4SteppingAction_time_map_iterator i = GLG4SteppingAction_times.begin(); i != GLG4SteppingAction_times.end();
        i++) {
-    G4cout << i->first << ' ' << i->second.sumtime << ' ' << i->second.stepcount << G4endl;
-    G4cout.flush();
+    RAT::info << i->first << ' ' << i->second.sumtime << ' ' << i->second.stepcount << newline;
   }
   return 1;
 }
@@ -105,7 +104,7 @@ int GLG4SteppingAction_dump_IlluminationMap(void) {
           }
   }
   if (maxval == 0.0) {
-    G4cout << "Empty Illumination Map" << G4endl;
+    RAT::info << "Empty Illumination Map" << newline;
     return 0;
   }
   meanval /= nsum;
@@ -155,7 +154,7 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
              << " type=" << track->GetDefinition()->GetParticleName()
              << "\n volume=" << (pv != 0 ? pv->GetName() : G4String("NULL"))
              << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))
-             << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << G4endl;
+             << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << newline;
       track->SetTrackStatus(fStopAndKill);
       num_zero_steps_in_a_row = 0;
     }
@@ -164,7 +163,7 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
 
   // check for very high number of steps
   if (track->GetCurrentStepNumber() % GLG4SteppingAction_MaxStepNumber == 0) {
-    G4cerr << "warning:  step_no=" << track->GetCurrentStepNumber() << "  %  " << GLG4SteppingAction_MaxStepNumber
+    RAT::warn << "warning:  step_no=" << track->GetCurrentStepNumber() << "  %  " << GLG4SteppingAction_MaxStepNumber
            << " == 0 for particle: " << track->GetDefinition()->GetParticleName() << newline;
   }
 
@@ -176,7 +175,7 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
            << " step_no=" << track->GetCurrentStepNumber() << " type=" << track->GetDefinition()->GetParticleName()
            << "\n volume=" << (pv != 0 ? pv->GetName() : G4String("NULL"))
            << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))
-           << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << G4endl;
+           << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << newline;
     track->SetTrackStatus(fStopAndKill);
   }
 
@@ -199,7 +198,7 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
              << (lastproc!=0 ? lastproc->GetProcessName() : G4String("NULL"))
              << "\n position=" << track->GetPosition()
              << " momentum=" << track->GetMomentum()
-             << G4endl;
+             << newline;
       */
 
       track->SetTrackStatus(fStopAndKill);
@@ -226,7 +225,7 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
 
   if (nameProcess == "nCapture") {
 #ifdef debug_dicebox158Gd
-    G4cout << G4endl << "=======================BEFORE DICEBOX======================" << G4endl;
+    RAT::debug << newline << "=======================BEFORE DICEBOX======================" << newline;
 #endif
 
     if (numSecondaries > 0) {
@@ -237,11 +236,11 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
 #ifdef debug_dicebox158Gd
         G4cout << "(i,name,pos,momentum,erg,time) : (" << lp1 << "," << par->GetParticleName() << ","
                << (*fSecondary)[lp1]->GetPosition() << "," << (*fSecondary)[lp1]->GetMomentum() << ","
-               << (*fSecondary)[lp1]->GetKineticEnergy() << "," << (*fSecondary)[lp1]->GetGlobalTime() << ")" << G4endl;
+               << (*fSecondary)[lp1]->GetKineticEnergy() << "," << (*fSecondary)[lp1]->GetGlobalTime() << ")" << newline;
 
         G4cout << "(parentID,trackID,stepID,status) : (" << (*fSecondary)[lp1]->GetParentID() << ","
                << (*fSecondary)[lp1]->GetTrackID() << "," << (*fSecondary)[lp1]->GetCurrentStepNumber() << ","
-               << (*fSecondary)[lp1]->GetTrackStatus() << ")" << G4endl;
+               << (*fSecondary)[lp1]->GetTrackStatus() << ")" << newline;
 #endif
         if (nameParticle == "Gd158") {
           nCap157Gd = true;
@@ -277,18 +276,18 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
 #ifdef debug_dicebox158Gd
   const std::vector<const G4Track *> *secondary = aStep->GetSecondaryInCurrentStep();
   if (nameProcess == "nCapture") {
-    G4cout << G4endl << "=======================AFTER DICEBOX======================" << G4endl;
+    RAT::debug << newline << "=======================AFTER DICEBOX======================" << newline;
 
     for (size_t lp = 0; lp < (*secondary).size(); lp++) {
       G4ParticleDefinition *par = (*secondary)[lp]->GetDefinition();
 
-      G4cout << "(i,name,pos,momentum,erg,time) : (" << lp << "," << par->GetParticleName() << ","
+      RAT::debug << "(i,name,pos,momentum,erg,time) : (" << lp << "," << par->GetParticleName() << ","
              << (*secondary)[lp]->GetPosition() << "," << (*secondary)[lp]->GetMomentum() << ","
-             << (*secondary)[lp]->GetKineticEnergy() << "," << (*secondary)[lp]->GetGlobalTime() << ")" << G4endl;
+             << (*secondary)[lp]->GetKineticEnergy() << "," << (*secondary)[lp]->GetGlobalTime() << ")" << newline;
 
-      G4cout << "(parentID,trackID,stepID,status) : (" << (*secondary)[lp]->GetParentID() << ","
+      RAT::debug << "(parentID,trackID,stepID,status) : (" << (*secondary)[lp]->GetParentID() << ","
              << (*secondary)[lp]->GetTrackID() << "," << (*secondary)[lp]->GetCurrentStepNumber() << ","
-             << (*secondary)[lp]->GetTrackStatus() << ")" << G4endl;
+             << (*secondary)[lp]->GetTrackStatus() << ")" << newline;
     }
   }
 
@@ -312,7 +311,7 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
            << " step_no=" << track->GetCurrentStepNumber() << " type=" << track->GetDefinition()->GetParticleName()
            << "\n volume=NULL"
            << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))
-           << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << G4endl;
+           << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << newline;
     track->SetTrackStatus(fStopAndKill);
   }
 

--- a/src/core/src/GLG4VEventAction.cc
+++ b/src/core/src/GLG4VEventAction.cc
@@ -90,9 +90,9 @@ void GLG4VEventAction::SetNewValue(G4UIcommand *command, G4String newValue) {
     G4bool old_flagFullOutputMode = flagFullOutputMode;
     flagFullOutputMode = (newValue == "full");
     if (flagFullOutputMode != old_flagFullOutputMode) {
-      G4cout << "Switching output mode to " << (flagFullOutputMode ? "full" : "basic") << G4endl;
+      RAT::info << "Switching output mode to " << (flagFullOutputMode ? "full" : "basic") << newline;
     } else {
-      G4cout << "FYI: new output mode == old output mode" << G4endl;
+      RAT::info << "FYI: new output mode == old output mode" << newline;
     }
   } else if (command->GetCommandName() == "output_file") {
     // always call CloseFile() here, in case file is open
@@ -101,7 +101,7 @@ void GLG4VEventAction::SetNewValue(G4UIcommand *command, G4String newValue) {
     // open new file, if new filename given
     // (it is okay not to give a name, in case user just wants to close file)
     if (newValue.length() <= 0) {
-      // G4cerr << "Null Output File Name" << G4endl;
+      // RAT::warn << "Null Output File Name" << newline;
       return;
     } else
       OpenFile(newValue, flagFullOutputMode);
@@ -109,7 +109,7 @@ void GLG4VEventAction::SetNewValue(G4UIcommand *command, G4String newValue) {
   } else if (command->GetCommandName() == "doParameterizedScintillation") {
     fgDoParameterizedScintillation = (atoi((const char *)newValue) != 0);
   } else {
-    G4cerr << "Unknown command ``" << command->GetCommandName() << " passed to GLG4EventAction::SetNewValue" << newline;
+    RAT::warn << "Unknown command ``" << command->GetCommandName() << " passed to GLG4EventAction::SetNewValue" << newline;
   }
 }
 

--- a/src/core/src/StackingAction.cc
+++ b/src/core/src/StackingAction.cc
@@ -29,13 +29,13 @@ G4ClassificationOfNewTrack StackingAction::ClassifyNewTrack(const G4Track *track
 #ifdef debug_dicebox
 
   if (nameParticle != "opticalphoton" && track->GetParentID() == 1) {
-    G4cout << "*******************************" << G4endl;
-    G4cout << "      Classify new track       " << G4endl;
-    G4cout << "*******************************" << G4endl;
+    RAT::debug << "*******************************" << newline;
+    RAT::debug << "      Classify new track       " << newline;
+    RAT::debug << "*******************************" << newline;
 
-    G4cout << "(name, parentID,trackID,stepID,status) : (" << par->GetParticleName() << "," << track->GetParentID()
+    RAT::debug << "(name, parentID,trackID,stepID,status) : (" << par->GetParticleName() << "," << track->GetParentID()
            << "," << track->GetTrackID() << "," << track->GetCurrentStepNumber() << "," << track->GetTrackStatus()
-           << ")" << G4endl;
+           << ")" << newline;
   }
 
 #endif

--- a/src/fit/src/MiniSim.cc
+++ b/src/fit/src/MiniSim.cc
@@ -82,7 +82,7 @@ void MiniSim::UserSteppingAction(const G4Step *aStep) {
              << " type=" << track->GetDefinition()->GetParticleName()
              << "\n volume=" << (pv != 0 ? pv->GetName() : G4String("NULL"))
              << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))
-             << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << G4endl;
+             << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << newline;
       track->SetTrackStatus(fStopAndKill);
       num_zero_steps_in_a_row = 0;
     }
@@ -97,7 +97,7 @@ void MiniSim::UserSteppingAction(const G4Step *aStep) {
            << " step_no=" << track->GetCurrentStepNumber() << " type=" << track->GetDefinition()->GetParticleName()
            << "\n volume=" << (pv != 0 ? pv->GetName() : G4String("NULL"))
            << " last_process=" << (lastproc != 0 ? lastproc->GetProcessName() : G4String("NULL"))
-           << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << G4endl;
+           << "\n position=" << track->GetPosition() << " momentum=" << track->GetMomentum() << newline;
     track->SetTrackStatus(fStopAndKill);
   }
 

--- a/src/geo/src/BWVetGenericChamber.cc
+++ b/src/geo/src/BWVetGenericChamber.cc
@@ -16,6 +16,8 @@
 #include <RAT/BWVetGenericChamber.hh>
 #include <RAT/BWVetGenericChamberHit.hh>
 
+#include <RAT/Log.hh>
+
 namespace RAT {
 
 BWVetGenericChamber::BWVetGenericChamber(G4String name) : G4VSensitiveDetector(name) {
@@ -28,16 +30,16 @@ BWVetGenericChamber::~BWVetGenericChamber() { ; }
 
 void BWVetGenericChamber::Initialize(G4HCofThisEvent *HCE) {
   int deb = 0;  // G4int(db["veto_debugging"]);
-  if (deb != 0) std::cout << "BWVetGenericChamber::Initialize start." << std::endl;
+  if (deb) RAT::debug << "BWVetGenericChamber::Initialize start." << newline;
   _hitsCollection = new BWVetGenericChamberHitsCollection(SensitiveDetectorName, collectionName[0]);
 
-  if (deb != 0) {
-    std::cout << "BWVetGenericChamber::Initialize hit collection address is " << _hitsCollection << std::endl;
+  if (deb) {
+    RAT::debug << "BWVetGenericChamber::Initialize hit collection address is " << _hitsCollection << newline;
   }
   if (HCID < 0) {
     HCID = G4SDManager::GetSDMpointer()->GetCollectionID(_hitsCollection);
   }
-  if (deb != 0) std::cout << "BWVetGenericChamber::Initialize hit collection ID = " << HCID << std::endl;
+  if (deb) RAT::debug << "BWVetGenericChamber::Initialize hit collection ID = " << HCID << newline;
   HCE->AddHitsCollection(HCID, _hitsCollection);
 
   // store pointer to hit collection
@@ -58,7 +60,7 @@ void BWVetGenericChamber::Initialize(G4HCofThisEvent *HCE) {
   _hit_volume.clear();
   fLastTrackID = fLastEventID = -1;
 
-  if (deb != 0) std::cout << "BWVetGenericChamber::Initialize end." << std::endl;
+  if (deb) RAT::debug << "BWVetGenericChamber::Initialize end." << newline;
 }
 
 G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*ROhist*/) {
@@ -68,14 +70,14 @@ G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*RO
 
   int deb = 0;  // G4int(db["veto_debugging"]);
 
-  if (deb != 0) {
-    std::cout << "BWVetGenericChamber::ProcessHits start." << std::endl;
-    std::cout << "BWVetGenericChamber::ProcessHits getting energy deposited." << std::endl;
+  if (deb) {
+    RAT::debug << "BWVetGenericChamber::ProcessHits start." << newline;
+    RAT::debug << "BWVetGenericChamber::ProcessHits getting energy deposited." << newline;
   }
   G4double edep = aStep->GetTotalEnergyDeposit();
   G4double dl = aStep->GetStepLength();
 
-  if (deb) std::cout << "   Energy deposited: " << edep << std::endl;
+  if (deb) RAT::debug << "   Energy deposited: " << edep << newline;
 
   //   if(edep==0.) return true;
 
@@ -84,11 +86,11 @@ G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*RO
   int pdg = part->GetPDGEncoding();
 
   if (deb)
-    std::cout << "  track information: " << std::endl
-              << "    G4Track Pointer: " << aTrack << G4endl << "    Particle Definition Pointer: " << part << std::endl
-              << "    Particle PDG Encoding: " << pdg << G4endl;
+    RAT::debug << "  track information: " << newline
+              << "    G4Track Pointer: " << aTrack << newline << "    Particle Definition Pointer: " << part << newline
+              << "    Particle PDG Encoding: " << pdg << newline;
 
-  if (deb) std::cout << "BWVetGenericChamber::ProcessHits getting global time." << std::endl;
+  if (deb) RAT::debug << "BWVetGenericChamber::ProcessHits getting global time." << newline;
   G4StepPoint *preStepPoint = aStep->GetPreStepPoint();
   G4Material *m = preStepPoint->GetMaterial();
   G4String mname = m->GetName();
@@ -109,10 +111,10 @@ G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*RO
   G4int idOffset = 1;
   uid = 0;
 
-  if (deb != 0) std::cout << "History level: " << theTouchable->GetHistoryDepth() << std::endl;
+  if (deb) RAT::debug << "History level: " << theTouchable->GetHistoryDepth() << newline;
 
   while (ivol < theTouchable->GetHistoryDepth()) {
-    if (deb != 0) std::cout << " * volume layer level = " << ivol << std::endl;
+    if (deb) RAT::debug << " * volume layer level = " << ivol << newline;
     uid += theTouchable->GetVolume(ivol)->GetCopyNo() * idOffset;
     idOffset *= 100;
     ivol++;
@@ -120,31 +122,31 @@ G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*RO
 
   G4ThreeVector worldPos = preStepPoint->GetPosition();
 
-  if (deb != 0) {
-    std::cout << "Hit material name " << mname << std::endl;
-    std::cout << "density           " << d << std::endl;
-    std::cout << "formula           " << f << std::endl;
-    std::cout << "edep " << G4BestUnit(edep, "Energy") << std::endl;
-    std::cout << "dl " << G4BestUnit(dl, "Length") << std::endl;
-    std::cout << "pid " << pdg << std::endl;
-    std::cout << "Position " << G4BestUnit(worldPos.x(), "Length") << " " << G4BestUnit(worldPos.y(), "Length") << " "
-              << G4BestUnit(worldPos.z(), "Length") << " " << std::endl;
+  if (deb) {
+    RAT::debug << "Hit material name " << mname << newline;
+    RAT::debug << "density           " << d << newline;
+    RAT::debug << "formula           " << f << newline;
+    RAT::debug << "edep " << G4BestUnit(edep, "Energy") << newline;
+    RAT::debug << "dl " << G4BestUnit(dl, "Length") << newline;
+    RAT::debug << "pid " << pdg << newline;
+    RAT::debug << "Position " << G4BestUnit(worldPos.x(), "Length") << " " << G4BestUnit(worldPos.y(), "Length") << " "
+              << G4BestUnit(worldPos.z(), "Length") << " " << newline;
 
-    std::cout << " " << std::endl;
+    RAT::debug << " " << newline;
   }
 
   G4double hitTime = preStepPoint->GetGlobalTime();
 
-  if (deb != 0)
-    std::cout << "BWVetGenericChamber::ProcessHits checking for an existing hit "
+  if (deb)
+    RAT::debug << "BWVetGenericChamber::ProcessHits checking for an existing hit "
                  "in this element."
-              << std::endl;
+              << newline;
   // check if this finger already has a hit
   G4int ix = -1;
 
-  if (deb != 0) {
-    std::cout << "BWVetGenericChamber::ProcessHits hit collection address is " << _hitsCollection << std::endl;
-    std::cout << "BWVetGenericChamber: Hit ID = " << uid << " and position: " << worldPos << std::endl;
+  if (deb) {
+    RAT::debug << "BWVetGenericChamber::ProcessHits hit collection address is " << _hitsCollection << newline;
+    G4cerr << "BWVetGenericChamber: Hit ID = " << uid << " and position: " << worldPos << newline;
   }
 
   int eventID = G4RunManager::GetRunManager()->GetCurrentRun()->GetNumberOfEvent();
@@ -171,31 +173,31 @@ G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*RO
   /*G4int hitfreq = G4int(db["veto_hit_frequency"]);*/
 
   if (NULL == _hitsCollection) {
-    if (deb != 0)
-      std::cout << "BWVetGenericChamber::ProcessHits hit collection null. "
+    if (deb)
+      RAT::debug << "BWVetGenericChamber::ProcessHits hit collection null. "
                    "Reloading from HCofEThisEvent."
-                << std::endl;
+                << newline;
     if (_HCE) {
       _hitsCollection = (BWVetGenericChamberHitsCollection *)(_HCE->GetHC(HCID));
-      if (deb != 0) {
-        std::cout << "BWVetGenericChamber::ProcessHits   * hit collection address is " << _hitsCollection << std::endl;
+      if (deb) {
+        RAT::debug << "BWVetGenericChamber::ProcessHits   * hit collection address is " << _hitsCollection << newline;
       }
     } else {
-      if (deb != 0)
-        std::cout << "BWVetGenericChamber::ProcessHits   (E) HCofEThisEvent "
+      if (deb)
+        RAT::debug << "BWVetGenericChamber::ProcessHits   (E) HCofEThisEvent "
                      "pointer is NULL!"
-                  << std::endl;
+                  << newline;
     }
   }
 
   if (_hitsCollection) {
     for (G4int i = 0; i < _hitsCollection->entries(); i++) {
-      // 	std::cout << "  * BWVetGenericChamber::ProcessHits checking hit "
+      // 	RAT::debug << "  * BWVetGenericChamber::ProcessHits checking hit "
       // 	       << i + 1
       // 	       << " of "
       // 	       << _hitsCollection->entries()
-      // 	       << std::endl;
-      if (deb != 0) std::cout << "  * this hit ID is " << (*_hitsCollection)[i]->GetID() << std::endl;
+      // 	       << newline;
+      if (deb) RAT::debug << "  * this hit ID is " << (*_hitsCollection)[i]->GetID() << newline;
       if ((*_hitsCollection)[i]->GetID() == uid) {
         ix = i;
         break;
@@ -204,17 +206,17 @@ G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*RO
 
     // if it has, then take the earlier time
     if (ix >= 0) {
-      if (deb != 0)
-        std::cout << "BWVetGenericChamber::ProcessHits use existing earlier time "
+      if (deb)
+        RAT::debug << "BWVetGenericChamber::ProcessHits use existing earlier time "
                      "for hit."
-                  << std::endl;
+                  << newline;
       if ((*_hitsCollection)[ix]->GetTime() > hitTime) {
         (*_hitsCollection)[ix]->SetTime(hitTime);
       }
     } else
     // if not, create a new hit and std::set it to the collection
     {
-      if (deb != 0) std::cout << "BWVetGenericChamber::ProcessHits creating a new hit." << std::endl;
+      if (deb) RAT::debug << "BWVetGenericChamber::ProcessHits creating a new hit." << newline;
       BWVetGenericChamberHit *aHit = new BWVetGenericChamberHit(uid, hitTime);
       G4VPhysicalVolume *thePhysical = theTouchable->GetVolume();
       aHit->SetLogV(thePhysical->GetLogicalVolume());
@@ -225,10 +227,10 @@ G4bool BWVetGenericChamber::ProcessHits(G4Step *aStep, G4TouchableHistory * /*RO
       _hitsCollection->insert(aHit);
       aHit->Print();
       aHit->Draw();
-      if (deb != 0) std::cout << "  * Drawing Hit " << uid << std::endl;
+      if (deb) RAT::debug << "  * Drawing Hit " << uid << newline;
     }
   }
-  if (deb != 0) std::cout << "BWVetGenericChamber::ProcessHits end." << std::endl;
+  if (deb) RAT::debug << "BWVetGenericChamber::ProcessHits end." << newline;
   return true;
 }
 

--- a/src/geo/src/GLG4BoxSD.cc
+++ b/src/geo/src/GLG4BoxSD.cc
@@ -30,6 +30,8 @@
 #include "G4ios.hh"
 #include "local_g4compat.hh"
 
+#include "RAT/Log.hh"
+
 GLG4BoxSD::GLG4BoxSD(G4String name) : G4VSensitiveDetector(name) {
   eCut = 1.5 * CLHEP::MeV;
   gCut = 1.5 * CLHEP::MeV;
@@ -96,10 +98,9 @@ void GLG4BoxSD::EndOfEvent(G4HCofThisEvent *) {
       sum_ng += h_ng[i];
       sum_ne += h_ne[i];
     }
-    std::cout << GetName() << ":\t" << sum_ng << " neutral-x0,\t" << sum_ne << " charged-x0,\t" << tot_edep / CLHEP::MeV
+    RAT::info << GetName() << ":\t" << sum_ng << " neutral-x0,\t" << sum_ne << " charged-x0,\t" << tot_edep / CLHEP::MeV
               << " MeV\n"
-              << std::endl;
-    std::cout.flush();
+              << newline;
   }
 }
 
@@ -118,9 +119,9 @@ static void dump_histo(T *hist, int hlength, int xmin) {
   for (i = 0; i < hlength; i++) {
     if (hist[i] != 0 || nrzflag == -1) {
       if (nrzflag != -1 && nrzflag != i - 1) {
-        std::cout << (i - 1 + xmin) << "\t0\n";
+        RAT::debug << (i - 1 + xmin) << "\t0\n";
       }
-      std::cout << (i + xmin) << "\t" << hist[i] << std::endl;
+      RAT::debug << (i + xmin) << "\t" << hist[i] << newline;
       if (hist[i] == 0)
         nrzflag = i;
       else
@@ -128,19 +129,19 @@ static void dump_histo(T *hist, int hlength, int xmin) {
     }
   }
   if (nrzflag > -1) {
-    std::cout << (hlength - 1 + xmin) << "\t0\n";
+    RAT::debug << (hlength - 1 + xmin) << "\t0\n";
   }
-  std::cout << std::endl;
+  RAT::debug << newline;
 }
 
 void GLG4BoxSD::PrintAll() {
   // print histograms in compressed form
-  std::cout << "\n# " << GetName() << std::endl;
-  std::cout << "# uncharged vs. 2*rad.length" << std::endl;
+  RAT::info << "\n# " << GetName() << newline;
+  RAT::info << "# uncharged vs. 2*rad.length" << newline;
   dump_histo(h_ng, nbin, 0);
-  std::cout << "# charged vs. 2*rad.length" << std::endl;
+  RAT::info << "# charged vs. 2*rad.length" << newline;
   dump_histo(h_ne, nbin, 0);
-  std::cout << "# edep vs. 2*rad.length" << std::endl;
+  RAT::info << "# edep vs. 2*rad.length" << newline;
   dump_histo(h_edep, nbin, 0);
-  std::cout << std::endl << std::flush;
+  RAT::info << newline;
 }

--- a/src/geo/src/GLG4TorusStack.cc
+++ b/src/geo/src/GLG4TorusStack.cc
@@ -34,6 +34,8 @@
 #include "local_g4compat.hh"
 #include "meshdefs.hh"
 
+#include "RAT/Log.hh"
+
 // debugging
 #ifdef DEBUG_GLG4TorusStack
 #undef DEBUG_GLG4TorusStack
@@ -150,9 +152,9 @@ void GLG4TorusStack::SetAllParameters(G4int n_,                  // number of Z-
         if (rho_edge[i] < a[i] - radTolerance || rho_edge[i + 1] < a[i] - radTolerance) {
           b[i] = -b[i];
         } else {
-          std::cerr << "Warning: ambiguous toroid segment curvature in "
+          RAT::warn << "Warning: ambiguous toroid segment curvature in "
                        "GLG4TorusStack!"
-                    << std::endl;
+                    << newline;
         }
       }
     }
@@ -191,12 +193,12 @@ void GLG4TorusStack::CheckABRho() {
       // make sure both rho_edges are >= a[i]
       if (rho_edge[i] < a[i]) {
         if (fabs(a[i] - rho_edge[i]) > max_rho * 1e-3 + radTolerance)
-          std::cerr << "Warning: GLG4TorusStack making sizeable adjustment to "
+          RAT::warn << "Warning: GLG4TorusStack making sizeable adjustment to "
                        "rho_edge["
                     << i << "]: old " << rho_edge[i] << ", new " << a[i] << " (1)\n";
 #ifdef G4DEBUG
         else
-          std::cerr << "Debug info: GLG4TorusStack making small adjustment to "
+          RAT::debug << "Debug info: GLG4TorusStack making small adjustment to "
                        "rho_edge["
                     << i << "]: old " << rho_edge[i] << ", new " << a[i] << " (1a)\n";
 #endif
@@ -205,12 +207,12 @@ void GLG4TorusStack::CheckABRho() {
       }
       if (rho_edge[i + 1] < a[i]) {
         if (fabs(a[i] - rho_edge[i + 1]) > max_rho * 1e-3 + radTolerance)
-          std::cerr << "Warning: GLG4TorusStack making sizeable adjustment to "
+          RAT::warn << "Warning: GLG4TorusStack making sizeable adjustment to "
                        "rho_edge["
                     << i + 1 << "]: old " << rho_edge[i + 1] << ", new " << a[i] << " (2)\n";
 #ifdef G4DEBUG
         else
-          std::cerr << "Debug info: GLG4TorusStack making small adjustment to "
+          RAT::debug << "Debug info: GLG4TorusStack making small adjustment to "
                        "rho_edge["
                     << i + 1 << "]: old " << rho_edge[i + 1] << ", new " << a[i] << " (2a)\n";
 #endif
@@ -221,12 +223,12 @@ void GLG4TorusStack::CheckABRho() {
       // make sure both rho_edges are <= a[i]
       if (rho_edge[i] > a[i]) {
         if (fabs(a[i] - rho_edge[i]) > max_rho * 1e-3 + radTolerance)
-          std::cerr << "Warning: GLG4TorusStack making sizeable adjustment to "
+          RAT::warn << "Warning: GLG4TorusStack making sizeable adjustment to "
                        "rho_edge["
                     << i << "]: old " << rho_edge[i] << ", new " << a[i] << " (3)\n";
 #ifdef G4DEBUG
         else
-          std::cerr << "Debug info: GLG4TorusStack making small adjustment to "
+          RAT::warn << "Debug info: GLG4TorusStack making small adjustment to "
                        "rho_edge["
                     << i << "]: old " << rho_edge[i] << ", new " << a[i] << " (3a)\n";
 #endif
@@ -235,12 +237,12 @@ void GLG4TorusStack::CheckABRho() {
       }
       if (rho_edge[i + 1] > a[i]) {
         if (fabs(a[i] - rho_edge[i + 1]) > max_rho * 1e-3 + radTolerance)
-          std::cerr << "Warning: GLG4TorusStack making sizeable adjustment to "
+          RAT::warn << "Warning: GLG4TorusStack making sizeable adjustment to "
                        "rho_edge["
                     << i + 1 << "]: old " << rho_edge[i + 1] << ", new " << a[i] << " (4)\n";
 #ifdef G4DEBUG
         else
-          std::cerr << "Debug info: GLG4TorusStack making small adjustment to "
+          RAT::debug << "Debug info: GLG4TorusStack making small adjustment to "
                        "rho_edge["
                     << i + 1 << "]: old " << rho_edge[i + 1] << ", new " << a[i] << " (4a)\n";
 #endif
@@ -257,7 +259,7 @@ void GLG4TorusStack::CheckABRho() {
 // computation & modification.
 
 void GLG4TorusStack::ComputeDimensions(G4VPVParameterisation *, const G4int, const G4VPhysicalVolume *) {
-  std::cerr << "Warning: ComputeDimensions is not defined for GLG4TorusStack. "
+  RAT::warn << "Warning: ComputeDimensions is not defined for GLG4TorusStack. "
                "It shouldn't be called.\n";
   // but note that G4Polycone just silently ignores calls to ComputeDimensions!
   // ComputeDimensions seems to be unimplemented in all classes -- just
@@ -758,11 +760,9 @@ G4ThreeVector GLG4TorusStack::SurfaceNormal(const G4ThreeVector &p) const {
     if (b[i] < 0.0)  // handle concave surface
       norm = -norm;
     if ((b[i] < 0.0) != (dr < 0.0)) {
-      std::cout.flush();
-      std::cerr << "Warning from GLG4TorusStack::SurfaceNormal: position "
+      RAT::warn << "Warning from GLG4TorusStack::SurfaceNormal: position "
                    "inconsistent with concavity\n\tb[i]="
-                << b[i] << " but a[i]=" << a[i] << " and pr=" << pr << std::endl;
-      std::cerr.flush();
+                << b[i] << " but a[i]=" << a[i] << " and pr=" << pr << newline;
     }
   }
 
@@ -1067,7 +1067,7 @@ G4double GLG4TorusStack::DistanceToOut(const G4ThreeVector &p, const G4ThreeVect
 
 #ifdef G4DEBUG
   if (dist_to_out >= kInfinity) {
-    std::cerr << "WARNING from GLG4TorusStack::DistanceToOut: "
+    RAT::debug << "WARNING from GLG4TorusStack::DistanceToOut: "
                  "did not find an intercept with the track!\n";
   }
 #endif
@@ -1103,24 +1103,20 @@ G4double GLG4TorusStack::DistanceToOut(const G4ThreeVector &p, const G4ThreeVect
           *norm = -*norm;
         *validNorm = true; /* (b[isurface] > 0.0); */
         if (dr != 0.0 && (b[isurface] < 0.0) != (dr < 0.0)) {
-          std::cout.flush();
-          std::cerr << "Warning from GLG4TorusStack::DistanceToOut (surface "
+          RAT::warn << "Warning from GLG4TorusStack::DistanceToOut (surface "
                        "normal calculation): position inconsistent with "
                        "concavity\n\tb[isurface]="
-                    << b[isurface] << " but a[isurface]=" << a[isurface] << " and pr=" << pr << std::endl;
-          std::cerr.flush();
+                    << b[isurface] << " but a[isurface]=" << a[isurface] << " and pr=" << pr << newline;
         }
       }
     }
     if ((*norm) * v <= 0.0) {
-      std::cout.flush();
-      std::cerr << "Warning from GLG4TorusStack::DistanceToOut: I have calculated "
+      G4cerr << "Warning from GLG4TorusStack::DistanceToOut: I have calculated "
                    "a normal that is antiparallel to the momentum std::vector!  I must "
                    "have done something wrong! isurface="
                 << isurface << " a[isurface]=" << a[isurface] << " b[isurface]=" << b[isurface] << " v=" << v
-                << " norm=" << (*norm) << std::endl;
+                << " norm=" << (*norm) << newline;
       *norm = -*norm;
-      std::cerr.flush();
     }
   }
 
@@ -1314,7 +1310,7 @@ GLG4PolyhedronTorusStack::GLG4PolyhedronTorusStack(const G4int n, const G4double
   //   C H E C K   I N P U T   P A R A M E T E R S
 
   if (n <= 0) {
-    std::cerr << "Error: bad parameters in GLG4PolyhedronTorusStack!" << std::endl;
+    RAT::warn << "Error: bad parameters in GLG4PolyhedronTorusStack!" << newline;
     G4Exception(__FILE__, "Invalid Parameter", FatalException, "GLG4PolyhedronTorusStack: bad parameters!");
   }
 

--- a/src/geo/src/pmt/PMTCoverageFactory.cc
+++ b/src/geo/src/pmt/PMTCoverageFactory.cc
@@ -38,7 +38,7 @@ G4VPhysicalVolume *PMTCoverageFactory::Construct(DBLinkPtr table) {
     Nphibins = int(sqrt(num_pmt * CLHEP::pi));
     Npmt = Ncosbins * Nphibins;
 
-    info << "PMTCoverageFactory: Generated " << Npmt << "PMTs" << endl;
+    info << "PMTCoverageFactory: Generated " << Npmt << "PMTs" << newline;
 
     std::vector<double> xpmt(Npmt);
     std::vector<double> ypmt(Npmt);

--- a/src/geo/src/pmt/PMTFactoryBase.cc
+++ b/src/geo/src/pmt/PMTFactoryBase.cc
@@ -105,7 +105,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table,
 
         // check if we can calculate B field effect
         if (BFieldTableName == "" || BEffiTableName == "") {
-            G4cout << "B field is on, but either B data or B PMT efficiency correction missing.\n"
+            warn << "B field is on, but either B data or B PMT efficiency correction missing." << newline
                    << "Turning B field off." << newline;
             BFieldOn = 0;
             BEffiTable = NULL;

--- a/src/geo/src/pmt/PMTInfoParser.cc
+++ b/src/geo/src/pmt/PMTInfoParser.cc
@@ -41,7 +41,7 @@ PMTInfoParser::PMTInfoParser(DBLinkPtr lpos_table, const std::string &mother_nam
         }
     }
     catch (DBNotFoundError &e) {
-        warn << "PMTInfoParser: PMTINFO does not specify direction information" << endl;
+        warn << "PMTInfoParser: PMTINFO does not specify direction information" << newline;
         fDir.resize(0);
     }
 

--- a/src/physics/include/RAT/GLG4PMTOpticalModel.hh
+++ b/src/physics/include/RAT/GLG4PMTOpticalModel.hh
@@ -63,13 +63,13 @@ class GLG4PMTOpticalModel : public G4VFastSimulationModel, public G4UImessenger 
 
   void SetEfficiencyCorrection(std::map<int, double> _EffiCorr) {
     EfficiencyCorrection = _EffiCorr;
-    G4cout << GetName() << ": Individual efficiency correction table set" << newline;
+    RAT::info << GetName() << ": Individual efficiency correction table set" << newline;
   }
   void DumpEfficiencyCorrectionTable() {
-    G4cout << "Individual correction table for the PMT efficiencies of " << GetName() << ":\nPMT ID  corr. factor" << newline;
+    RAT::info << "Individual correction table for the PMT efficiencies of " << GetName() << ":\nPMT ID  corr. factor" << newline;
     for (std::map<int, double>::iterator iter = EfficiencyCorrection.begin(); iter != EfficiencyCorrection.end();
          iter++) {
-      G4cout << iter->first << "," << iter->second << newline;
+      RAT::info << iter->first << "," << iter->second << newline;
     }
   }
   void fillPMTVector(double code, double A, double An, double T, double R, double collection_eff, double N_pe, double x,

--- a/src/physics/include/RAT/GLG4Scint.hh
+++ b/src/physics/include/RAT/GLG4Scint.hh
@@ -372,10 +372,10 @@ inline GLG4Scint::MyPhysicsTable *GLG4Scint::GetMyPhysicsTable() const { return 
 
 inline void GLG4Scint::DumpInfo() const {
   if (fMyPhysicsTable) {
-    G4cout << "GLG4Scint[" << *(fMyPhysicsTable->fName) << "] {" << newline
-           << "  fLowerMassLimit=" << fLowerMassLimit << G4endl;
+    RAT::info << "GLG4Scint[" << *(fMyPhysicsTable->fName) << "] {" << newline
+           << "  fLowerMassLimit=" << fLowerMassLimit << newline;
     if (fVerboseLevel >= 2) fMyPhysicsTable->Dump();
-    G4cout << "}" << G4endl;
+    RAT::info << "}" << newline;
   }
 }
 

--- a/src/physics/src/GLG4OpAttenuation.cc
+++ b/src/physics/src/GLG4OpAttenuation.cc
@@ -109,7 +109,7 @@ G4VParticleChange *GLG4OpAttenuation::PostStepDoIt(const G4Track &aTrack, const 
     G4double CosTheta = 4.0 * urand / (3.0 - Cos2Theta0);
 #ifdef G4DEBUG
     if (fabs(CosTheta) > 1.0) {
-      cerr << "GLG4OpAttenution: Warning, CosTheta=" << CosTheta << " urand=" << urand << endl;
+      RAT::debug << "GLG4OpAttenution: Warning, CosTheta=" << CosTheta << " urand=" << urand << newline;
       CosTheta = CosTheta > 0.0 ? 1.0 : -1.0;
     }
 #endif
@@ -130,13 +130,13 @@ G4VParticleChange *GLG4OpAttenuation::PostStepDoIt(const G4Track &aTrack, const 
 
     postStepPoint->SetProcessDefinedStep(&fgScattering);
   } else {
-    // photon absorbed (may be re-radiated... but that is GLG4Scint's job)
-    aParticleChange.ProposeTrackStatus(fStopAndKill);
-    postStepPoint->SetProcessDefinedStep(&fgAttenuation);
+      // photon absorbed (may be re-radiated... but that is GLG4Scint's job)
+      aParticleChange.ProposeTrackStatus(fStopAndKill);
+      postStepPoint->SetProcessDefinedStep(&fgAttenuation);
 
-    if (verboseLevel > 0) {
-      G4cout << "\n** Photon absorbed! **" << G4endl;
-    }
+      if (verboseLevel > 0) {
+        RAT::debug << "\n** Photon absorbed! **" << newline;
+      }
   }
 
   return G4VDiscreteProcess::PostStepDoIt(aTrack, aStep);

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -280,7 +280,6 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
 
     // print verbose info
     if (_verbosity > 0) {
-        G4cout.flush();
         G4cout << "> Enter GLG4PMTOpticalModel, ipmt=" << ipmt << (whereAmI == kInVacuum ? " vacuum" : " glass")
             << ", pos=" << pos << ", dir=" << dir << ", weight=" << weight << ", pol=" << pol
             << ", energy=" << _photon_energy << ", wavelength=" << _wavelength << ", (n1,n3,n2,k2,efficiency)=(" << _n1
@@ -321,8 +320,8 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
             // advance to next interface
             dist = _inner1_solid->DistanceToOut(pos, dir);
             if (dist < 0.0) {
-                G4cerr << "GLG4PMTOpticalModel::DoIt(): "
-                    << "Warning, strangeness detected! inner1->DistanceToOut()=" << dist << G4endl;
+                RAT::warn << "GLG4PMTOpticalModel::DoIt(): "
+                    << "Warning, strangeness detected! inner1->DistanceToOut()=" << dist << newline;
                 dist = 0.0;
             }
             pos += dist * dir;
@@ -335,7 +334,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
         }
 
         if (_verbosity >= 2) {
-            G4cout << " " << iloop << " dist=" << dist << " newpos=" << pos << G4endl;
+            G4cout << " " << iloop << " dist=" << dist << " newpos=" << pos << newline;
         }
 
         // get outward-pointing normal in local coordinates at this position
@@ -352,9 +351,9 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
 #ifdef G4DEBUG
             G4cerr << "GLG4PMTOpticalModel::DoIt(): "
                 << " The normal points the wrong way!" << newline
-                << "  norm: " << norm << G4endl << "  dir:  " << dir << G4endl << "  _cos_theta1:  " << _cos_theta1
-                << G4endl << "  pos:  " << pos << G4endl << "  whereAmI:  " << (int)(whereAmI) << G4endl
-                << " Reversing normal!" << G4endl;
+                << "  norm: " << norm << newline << "  dir:  " << dir << newline << "  _cos_theta1:  " << _cos_theta1
+                << newline << "  pos:  " << pos << newline << "  whereAmI:  " << (int)(whereAmI) << newline
+                << " Reversing normal!" << newline;
 #endif
             _cos_theta1 = -_cos_theta1;
             norm = -norm;
@@ -382,10 +381,10 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
 
 #ifdef G4DEBUG
         if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || collection_eff > 1.0) {
-            G4cerr << "GLG4PMTOpticalModel::DoIt(): Strange coefficients!" << newline;
-            G4cout << "T, R, A, An, weight: " << T << " " << R << " " << A << " " << An << " " << weight << G4endl;
-            G4cout << "collection eff, std QE: " << collection_eff << " " << _efficiency << G4endl;
-            G4cout << "=========================================================" << G4endl;
+            RAT::debug << "GLG4PMTOpticalModel::DoIt(): Strange coefficients!" << newline;
+            RAT::debug << "T, R, A, An, weight: " << T << " " << R << " " << A << " " << An << " " << weight << newline;
+            RAT::debug << "collection eff, std QE: " << collection_eff << " " << _efficiency << newline;
+            RAT::debug << "=========================================================" << newline;
             A = collection_eff = 0.5;  // safe values???
         }
 #endif
@@ -406,7 +405,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
                 mean_N_pe *= EfficiencyCorrection[ipmt];
             }
             else {
-                G4cout << "GLG4PMTOpticalModel[" << GetName() << "] warning: individual efficiency correction for PMT " << ipmt
+                RAT::warn << "GLG4PMTOpticalModel[" << GetName() << "] warning: individual efficiency correction for PMT " << ipmt
                     << " is " << EfficiencyCorrection[ipmt] << ", resetting to 1" << newline;
                 EfficiencyCorrection[ipmt] = 1.0;
             }
@@ -449,7 +448,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
                     break;
                 }
                 if (_verbosity >= 2) {
-                    G4cout << "GLG4PMTOpticalModel made " << N_pe << " pe" << newline;
+                    RAT::debug << "GLG4PMTOpticalModel made " << N_pe << " pe" << newline;
                 }
             }
         }
@@ -470,7 +469,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
         if (ranno_absorb < A) {
             weight = 0;
             if (_verbosity >= 2) {
-                G4cout << "GLG4PMTOpticalModel absorbed track" << newline;
+                RAT::debug << "GLG4PMTOpticalModel absorbed track" << newline;
             }
             break;
         }
@@ -479,7 +478,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
         if (G4UniformRand() < R / (R + T)) {  // reflect
             Reflect(dir, pol, norm);
             if (_verbosity >= 2) {
-                G4cout << "GLG4PMTOpticalModel reflects track" << newline;
+                RAT::debug << "GLG4PMTOpticalModel reflects track" << newline;
             }
         }
         else {  // transmit
@@ -492,7 +491,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
             }
 
             if (_verbosity >= 2) {
-                G4cout << "GLG4PMTOpticalModel transmits track, now in " << (whereAmI == kInVacuum ? " vacuum" : " glass") << G4endl;
+                RAT::debug << "GLG4PMTOpticalModel transmits track, now in " << (whereAmI == kInVacuum ? " vacuum" : " glass") << newline;
             }
         }
     }
@@ -505,7 +504,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     if (weight <= 0) {
         fastStep.ProposeTrackStatus(fStopAndKill);
         if (weight < 0) {
-            G4cerr << "GLG4PMTOpticalModel::DoIt(): Logic error, weight = " << weight << G4endl;
+            RAT::warn << "GLG4PMTOpticalModel::DoIt(): Logic error, weight = " << weight << newline;
         }
     }
     else {
@@ -514,12 +513,11 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     }
 
     if (iloop >= max_iloop) {
-        G4cerr << "GLG4PMTOpticalModel::DoIt(): Too many loops, particle trapped! Killing it." << G4endl;
+        RAT::warn << "GLG4PMTOpticalModel::DoIt(): Too many loops, particle trapped! Killing it." << newline;
         fastStep.ProposeTrackStatus(fStopAndKill);
     }
 
     if (_verbosity > 0) {
-        G4cout.flush();
         G4cout << "> Exit GLG4PMTOpticalModel, ipmt=" << ipmt << (whereAmI == kInVacuum ? " vacuum" : " glass")
             << ", pos=" << pos << ", dir=" << dir << ", weight=" << weight << ", pol=" << pol << ", iloop=" << iloop
             << newline;
@@ -655,11 +653,11 @@ void GLG4PMTOpticalModel::CalculateCoefficients()
 
 #ifdef G4DEBUG
     if (_verbosity >= 10) {
-        G4cout << "=> lam, n1, n2: " << _wavelength / nanometer << " " << _n1 << " " << _n2comp << G4endl;
-        G4cout << "=> Angles: " << real(theta1) / degree << " " << theta2 / degree << " " << theta3 / degree << G4endl;
-        G4cout << "Rper, Rpar, Tper, Tpar: " << fR_s << " " << fR_p << " " << fT_s << " " << fT_p;
-        G4cout << "\nRn, Tn : " << fR_n << " " << fT_n;
-        G4cout << "\n-------------------------------------------------------" << G4endl;
+        RAT::debug << "=> lam, n1, n2: " << _wavelength / nanometer << " " << _n1 << " " << _n2comp << newline;
+        RAT::debug << "=> Angles: " << real(theta1) / degree << " " << theta2 / degree << " " << theta3 / degree << newline;
+        RAT::debug << "Rper, Rpar, Tper, Tpar: " << fR_s << " " << fR_p << " " << fT_s << " " << fT_p;
+        RAT::debug << "\nRn, Tn : " << fR_n << " " << fT_n;
+        RAT::debug << "\n-------------------------------------------------------" << newline;
     }
 #endif
 }
@@ -711,7 +709,7 @@ void GLG4PMTOpticalModel::SetNewValue(G4UIcommand *command, G4String newValues) 
         DumpEfficiencyCorrectionTable();
     }
     else {
-        G4cerr << "No PMTOpticalModel command named " << commandName << G4endl;
+        RAT::warn << "No PMTOpticalModel command named " << commandName << newline;
     }
     return;
 }

--- a/src/util/src/MultiChargeDist.cc
+++ b/src/util/src/MultiChargeDist.cc
@@ -209,7 +209,7 @@ std::vector<TGraph *> MultiChargeDist(int maxPE, double qMaxStepSize, int qBins,
   if (inorm > 0)
     warn << "WARNING--Charge PDFs " << inorm << " to " << maxPE
          << " are biased by more than 1%.  Increase number of bins"
-         << " and/or decrease the maximum bin size to reduce the bias." << endl;
+         << " and/or decrease the maximum bin size to reduce the bias." << newline;
 
   return chargeDistInterp;
 }


### PR DESCRIPTION
This is a follow up to PR #62 that continues to pull out uses of std::cout/cerr and G4cout/cerr in favor of the RAT Log functionality. There's still a few edge cases remaining due to particularities with Geant4 classes and operator overloading, but this PR covers most of what was left besides that and some cases where the ostream seemed to be actually passed around that I didn't want to reengineer.