### PR TITLE
Geant4 + CMake update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ include(${ROOT_USE_FILE})
 
 find_package(Geant4 REQUIRED COMPONENTS qt)
 include(${Geant4_USE_FILE})
+include_directories(${Geant4_INCLUDE_DIRS})
 
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
Geant4 include directories no longer enabled by default with cmake:find_package