### PR TITLE
Calibration stick fix

### DIFF
--- a/src/geo/src/GeoCalibrationStickFactory.cc
+++ b/src/geo/src/GeoCalibrationStickFactory.cc
@@ -82,11 +82,11 @@ G4VPhysicalVolume *GeoCalibrationStickFactory::Construct(DBLinkPtr table) {
   G4VPhysicalVolume *bottomPhys =
       new G4PVPlacement(rotation, position - G4ThreeVector(0, 0, (stickLength + bottomThickness) / 2.0),
                         "CalibrationStick_Bottom", bottomLog, motherPhys, false, 0);
+  G4VPhysicalVolume *gasPhys =
+      new G4PVPlacement(rotation, position, "CalibrationStick_Gas", gasLog, motherPhys, false, 0);
   G4VPhysicalVolume *sourcePhys =
       new G4PVPlacement(rotation, position - G4ThreeVector(0, 0, (stickLength / 2.0) - sourcePosition),
                         "CalibrationStick_Source", sourceLog, motherPhys, false, 0);
-  G4VPhysicalVolume *gasPhys =
-      new G4PVPlacement(rotation, position, "CalibrationStick_Gas", gasLog, motherPhys, false, 0);
 
   // Set visuals
   SetVis(stickLog, table->GetDArray("stick_color"));


### PR DESCRIPTION
Due to the order of placement of volumes, it seems like the properties of the source volume were not actually being used by Geant4. This was causing some issues for the BNL 1T simulation.