### PR TITLE
Formatting changes

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -1,0 +1,14 @@
+name: clang-format Check
+on: [push, pull_request, workflow_dispatch]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format style check for C/C++/Protobuf programs.
+      uses: jidicula/clang-format-action@v4.11.0
+      with:
+        clang-format-version: '17'
+        check-path: 'src'
+        fallback-style: 'Google'

--- a/cformat.sh
+++ b/cformat.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 
+if command -v clang-format &>/dev/null; then
+    echo "clang-format is installed."
+else
+    echo "clang-format is not installed. Formatting rules won't be auto applied upon commit."
+    echo "Consider installing clang-format to ensure consistent formatting across the project, especially if you \
+plan to contribute."
+    exit 1
+fi
+
 echo "Checking formatting..."
 changes=0
-for file in `find ./src \( -name "*.cc" -o -name "*.hh" -o -name "*.icc" -o -name "*.cpp" -o -name "*.hpp" \)`;
-do
-    retval=`clang-format -style=file -n -Werror $file`
+for file in $(find ./src \( -name "*.cc" -o -name "*.hh" -o -name "*.icc" -o -name "*.cpp" -o -name "*.hpp" \)); do
+    retval=$(clang-format -style=file -n -Werror $file)
     if [ $? -eq 1 ]; then
         echo "Formatting $file"
         clang-format -style=file -i $file

--- a/cformat.sh
+++ b/cformat.sh
@@ -2,7 +2,7 @@
 
 echo "Checking formatting..."
 changes=0
-for file in `find ./src \( -name "*.cc" -o -name "*.hh" -o -name "*.icc" -o -name "*.cpp" \)`;
+for file in `find ./src \( -name "*.cc" -o -name "*.hh" -o -name "*.icc" -o -name "*.cpp" -o -name "*.hpp" \)`;
 do
     retval=`clang-format -style=file -n -Werror $file`
     if [ $? -eq 1 ]; then

--- a/src/stlplus/include/RAT/clonable.hpp
+++ b/src/stlplus/include/RAT/clonable.hpp
@@ -9,7 +9,7 @@
   This abstract class defines the clonable interface
 
   The clonable interface is used by smart_ptr_clone and by the persistence
-  functions for polymorphic types. 
+  functions for polymorphic types.
 
   If you make any class a subclass of clonable, then you must provide a
   clone() method with the type profile specified here. This method must copy
@@ -21,9 +21,8 @@
 
   ------------------------------------------------------------------------------*/
 
-class clonable
-{
-public:
+class clonable {
+ public:
   virtual clonable* clone(void) const = 0;
 };
 

--- a/src/stlplus/include/RAT/debug.hpp
+++ b/src/stlplus/include/RAT/debug.hpp
@@ -10,18 +10,19 @@
   NDEBUG compiler directive
 
   ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include "exceptions.hpp"
 #include <assert.h>
 #include <stdio.h>
+
 #include <string>
+
+#include "exceptions.hpp"
+#include "os_fixes.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Exception thrown if an assertion fails
 
-class assert_failed : public std::logic_error
-{
-public:
+class assert_failed : public std::logic_error {
+ public:
   assert_failed(const char* file, int line, const char* function, const std::string& message) throw();
   ~assert_failed(void) throw();
 };
@@ -31,17 +32,24 @@ public:
 
 #ifndef NDEBUG
 
-#define DEBUG_TRACE _debug_trace _debug_trace_(__FILE__,__LINE__,__FUNCTION__)
-#define IF_DEBUG(stmts) {if (_debug_trace_.debug()){_debug_trace_.prefix(__LINE__);stmts;}}
-#define DEBUG_REPORT(str) IF_DEBUG(_debug_trace_.report(__LINE__,str))
-#define DEBUG_ERROR(str) _debug_trace_.error(__LINE__,str)
-#define DEBUG_STACKDUMP(str) _debug_trace_.stackdump(__LINE__,str)
-#define DEBUG_ON _debug_trace_.debug_on(__LINE__,true)
-#define DEBUG_ON_LOCAL _debug_trace_.debug_on(__LINE__,false)
-#define DEBUG_ON_GLOBAL _debug_global(__FILE__,__LINE__,__FUNCTION__,true)
-#define DEBUG_OFF_GLOBAL _debug_global(__FILE__,__LINE__,__FUNCTION__,false)
+#define DEBUG_TRACE _debug_trace _debug_trace_(__FILE__, __LINE__, __FUNCTION__)
+#define IF_DEBUG(stmts)               \
+  {                                   \
+    if (_debug_trace_.debug()) {      \
+      _debug_trace_.prefix(__LINE__); \
+      stmts;                          \
+    }                                 \
+  }
+#define DEBUG_REPORT(str) IF_DEBUG(_debug_trace_.report(__LINE__, str))
+#define DEBUG_ERROR(str) _debug_trace_.error(__LINE__, str)
+#define DEBUG_STACKDUMP(str) _debug_trace_.stackdump(__LINE__, str)
+#define DEBUG_ON _debug_trace_.debug_on(__LINE__, true)
+#define DEBUG_ON_LOCAL _debug_trace_.debug_on(__LINE__, false)
+#define DEBUG_ON_GLOBAL _debug_global(__FILE__, __LINE__, __FUNCTION__, true)
+#define DEBUG_OFF_GLOBAL _debug_global(__FILE__, __LINE__, __FUNCTION__, false)
 #define DEBUG_OFF _debug_trace_.debug_off(__LINE__)
-#define DEBUG_ASSERT(test) if (!(test))_debug_assert_fail(__FILE__,__LINE__,__FUNCTION__,#test)
+#define DEBUG_ASSERT(test) \
+  if (!(test)) _debug_assert_fail(__FILE__, __LINE__, __FUNCTION__, #test)
 
 #else
 
@@ -65,9 +73,8 @@ public:
 void _debug_global(const char* file, int line, const char* function, bool state = true);
 void _debug_assert_fail(const char* file, int line, const char* function, const char* test) throw();
 
-class _debug_trace
-{
-public:
+class _debug_trace {
+ public:
   _debug_trace(const char* f, int l, const char* fn);
   ~_debug_trace(void);
   const char* file(void) const;
@@ -84,7 +91,7 @@ public:
   void stackdump(const std::string& message) const;
   void stackdump(void) const;
 
-private:
+ private:
   const char* m_file;
   int m_line;
   const char* m_function;
@@ -97,7 +104,7 @@ private:
 
   // make this class uncopyable
   _debug_trace(const _debug_trace&);
-  _debug_trace& operator = (const _debug_trace&);
+  _debug_trace& operator=(const _debug_trace&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/stlplus/include/RAT/dprintf.hpp
+++ b/src/stlplus/include/RAT/dprintf.hpp
@@ -62,7 +62,7 @@ The result supports the following "C" format codes:
    h    - short or unsigned short
    l    - long or unsigned long
    L    - long double
-   
+
  conversions:
    d, i - short/int/long as decimal
    u    - short/int/long as unsigned decimal
@@ -78,14 +78,16 @@ The result supports the following "C" format codes:
    n    - int* as recipient of length of formatted string so far
 
 ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include <string>
 #include <stdarg.h>
-#include <cstring>
-int dprintf (std::string& formatted, const char* format, ...);
-int vdprintf (std::string& formatted, const char* format, va_list args);
 
-std::string dformat (const char* format, ...);
-std::string vdformat (const char* format, va_list);
+#include <cstring>
+#include <string>
+
+#include "os_fixes.hpp"
+int dprintf(std::string& formatted, const char* format, ...);
+int vdprintf(std::string& formatted, const char* format, va_list args);
+
+std::string dformat(const char* format, ...);
+std::string vdformat(const char* format, va_list);
 
 #endif

--- a/src/stlplus/include/RAT/exceptions.hpp
+++ b/src/stlplus/include/RAT/exceptions.hpp
@@ -9,15 +9,15 @@
   The set of general exceptions thrown by STLplus components
 
   ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
 #include <stdexcept>
+
+#include "os_fixes.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Thrown if a pointer or an iterator is dereferenced when it is null
 
-class null_dereference : public std::logic_error
-{
-public:
+class null_dereference : public std::logic_error {
+ public:
   null_dereference(const std::string& description) throw();
   ~null_dereference(void) throw();
 };
@@ -25,9 +25,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // Thrown if an iterator is dereferenced when it is pointing to the end element
 
-class end_dereference : public std::logic_error
-{
-public:
+class end_dereference : public std::logic_error {
+ public:
   end_dereference(const std::string& description) throw();
   ~end_dereference(void) throw();
 };
@@ -38,9 +37,8 @@ public:
 // that iterator is then used with a different container, this exception is
 // thrown.
 
-class wrong_object : public std::logic_error
-{
-public:
+class wrong_object : public std::logic_error {
+ public:
   wrong_object(const std::string& description) throw();
   ~wrong_object(void) throw();
 };

--- a/src/stlplus/include/RAT/file_system.hpp
+++ b/src/stlplus/include/RAT/file_system.hpp
@@ -13,10 +13,12 @@
   to port all file handling.
 
 ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
+#include <time.h>
+
 #include <string>
 #include <vector>
-#include <time.h>
+
+#include "os_fixes.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // classifying functions
@@ -33,9 +35,9 @@ bool file_readable(const std::string& filespec);
 bool file_writable(const std::string& filespec);
 size_t file_size(const std::string& filespec);
 bool file_delete(const std::string& filespec);
-bool file_rename (const std::string& old_filespec, const std::string& new_filespec);
-bool file_move (const std::string& old_filespec, const std::string& new_filespec);
-bool file_copy (const std::string& old_filespec, const std::string& new_filespec);
+bool file_rename(const std::string& old_filespec, const std::string& new_filespec);
+bool file_move(const std::string& old_filespec, const std::string& new_filespec);
+bool file_copy(const std::string& old_filespec, const std::string& new_filespec);
 
 // Read-only versus read-write control. This is equivalent to chmod on Unix,
 // but I've insulated the user from the low-level routine because of
@@ -91,7 +93,7 @@ bool folder_exists(const std::string& folder);
 bool folder_readable(const std::string& folder);
 bool folder_writable(const std::string& folder);
 bool folder_delete(const std::string& folder, bool recurse = false);
-bool folder_rename (const std::string& old_directory, const std::string& new_directory);
+bool folder_rename(const std::string& old_directory, const std::string& new_directory);
 bool folder_empty(const std::string& folder);
 
 bool folder_set_current(const std::string& folder);
@@ -104,7 +106,8 @@ std::string folder_up(const std::string& folder, unsigned levels = 1);
 std::vector<std::string> folder_subdirectories(const std::string& folder);
 std::vector<std::string> folder_files(const std::string& folder);
 std::vector<std::string> folder_all(const std::string& folder);
-std::vector<std::string> folder_wildcard(const std::string& folder, const std::string& wildcard, bool subdirs = true, bool files = true);
+std::vector<std::string> folder_wildcard(const std::string& folder, const std::string& wildcard, bool subdirs = true,
+                                         bool files = true);
 
 ////////////////////////////////////////////////////////////////////////////////
 // path functions
@@ -155,13 +158,13 @@ std::vector<std::string> filespec_elements(const std::string& filespec);
 // The lookup normally carried out by the shell to find a command in a
 // directory in the PATH. Give this function the name of a command and it
 // will return the full path. It returns an empty string on failure.
-std::string path_lookup (const std::string& command);
+std::string path_lookup(const std::string& command);
 
 // Generalised form of the above, takes a second argument
 // - the list to search. This can be used to do other path lookups,
 // such as LD_LIBRARY_PATH. The third argument specifies the splitter -
 // the default value of PATH_SPLITTER is appropriate for environment variables.
-std::string lookup (const std::string& file, const std::string& path, const std::string& splitter = PATH_SPLITTER);
+std::string lookup(const std::string& file, const std::string& path, const std::string& splitter = PATH_SPLITTER);
 
 // utility function for finding the folder that contains the current executable
 // the argument is the argv[0] parameter passed to main

--- a/src/stlplus/include/RAT/fileio.hpp
+++ b/src/stlplus/include/RAT/fileio.hpp
@@ -9,140 +9,120 @@
   TextIO classes customised to use C stdio FILE*
 
 ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include "textio.hpp"
 #include <stddef.h>
 #include <stdio.h>
+
 #include <cstring>
+
+#include "os_fixes.hpp"
+#include "textio.hpp"
 ////////////////////////////////////////////////////////////////////////////////
 // Output Files
 
-class oftext : public otext
-{
-public:
+class oftext : public otext {
+ public:
   static size_t preferred_buffer;
 
   // create an uninitialised device which acts like /dev/null
-  oftext (void);
+  oftext(void);
   // attach an already-opened file to this device
   // this will not be closed when the device is destroyed
-  // Note: on Windoze, already-open files such as stdout/err are treated as Unix mode because Windoze does eoln conversion
-  oftext (FILE* handle,
-          bool line_buffer = false);
+  // Note: on Windoze, already-open files such as stdout/err are treated as Unix mode because Windoze does eoln
+  // conversion
+  oftext(FILE* handle, bool line_buffer = false);
   // open the file and attach it to this device
   // this will be closed automatically when the device is destroyed
-  oftext (const char* filename,
-          size_t bufsize = preferred_buffer,
-          open_t mode = overwrite,
-          bool line_buffer = false);
-  oftext (const std::string& filename,
-          size_t bufsize = preferred_buffer,
-          open_t mode = overwrite,
-          bool line_buffer = false);
+  oftext(const char* filename, size_t bufsize = preferred_buffer, open_t mode = overwrite, bool line_buffer = false);
+  oftext(const std::string& filename, size_t bufsize = preferred_buffer, open_t mode = overwrite,
+         bool line_buffer = false);
 
   // similar to the constructors - these destroy the previous device contents (closing if appropriate)
   // then perform the open/attach as above
-  void open (FILE* handle,
-             bool line_buffer = false);
-  void open (const char* filename,
-             size_t bufsize = preferred_buffer,
-             open_t mode = overwrite,
-             bool line_buffer = false);
-  void open (const std::string& filename,
-             size_t bufsize = preferred_buffer,
-             open_t mode = overwrite,
-             bool line_buffer = false);
+  void open(FILE* handle, bool line_buffer = false);
+  void open(const char* filename, size_t bufsize = preferred_buffer, open_t mode = overwrite, bool line_buffer = false);
+  void open(const std::string& filename, size_t bufsize = preferred_buffer, open_t mode = overwrite,
+            bool line_buffer = false);
 
   // get at the internal handle
   // note that the handle and this device are guaranteed to be synchronised!
-  operator FILE* (void);
+  operator FILE*(void);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 // Input Files
 
-class iftext : public itext
-{
-public:
+class iftext : public itext {
+ public:
   static size_t preferred_buffer;
 
   // create an uninitialised device which acts like /dev/null
-  iftext (void);
+  iftext(void);
   // attach an already-opened file to this device
   // this will not be closed when the device is destroyed
-  iftext (FILE* handle);
+  iftext(FILE* handle);
   // open the file and attach it to this device
   // this will be closed automatically when the device is destroyed
-  iftext (const char* filename, size_t bufsize = preferred_buffer);
-  iftext (const std::string& filename, size_t bufsize = preferred_buffer);
+  iftext(const char* filename, size_t bufsize = preferred_buffer);
+  iftext(const std::string& filename, size_t bufsize = preferred_buffer);
 
   // similar to the constructors - these destroy the previous device contents (closing if appropriate)
   // then perform the open/attach as above
-  void open (FILE* handle);
-  void open (const char* filename,
-             size_t bufsize = preferred_buffer);
-  void open (const std::string& filename,
-             size_t bufsize = preferred_buffer);
+  void open(FILE* handle);
+  void open(const char* filename, size_t bufsize = preferred_buffer);
+  void open(const std::string& filename, size_t bufsize = preferred_buffer);
 
   // get at the internal handle
   // note that the handle and this device are guaranteed to be synchronised!
-  operator FILE* (void);
+  operator FILE*(void);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 // Internal buffers
 
-class ofbuff : public obuff
-{
+class ofbuff : public obuff {
   friend class oftext;
-public:
-  ofbuff (FILE* handle,
-          bool line_buffer);
-  ofbuff (const char* filename,
-          size_t bufsize,
-          otext::open_t mode,
-          bool line_buffer);
-  ofbuff (const std::string& filename,
-          size_t bufsize,
-          otext::open_t mode,
-          bool line_buffer);
+
+ public:
+  ofbuff(FILE* handle, bool line_buffer);
+  ofbuff(const char* filename, size_t bufsize, otext::open_t mode, bool line_buffer);
+  ofbuff(const std::string& filename, size_t bufsize, otext::open_t mode, bool line_buffer);
   virtual ~ofbuff(void);
 
   void open(const std::string& fname, size_t bufsize, otext::open_t mode, bool line_buffer);
-  virtual void flush (void);
-  virtual unsigned put (unsigned char);
+  virtual void flush(void);
+  virtual unsigned put(unsigned char);
   virtual std::string error_string(void) const;
 
-private:
+ private:
   bool m_managed;
   FILE* m_handle;
 
   // make this class uncopyable
   ofbuff(const ofbuff&);
-  ofbuff& operator = (const ofbuff&);
+  ofbuff& operator=(const ofbuff&);
 };
 
-class ifbuff : public ibuff
-{
+class ifbuff : public ibuff {
   friend class iftext;
-public:
-  ifbuff (FILE*);
-  ifbuff (const char*, size_t bufsize = iftext::preferred_buffer);
-  ifbuff (const std::string&, size_t bufsize = iftext::preferred_buffer);
+
+ public:
+  ifbuff(FILE*);
+  ifbuff(const char*, size_t bufsize = iftext::preferred_buffer);
+  ifbuff(const std::string&, size_t bufsize = iftext::preferred_buffer);
   virtual ~ifbuff(void);
 
   void open(const std::string& filename, size_t bufsize);
-  virtual int peek (void);
-  virtual int get (void);
+  virtual int peek(void);
+  virtual int get(void);
   virtual std::string error_string(void) const;
 
-private:
+ private:
   bool m_managed;
   FILE* m_handle;
 
   // make this class uncopyable
   ifbuff(const ifbuff&);
-  ifbuff& operator = (const ifbuff&);
+  ifbuff& operator=(const ifbuff&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/stlplus/include/RAT/format_types.hpp
+++ b/src/stlplus/include/RAT/format_types.hpp
@@ -12,16 +12,16 @@
 // Integer radix display representations:
 //   There are three ways in which the radix is represented:
 //     - none - the number is just printed as a number (e.g. 12345). Can be confusing for non-decimal radix
-//     - C style - for binary, octal and hex, the C-style prefices 0b, 0 and 0x are used - note that this is an unsigned representation
+//     - C style - for binary, octal and hex, the C-style prefices 0b, 0 and 0x are used - note that this is an unsigned
+//     representation
 //     - Hash style - in the form radix#value - the value may be signed, e.g. 10#-9
 
-enum radix_display_t 
-{
-  radix_none,               // just print the number with no radix indicated
-  radix_hash_style,         // none for decimal, hash style for all others
-  radix_hash_style_all,     // hash style for all radices including decimal
-  radix_c_style,            // C style for hex and octal, none for others
-  radix_c_style_or_hash     // C style for hex and octal, none for decimal, hash style for others
+enum radix_display_t {
+  radix_none,            // just print the number with no radix indicated
+  radix_hash_style,      // none for decimal, hash style for all others
+  radix_hash_style_all,  // hash style for all radices including decimal
+  radix_c_style,         // C style for hex and octal, none for others
+  radix_c_style_or_hash  // C style for hex and octal, none for decimal, hash style for others
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -29,13 +29,13 @@ enum radix_display_t
 // There are three formats for the printout:
 //   - fixed - formatted as a fixed-point number, so no mantissa is printed (equivalent to %f in printf)
 //   - floating - formatted as a normalised floating-point number (equivalent to %e in printf)
-//   - mixed - formatted as fixed-point if this is appropriate, otherwise the floating format (equivalent to %g in printf)
+//   - mixed - formatted as fixed-point if this is appropriate, otherwise the floating format (equivalent to %g in
+//   printf)
 
-enum real_display_t
-{
-  display_fixed,    // %f
-  display_floating, // %e
-  display_mixed     // %g
+enum real_display_t {
+  display_fixed,     // %f
+  display_floating,  // %e
+  display_mixed      // %g
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -45,12 +45,7 @@ enum real_display_t
 //     - right aligned - the value is to the right of the field which is padded to the left with spaces
 //     - centred - the value is in the centre of the field and spaces added to both left and right
 
-enum alignment_t
-{
-  align_left,
-  align_right,
-  align_centre
-};
+enum alignment_t { align_left, align_right, align_centre };
 
 ////////////////////////////////////////////////////////////////////////////////
 #endif

--- a/src/stlplus/include/RAT/hash.hpp
+++ b/src/stlplus/include/RAT/hash.hpp
@@ -9,36 +9,38 @@
   A chained hash table using STL semantics
 
 ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include "textio.hpp"
-#include "persistent.hpp"
-#include "exceptions.hpp"
 #include <map>
+
+#include "exceptions.hpp"
+#include "os_fixes.hpp"
+#include "persistent.hpp"
+#include "textio.hpp"
 
 namespace stlplus {
 ////////////////////////////////////////////////////////////////////////////////
 // internals
 
-template<typename K, typename T, class H, class E> class hash;
-template<typename K, typename T> class hash_element;
+template <typename K, typename T, class H, class E>
+class hash;
+template <typename K, typename T>
+class hash_element;
 
 ////////////////////////////////////////////////////////////////////////////////
 // iterator class
 
-template<typename K, typename T, class H, class E, typename V>
-class hash_iterator
-{
-public:
-  friend class hash<K,T,H,E>;
+template <typename K, typename T, class H, class E, typename V>
+class hash_iterator {
+ public:
+  friend class hash<K, T, H, E>;
 
   // local type definitions
   // an iterator points to a value whilst a const_iterator points to a const value
-  typedef V                                                  value_type;
-  typedef hash_iterator<K,T,H,E,std::pair<const K,T> >       iterator;
-  typedef hash_iterator<K,T,H,E,const std::pair<const K,T> > const_iterator;
-  typedef hash_iterator<K,T,H,E,V>                           this_iterator;
-  typedef V&                                                 reference;
-  typedef V*                                                 pointer;
+  typedef V value_type;
+  typedef hash_iterator<K, T, H, E, std::pair<const K, T> > iterator;
+  typedef hash_iterator<K, T, H, E, const std::pair<const K, T> > const_iterator;
+  typedef hash_iterator<K, T, H, E, V> this_iterator;
+  typedef V& reference;
+  typedef V* pointer;
 
   // constructor to create a null iterator - you must assign a valid value to this iterator before using it
   // any attempt to dereference or use a null iterator is an error
@@ -59,7 +61,7 @@ public:
 
   // get the hash container that created this iterator
   // a null iterator doesn't have an owner so returns a null pointer
-  const hash<K,T,H,E>* owner(void) const;
+  const hash<K, T, H, E>* owner(void) const;
 
   // Type conversion methods allow const_iterator and iterator to be converted
   // convert an iterator/const_iterator to a const_iterator
@@ -71,49 +73,40 @@ public:
   // it is only legal to increment a valid iterator
   // there's no decrement - I've only implemented this as a unidirectional iterator
   // pre-increment
-  this_iterator& operator ++ (void)
-    throw();
+  this_iterator& operator++(void) throw();
   // post-increment
-  this_iterator operator ++ (int)
-    throw();
+  this_iterator operator++(int) throw();
 
   // tests useful for putting iterators into other STL structures and for testing whether iteration has completed
-  bool operator == (const this_iterator& r) const;
-  bool operator != (const this_iterator& r) const;
-  bool operator < (const this_iterator& r) const;
+  bool operator==(const this_iterator& r) const;
+  bool operator!=(const this_iterator& r) const;
+  bool operator<(const this_iterator& r) const;
 
   // access the value - a const_iterator gives you a const value, an iterator a non-const value
   // it is illegal to dereference an invalid (i.e. null or end) iterator
-  reference operator*(void) const
-    throw();
-  pointer operator->(void) const
-    throw();
+  reference operator*(void) const throw();
+  pointer operator->(void) const throw();
 
   // Note: hash iterators are not persistent for a good reason: they are
   // invalidated by rehashing and so it is not a good idea to build data
   // structures containing hash iterators in the first place
 
-private:
-  friend class hash_element<K,T>;
+ private:
+  friend class hash_element<K, T>;
 
-  const hash<K,T,H,E>* m_owner;
+  const hash<K, T, H, E>* m_owner;
   unsigned m_bin;
-  hash_element<K,T>* m_element;
+  hash_element<K, T>* m_element;
 
-  void check_owner(const hash<K,T,H,E>* owner) const
-    throw();
-  void check_non_null(void) const
-    throw();
-  void check_non_end(void) const
-    throw();
-  void check_valid(void) const
-    throw();
-  void check(const hash<K,T,H,E>* owner) const
-    throw();
+  void check_owner(const hash<K, T, H, E>* owner) const throw();
+  void check_non_null(void) const throw();
+  void check_non_end(void) const throw();
+  void check_valid(void) const throw();
+  void check(const hash<K, T, H, E>* owner) const throw();
 
   // constructor used by hash to create a non-null iterator
   // you cannot create a valid iterator except by calling a hash method that returns one
-  hash_iterator(const hash<K,T,H,E>* owner, unsigned bin, hash_element<K,T>* element);
+  hash_iterator(const hash<K, T, H, E>* owner, unsigned bin, hash_element<K, T>* element);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -123,17 +116,16 @@ private:
 // H = hash function object with the profile 'unsigned H(const K&)'
 // E = equal function object with the profile 'bool E(const K&, const K&)' defaults to equal_to which in turn calls '=='
 
-template<typename K, typename T, class H, class E = std::equal_to<K> >
-class hash
-{
-public:
-  typedef unsigned                                size_type;
-  typedef K                                       key_type;
-  typedef T                                       data_type;
-  typedef T                                       mapped_type;
-  typedef std::pair<const K, T>                   value_type;
-  typedef hash_iterator<K,T,H,E,value_type>       iterator;
-  typedef hash_iterator<K,T,H,E,const value_type> const_iterator;
+template <typename K, typename T, class H, class E = std::equal_to<K> >
+class hash {
+ public:
+  typedef unsigned size_type;
+  typedef K key_type;
+  typedef T data_type;
+  typedef T mapped_type;
+  typedef std::pair<const K, T> value_type;
+  typedef hash_iterator<K, T, H, E, value_type> iterator;
+  typedef hash_iterator<K, T, H, E, const value_type> const_iterator;
 
   // construct a hash table with specified number of bins
   // the default 0 bins means leave it to the table to decide
@@ -143,15 +135,16 @@ public:
 
   // copy and equality copy the data elements but not the size of the copied table
   hash(const hash&);
-  hash& operator = (const hash&);
+  hash& operator=(const hash&);
 
-  // test for an empty table and for the size of a table - efficient because the size is stored separately from the table contents
+  // test for an empty table and for the size of a table - efficient because the size is stored separately from the
+  // table contents
   bool empty(void) const;
   unsigned size(void) const;
 
   // test for equality - two hashes are equal if they contain equal values
-  bool operator == (const hash&) const;
-  bool operator != (const hash&) const;
+  bool operator==(const hash&) const;
+  bool operator!=(const hash&) const;
 
   // switch auto-rehash on
   void auto_rehash(void);
@@ -190,10 +183,11 @@ public:
   const_iterator find(const K& key) const;
   iterator find(const K& key);
   // returns the data corresponding to the key
-  // the const version is used by the compiler on const hashes and cannot change the hash, so find failure causes an exception
-  // the non-const version is used by the compiler on non-const hashes and is like map - it creates a new key/data pair if find fails
-  const T& operator[] (const K& key) const;
-  T& operator[] (const K& key);
+  // the const version is used by the compiler on const hashes and cannot change the hash, so find failure causes an
+  // exception the non-const version is used by the compiler on non-const hashes and is like map - it creates a new
+  // key/data pair if find fails
+  const T& operator[](const K& key) const;
+  T& operator[](const K& key);
 
   // iterators allow the hash table to be traversed
   // iterators remain valid unless an item is removed or unless a rehash happens
@@ -208,43 +202,39 @@ public:
   std::string debug_report(unsigned indent = 0) const;
 
   // persistence methods
-  void dump(dump_context&) const
-    throw();
-  void restore(restore_context&)
-    throw();
+  void dump(dump_context&) const throw();
+  void restore(restore_context&) throw();
 
   // internals
-private:
-  friend class hash_element<K,T>;
-  friend class hash_iterator<K,T,H,E,std::pair<const K,T> >;
-  friend class hash_iterator<K,T,H,E,const std::pair<const K,T> >;
+ private:
+  friend class hash_element<K, T>;
+  friend class hash_iterator<K, T, H, E, std::pair<const K, T> >;
+  friend class hash_iterator<K, T, H, E, const std::pair<const K, T> >;
 
   unsigned m_rehash;
   unsigned m_bins;
   unsigned m_size;
-  hash_element<K,T>** m_values;
+  hash_element<K, T>** m_values;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename K, typename T, class H, class E>
-otext& print(otext& str, const hash<K,T,H,E>& table, unsigned indent = 0);
+template <typename K, typename T, class H, class E>
+otext& print(otext& str, const hash<K, T, H, E>& table, unsigned indent = 0);
 
-template<typename K, typename T, class H, class E>
-otext& operator << (otext& str, const hash<K,T,H,E>& table);
-
-////////////////////////////////////////////////////////////////////////////////
-
-template<typename K, typename T, class H, class E>
-void dump_hash(dump_context& str, const hash<K,T,H,E>& data)
-  throw();
-
-template<typename K, typename T, class H, class E>
-void restore_hash(restore_context& str, hash<K,T,H,E>& data)
-  throw();
+template <typename K, typename T, class H, class E>
+otext& operator<<(otext& str, const hash<K, T, H, E>& table);
 
 ////////////////////////////////////////////////////////////////////////////////
-}
+
+template <typename K, typename T, class H, class E>
+void dump_hash(dump_context& str, const hash<K, T, H, E>& data) throw();
+
+template <typename K, typename T, class H, class E>
+void restore_hash(restore_context& str, hash<K, T, H, E>& data) throw();
+
+////////////////////////////////////////////////////////////////////////////////
+}  // namespace stlplus
 
 #include "hash.tpp"
 #endif

--- a/src/stlplus/include/RAT/multiio.hpp
+++ b/src/stlplus/include/RAT/multiio.hpp
@@ -15,9 +15,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Output
 
-class omtext : public otext
-{
-public:
+class omtext : public otext {
+ public:
   omtext(void);
   omtext(const otext&);
   omtext(const otext&, const otext&);
@@ -34,9 +33,8 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // Input
 
-class imtext : public itext
-{
-public:
+class imtext : public itext {
+ public:
   imtext(void);
   imtext(const itext&);
   imtext(const itext&, const itext&);
@@ -53,49 +51,49 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // Internals
 
-class ombuff : public obuff
-{
+class ombuff : public obuff {
   friend class omtext;
-public:
+
+ public:
   ombuff(void);
   unsigned add(const otext&);
   void remove(unsigned);
 
-  virtual unsigned put (unsigned char);
+  virtual unsigned put(unsigned char);
 
   unsigned count(void) const;
   otext& device(unsigned);
   const otext& device(unsigned) const;
 
-private:
+ private:
   std::vector<otext> m_devices;
 
   // make this class uncopyable
   ombuff(const ombuff&);
-  ombuff& operator = (const ombuff&);
+  ombuff& operator=(const ombuff&);
 };
 
-class imbuff : public ibuff
-{
+class imbuff : public ibuff {
   friend class imtext;
-public:
+
+ public:
   imbuff(void);
   unsigned add(const itext&);
   void remove(unsigned);
 
-  virtual int peek (void);
-  virtual int get (void);
+  virtual int peek(void);
+  virtual int get(void);
 
   unsigned count(void) const;
   itext& device(unsigned);
   const itext& device(unsigned) const;
 
-private:
+ private:
   std::vector<itext> m_devices;
 
   // make this class uncopyable
   imbuff(const imbuff&);
-  imbuff& operator = (const imbuff&);
+  imbuff& operator=(const imbuff&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/stlplus/include/RAT/os_fixes.hpp
+++ b/src/stlplus/include/RAT/os_fixes.hpp
@@ -29,7 +29,7 @@
 //   4290 - VC6, C++ exception specification ignored
 //   4800 - VC6, forcing value to bool 'true' or 'false' (performance warning)
 //   4675 - VC7.1, "change" in function overload resolution _might_ have altered program
-#pragma warning(disable: 4275 4786 4305 4503 4309 4290 4800 4675)
+#pragma warning(disable : 4275 4786 4305 4503 4309 4290 4800 4675)
 #endif
 
 #if defined(__BORLANDC__)
@@ -54,10 +54,10 @@
 //          label or the end of a loop or function. The compiler checks while,
 //          do, and for loops with a constant test condition, and attempts to
 //          recognize loops that can't fall through.
-#pragma warn -8022
-#pragma warn -8008
-#pragma warn -8060
-#pragma warn -8066
+#pragma warn - 8022
+#pragma warn - 8008
+#pragma warn - 8060
+#pragma warn - 8066
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -83,16 +83,27 @@
 #undef min
 // replace missing template definitions in VC6
 #if defined(_MSC_VER) && (_MSC_VER < 1300)
-namespace std 
-{
-  template<typename T> const T& max(const T& l, const T& r) {return l > r ? l : r;}
-  template<typename T> const T& min(const T& l, const T& r) {return l < r ? l : r;}
+namespace std {
+template <typename T>
+const T& max(const T& l, const T& r) {
+  return l > r ? l : r;
 }
+template <typename T>
+const T& min(const T& l, const T& r) {
+  return l < r ? l : r;
+}
+}  // namespace std
 #endif
 #endif
 
-template<typename T> const T& maximum(const T& l, const T& r) {return l > r ? l : r;}
-template<typename T> const T& minimum(const T& l, const T& r) {return l < r ? l : r;}
+template <typename T>
+const T& maximum(const T& l, const T& r) {
+  return l > r ? l : r;
+}
+template <typename T>
+const T& minimum(const T& l, const T& r) {
+  return l < r ? l : r;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Problem with missing __FUNCTION__ macro
@@ -122,12 +133,9 @@ template<typename T> const T& minimum(const T& l, const T& r) {return l < r ? l 
 // do *not* try to move the contents of std::rel_ops into namespace std
 
 #if defined(__GNUC__)
-namespace std
-{
-  namespace rel_ops
-  {
-  }
-}
+namespace std {
+namespace rel_ops {}
+}  // namespace std
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -212,7 +220,7 @@ unsigned sleep(unsigned seconds);
 // Function for establishing endian-ness
 ////////////////////////////////////////////////////////////////////////////////
 // Different machine architectures store data using different byte orders.
-// This is referred to as Big- and Little-Endian Byte Ordering. 
+// This is referred to as Big- and Little-Endian Byte Ordering.
 //
 // The issue is: where does a pointer to an integer type actually point?
 //

--- a/src/stlplus/include/RAT/persistent.hpp
+++ b/src/stlplus/include/RAT/persistent.hpp
@@ -7,20 +7,22 @@
   License:   BSD License, see ../docs/license.html
 
   ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include "textio.hpp"
-#include "clonable.hpp"
 #include <stdlib.h>
+
+#include <bitset>
 #include <complex>
 #include <deque>
-#include <bitset>
-#include <set>
-#include <map>
 #include <list>
-#include <vector>
+#include <map>
+#include <set>
+#include <stdexcept>
 #include <string>
 #include <typeinfo>
-#include <stdexcept>
+#include <vector>
+
+#include "clonable.hpp"
+#include "os_fixes.hpp"
+#include "textio.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // The format version number currently supported
@@ -32,26 +34,23 @@ extern unsigned char PersistentVersion;
 // Exceptions thrown by the persistence functions
 
 // exception thrown if you try to dump or restore an illegal polymorphic type
-class persistent_illegal_type : public std::logic_error
-{
-public:
+class persistent_illegal_type : public std::logic_error {
+ public:
   persistent_illegal_type(const std::string& type) throw();
   persistent_illegal_type(unsigned short key) throw();
   ~persistent_illegal_type(void) throw();
 };
 
 // exception thrown if a dump fails for any reason - but typically because the output stream couldn't take the data
-class persistent_dump_failed : public std::runtime_error
-{
-public:
+class persistent_dump_failed : public std::runtime_error {
+ public:
   persistent_dump_failed(const std::string& message) throw();
   ~persistent_dump_failed(void) throw();
 };
 
 // exception thrown if you try to restore from an out of date or unrecognised byte stream
-class persistent_restore_failed : public std::runtime_error
-{
-public:
+class persistent_restore_failed : public std::runtime_error {
+ public:
   persistent_restore_failed(const std::string& message) throw();
   ~persistent_restore_failed(void) throw();
 };
@@ -62,15 +61,14 @@ public:
 
 class dump_context_body;
 
-class dump_context
-{
-public:
+class dump_context {
+ public:
   // types used in making polymorphous classes persistent using the callback approach
 
   // callback function for dumping the class
-  typedef void (*dump_callback)(dump_context&,const void*);
+  typedef void (*dump_callback)(dump_context&, const void*);
   // data stored per class registered
-  typedef std::pair<unsigned short,dump_callback> callback_data;
+  typedef std::pair<unsigned short, dump_callback> callback_data;
 
   // type of callback function used to install all polymorphic classes for either approach
   typedef void (*installer)(dump_context&);
@@ -95,7 +93,7 @@ public:
 
   // Assist functions for Pointers
   // the return pair is a flag saying whether this is a new pointer and the magic key to dump to file
-  std::pair<bool,unsigned> pointer_map(const void* const pointer);
+  std::pair<bool, unsigned> pointer_map(const void* const pointer);
 
   // Assist functions for Polymorphous classes (i.e. subclasses) using callback approach
   unsigned short register_type(const std::type_info& info, dump_callback);
@@ -110,7 +108,7 @@ public:
   // Register all Polymorphous classes using either approach by calling an installer callback
   void register_all(installer);
 
-private:
+ private:
   friend class dump_context_body;
   dump_context_body* m_body;
 
@@ -125,23 +123,22 @@ private:
 class persistent;
 class restore_context_body;
 
-class restore_context
-{
-public:
+class restore_context {
+ public:
   // types used in making polymorphous classes persistent using the callback approach
 
   // callback function for creating a new object of the class and returning the pointer
   typedef void* (*create_callback)(void);
   // callback for restoring the contents of a new object created by the create_callback
   // and passed as the second argument
-  typedef void (*restore_callback)(restore_context&,void*);
+  typedef void (*restore_callback)(restore_context&, void*);
   // data stored per class registered
   typedef std::pair<create_callback, restore_callback> callback_data;
 
   // types used in making polymorphous classes persistent using the interface approach
 
   friend class persistent;
-  typedef std::pair<unsigned short,persistent*> interface_data;
+  typedef std::pair<unsigned short, persistent*> interface_data;
 
   // type of callback function used to install all polymorphic classes for either approach
   typedef void (*installer)(restore_context&);
@@ -165,11 +162,11 @@ public:
   bool little_endian(void) const;
 
   // Assist functions for Pointers
-  std::pair<bool,void*> pointer_map(unsigned magic);
+  std::pair<bool, void*> pointer_map(unsigned magic);
   void pointer_add(unsigned magic, void* new_pointer);
 
   // Assist functions for Polymorphous classes using the callback approach
-  unsigned short register_type(create_callback,restore_callback);
+  unsigned short register_type(create_callback, restore_callback);
   bool is_callback(unsigned short) const;
   callback_data lookup_type(unsigned short) const throw();
 
@@ -182,7 +179,7 @@ public:
   // Register all Polymorphous classes using either approach by calling an installer callback
   void register_all(installer);
 
-private:
+ private:
   friend class restore_context_body;
   restore_context_body* m_body;
 
@@ -197,12 +194,11 @@ private:
 // Note that it is derived from the clonable interface - so you must provide
 // that interface too
 
-class persistent : public clonable
-{
-public:
+class persistent : public clonable {
+ public:
   virtual void dump(dump_context&) const throw() = 0;
-  virtual void restore(restore_context&)  throw() = 0;
-  virtual ~persistent() {};
+  virtual void restore(restore_context&) throw() = 0;
+  virtual ~persistent(){};
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -245,9 +241,9 @@ void restore(restore_context&, double& data) throw();
 ////////////////////////////////////////////////////////////////////////////////
 // enumeration types
 
-template<typename T>
+template <typename T>
 void dump_enum(dump_context&, const T& data) throw();
-template<typename T>
+template <typename T>
 void restore_enum(restore_context&, T& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -270,10 +266,10 @@ void restore(restore_context&, char*& data) throw();
 ////////////////////////////////////////////////////////////////////////////////
 // STL strings
 
-template<typename charT, typename traits, typename allocator>
-void dump_basic_string(dump_context&, const std::basic_string<charT,traits,allocator>& data) throw();
-template<typename charT, typename traits, typename allocator>
-void restore_basic_string(restore_context&, std::basic_string<charT,traits,allocator>& data) throw();
+template <typename charT, typename traits, typename allocator>
+void dump_basic_string(dump_context&, const std::basic_string<charT, traits, allocator>& data) throw();
+template <typename charT, typename traits, typename allocator>
+void restore_basic_string(restore_context&, std::basic_string<charT, traits, allocator>& data) throw();
 
 void dump(dump_context&, const std::string& data) throw();
 void restore(restore_context&, std::string& data) throw();
@@ -294,10 +290,10 @@ void restore(restore_context&, std::string& data) throw();
 // only restored once and the magic keys are matched up so that the other
 // pointers now pojnt to the restored object.
 
-template<typename T>
+template <typename T>
 void dump_pointer(dump_context&, const T* const data) throw();
 
-template<typename T>
+template <typename T>
 void restore_pointer(restore_context&, T*& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -314,10 +310,10 @@ void restore_pointer(restore_context&, T*& data) throw();
 // These functions will throw an exception if the cross-reference points to
 // something not dumped before.
 
-template<typename T>
+template <typename T>
 void dump_xref(dump_context&, const T* const data) throw();
 
-template<typename T>
+template <typename T>
 void restore_xref(restore_context&, T*& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -330,10 +326,10 @@ void restore_xref(restore_context&, T*& data) throw();
 // Only classes registered with the context can be dumped and restored as
 // polymorphic types - see dump_context::register_type and restore_context::register_type.
 
-template<typename T>
+template <typename T>
 void dump_polymorph(dump_context&, const T* const data) throw();
 
-template<typename T>
+template <typename T>
 void restore_polymorph(restore_context&, T*& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -346,63 +342,63 @@ void restore_polymorph(restore_context&, T*& data) throw();
 // Only classes registered with the context can be dumped and restored as
 // polymorphic types - see dump_context::register_interface and restore_context::register_interface
 
-template<typename T>
+template <typename T>
 void dump_interface(dump_context&, const T* const data) throw();
 
-template<typename T>
+template <typename T>
 void restore_interface(restore_context&, T*& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
 // STL Containers
 
-template<size_t N>
+template <size_t N>
 void dump_bitset(dump_context&, const std::bitset<N>& data) throw();
-template<size_t N>
+template <size_t N>
 void restore_bitset(restore_context&, std::bitset<N>& data) throw();
 
-template<typename T>
+template <typename T>
 void dump_complex(dump_context&, const std::complex<T>& data) throw();
-template<typename T>
+template <typename T>
 void restore_complex(restore_context&, std::complex<T>& data) throw();
 
-template<typename T>
+template <typename T>
 void dump_deque(dump_context&, const std::deque<T>& data) throw();
-template<typename T>
+template <typename T>
 void restore_deque(restore_context&, std::deque<T>& data) throw();
 
-template<typename T>
+template <typename T>
 void dump_list(dump_context&, const std::list<T>& data) throw();
-template<typename T>
+template <typename T>
 void restore_list(restore_context&, std::list<T>& data) throw();
 
-template<typename K, typename T>
-void dump_pair(dump_context&, const std::pair<K,T>& data) throw();
-template<typename K, typename T>
-void restore_pair(restore_context&, std::pair<K,T>& data) throw();
+template <typename K, typename T>
+void dump_pair(dump_context&, const std::pair<K, T>& data) throw();
+template <typename K, typename T>
+void restore_pair(restore_context&, std::pair<K, T>& data) throw();
 
-template<typename K, typename T, typename P>
-void dump_map(dump_context&, const std::map<K,T,P>& data) throw();
-template<typename K, typename T, typename P>
-void restore_map(restore_context&, std::map<K,T,P>& data) throw();
+template <typename K, typename T, typename P>
+void dump_map(dump_context&, const std::map<K, T, P>& data) throw();
+template <typename K, typename T, typename P>
+void restore_map(restore_context&, std::map<K, T, P>& data) throw();
 
-template<typename K, typename T, typename P>
-void dump_multimap(dump_context&, const std::multimap<K,T,P>& data) throw();
-template<typename K, typename T, typename P>
-void restore_multimap(restore_context&, std::multimap<K,T,P>& data) throw();
+template <typename K, typename T, typename P>
+void dump_multimap(dump_context&, const std::multimap<K, T, P>& data) throw();
+template <typename K, typename T, typename P>
+void restore_multimap(restore_context&, std::multimap<K, T, P>& data) throw();
 
-template<typename K, typename P>
-void dump_set(dump_context&, const std::set<K,P>& data) throw();
-template<typename K, typename P>
-void restore_set(restore_context&, std::set<K,P>& data) throw();
+template <typename K, typename P>
+void dump_set(dump_context&, const std::set<K, P>& data) throw();
+template <typename K, typename P>
+void restore_set(restore_context&, std::set<K, P>& data) throw();
 
-template<typename K, typename P>
-void dump_multiset(dump_context&, const std::multiset<K,P>& data) throw();
-template<typename K, typename P>
-void restore_multiset(restore_context&, std::multiset<K,P>& data) throw();
+template <typename K, typename P>
+void dump_multiset(dump_context&, const std::multiset<K, P>& data) throw();
+template <typename K, typename P>
+void restore_multiset(restore_context&, std::multiset<K, P>& data) throw();
 
-template<typename T>
+template <typename T>
 void dump_vector(dump_context&, const std::vector<T>& data) throw();
-template<typename T>
+template <typename T>
 void restore_vector(restore_context&, std::vector<T>& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -412,26 +408,20 @@ void restore_vector(restore_context&, std::vector<T>& data) throw();
 // polymorphic type handlers required. If there are no polymorphic types used
 // in the data structure, then the callback can be set to null (i.e. 0).
 
-template<typename T>
-void dump_to_device(const T& source, otext& result, dump_context::installer installer)
-  throw();
-template<typename T>
-void restore_from_device(itext& source, T& result, restore_context::installer installer)
-  throw();
+template <typename T>
+void dump_to_device(const T& source, otext& result, dump_context::installer installer) throw();
+template <typename T>
+void restore_from_device(itext& source, T& result, restore_context::installer installer) throw();
 
-template<typename T>
-void dump_to_string(const T& source, std::string& result, dump_context::installer installer)
-  throw();
-template<typename T>
-void restore_from_string(const std::string& source, T& result, restore_context::installer installer)
-  throw();
+template <typename T>
+void dump_to_string(const T& source, std::string& result, dump_context::installer installer) throw();
+template <typename T>
+void restore_from_string(const std::string& source, T& result, restore_context::installer installer) throw();
 
-template<typename T>
-void dump_to_file(const T& source, const std::string& filename, dump_context::installer installer)
-  throw();
-template<typename T>
-void restore_from_file(const std::string& filename, T& result, restore_context::installer installer)
-  throw();
+template <typename T>
+void dump_to_file(const T& source, const std::string& filename, dump_context::installer installer) throw();
+template <typename T>
+void restore_from_file(const std::string& filename, T& result, restore_context::installer installer) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
 #include "persistent.tpp"

--- a/src/stlplus/include/RAT/smart_ptr.hpp
+++ b/src/stlplus/include/RAT/smart_ptr.hpp
@@ -17,12 +17,13 @@
     - smart_ptr_nocopy for any class that cannot or should no be copied
 
   ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include "exceptions.hpp"
-#include "persistent.hpp"
-#include "textio.hpp"
 #include <map>
 #include <string>
+
+#include "exceptions.hpp"
+#include "os_fixes.hpp"
+#include "persistent.hpp"
+#include "textio.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -30,10 +31,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-class simple_ptr
-{
-public:
+template <typename T>
+class simple_ptr {
+ public:
   //////////////////////////////////////////////////////////////////////////////
   // member type definitions
 
@@ -48,7 +48,7 @@ public:
   simple_ptr(void);
 
   // create a pointer containing a *copy* of the object
-  // this copy is taken because the pointer class maintains a dynamically allocated object 
+  // this copy is taken because the pointer class maintains a dynamically allocated object
   // and the T& may not be (usually is not) dynamically allocated
   // constructor form
   simple_ptr(const T& data);
@@ -65,7 +65,7 @@ public:
   // constructor form - must be called in the form simple_ptr<type> x(new type(args))
   explicit simple_ptr(T* data);
   // assignment form
-  simple_ptr<T>& operator= (T* data);
+  simple_ptr<T>& operator=(T* data);
 
   // destructor decrements the reference count and delete only when the last reference is destroyed
   ~simple_ptr(void);
@@ -117,14 +117,16 @@ public:
   // used in the form if(a.aliases(b))
   bool aliases(const simple_ptr<T>&) const;
 
-  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere (rare!)
+  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere
+  // (rare!)
   unsigned alias_count(void) const;
 
   // make this pointer unique with respect to any other references to the same object
   // if this pointer is already unique, it does nothing - otherwise it copies the object
   void make_unique(void);
 
-  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be null too
+  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be
+  // null too
   void clear(void);
 
   // make the pointer unique and null in one step - does not affect other pointers that were pointing to the same object
@@ -140,7 +142,7 @@ public:
   void dump(dump_context& str) const throw();
   void restore(restore_context& str) throw();
 
-protected:
+ protected:
   T* m_pointer;
   unsigned* m_count;
 };
@@ -153,22 +155,22 @@ protected:
 // these funcions are defined as non-members so that you only need provide
 // the underlying T::operator< and == if you are going to use these functions
 
-template<typename T>
+template <typename T>
 bool operator==(const simple_ptr<T>&, const simple_ptr<T>&);
 
-template<typename T>
+template <typename T>
 bool operator<(const simple_ptr<T>&, const simple_ptr<T>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 // string/print utilities
 
-template<typename T>
+template <typename T>
 std::string simple_ptr_to_string(const simple_ptr<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_simple_ptr(otext& str, const simple_ptr<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_simple_ptr(otext& str, const simple_ptr<T>& ptr, unsigned indent, std::string null_string);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -177,10 +179,10 @@ otext& print_simple_ptr(otext& str, const simple_ptr<T>& ptr, unsigned indent, s
 // similarly the restore routine calls restore_pointer
 // so therefore the class T should have non-member dump/restore functions
 
-template<typename T>
+template <typename T>
 void dump_simple_ptr(dump_context& str, const simple_ptr<T>& data) throw();
 
-template<typename T>
+template <typename T>
 void restore_simple_ptr(restore_context& str, simple_ptr<T>& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -190,10 +192,9 @@ void restore_simple_ptr(restore_context& str, simple_ptr<T>& data) throw();
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-class simple_ptr_clone
-{
-public:
+template <typename T>
+class simple_ptr_clone {
+ public:
   //////////////////////////////////////////////////////////////////////////////
   // member type definitions
 
@@ -208,7 +209,7 @@ public:
   simple_ptr_clone(void);
 
   // create a pointer containing a *copy* of the object
-  // this copy is taken because the pointer class maintains a dynamically allocated object 
+  // this copy is taken because the pointer class maintains a dynamically allocated object
   // and the T& may not be (usually is not) dynamically allocated
   // constructor form
   simple_ptr_clone(const T& data);
@@ -225,7 +226,7 @@ public:
   // constructor form - must be called in the form simple_ptr_clone<type> x(new type(args))
   explicit simple_ptr_clone(T* data);
   // assignment form
-  simple_ptr_clone<T>& operator= (T* data);
+  simple_ptr_clone<T>& operator=(T* data);
 
   // destructor decrements the reference count and delete only when the last reference is destroyed
   ~simple_ptr_clone(void);
@@ -277,14 +278,16 @@ public:
   // used in the form if(a.aliases(b))
   bool aliases(const simple_ptr_clone<T>&) const;
 
-  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere (rare!)
+  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere
+  // (rare!)
   unsigned alias_count(void) const;
 
   // make this pointer unique with respect to any other references to the same object
   // if this pointer is already unique, it does nothing - otherwise it copies the object
   void make_unique(void);
 
-  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be null too
+  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be
+  // null too
   void clear(void);
 
   // make the pointer unique and null in one step - does not affect other pointers that were pointing to the same object
@@ -300,7 +303,7 @@ public:
   void dump(dump_context& str) const throw();
   void restore(restore_context& str) throw();
 
-protected:
+ protected:
   T* m_pointer;
   unsigned* m_count;
 };
@@ -313,22 +316,22 @@ protected:
 // these funcions are defined as non-members so that you only need provide
 // the underlying T::operator< and == if you are going to use these functions
 
-template<typename T>
+template <typename T>
 bool operator==(const simple_ptr_clone<T>&, const simple_ptr_clone<T>&);
 
-template<typename T>
+template <typename T>
 bool operator<(const simple_ptr_clone<T>&, const simple_ptr_clone<T>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 // string/print utilities
 
-template<typename T>
+template <typename T>
 std::string simple_ptr_clone_to_string(const simple_ptr_clone<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_simple_ptr_clone(otext& str, const simple_ptr_clone<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_simple_ptr_clone(otext& str, const simple_ptr_clone<T>& ptr, unsigned indent, std::string null_string);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -337,10 +340,10 @@ otext& print_simple_ptr_clone(otext& str, const simple_ptr_clone<T>& ptr, unsign
 // similarly the restore routine calls restore_interface
 // so therefore the class T should implement the persistent interface defined by the class persistent in persistent.hpp
 
-template<typename T>
+template <typename T>
 void dump_simple_ptr_clone(dump_context& str, const simple_ptr_clone<T>& data) throw();
 
-template<typename T>
+template <typename T>
 void restore_simple_ptr_clone(restore_context& str, simple_ptr_clone<T>& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -349,10 +352,9 @@ void restore_simple_ptr_clone(restore_context& str, simple_ptr_clone<T>& data) t
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-class simple_ptr_nocopy
-{
-public:
+template <typename T>
+class simple_ptr_nocopy {
+ public:
   //////////////////////////////////////////////////////////////////////////////
   // member type definitions
 
@@ -376,7 +378,7 @@ public:
   // constructor form - must be called in the form simple_ptr_nocopy<type> x(new type(args))
   explicit simple_ptr_nocopy(T* data);
   // assignment form
-  simple_ptr_nocopy<T>& operator= (T* data);
+  simple_ptr_nocopy<T>& operator=(T* data);
 
   // destructor decrements the reference count and delete only when the last reference is destroyed
   ~simple_ptr_nocopy(void);
@@ -426,16 +428,18 @@ public:
   // used in the form if(a.aliases(b))
   bool aliases(const simple_ptr_nocopy<T>&) const;
 
-  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere (rare!)
+  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere
+  // (rare!)
   unsigned alias_count(void) const;
 
-  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be null too
+  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be
+  // null too
   void clear(void);
 
   // make the pointer unique and null in one step - does not affect other pointers that were pointing to the same object
-  //void clear_unique(void); FIXME
+  // void clear_unique(void); FIXME
 
-protected:
+ protected:
   T* m_pointer;
   unsigned* m_count;
 };
@@ -448,22 +452,22 @@ protected:
 // these funcions are defined as non-members so that you only need provide
 // the underlying T::operator< and == if you are going to use these functions
 
-template<typename T>
+template <typename T>
 bool operator==(const simple_ptr_nocopy<T>&, const simple_ptr_nocopy<T>&);
 
-template<typename T>
+template <typename T>
 bool operator<(const simple_ptr_nocopy<T>&, const simple_ptr_nocopy<T>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 // string/print utilities
 
-template<typename T>
+template <typename T>
 std::string simple_ptr_nocopy_to_string(const simple_ptr_nocopy<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_simple_ptr_nocopy(otext& str, const simple_ptr_nocopy<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_simple_ptr_nocopy(otext& str, const simple_ptr_nocopy<T>& ptr, unsigned indent, std::string null_string);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -479,14 +483,14 @@ otext& print_simple_ptr_nocopy(otext& str, const simple_ptr_nocopy<T>& ptr, unsi
 ////////////////////////////////////////////////////////////////////////////////
 // internals
 
-template<typename T> class smart_ptr_holder;
+template <typename T>
+class smart_ptr_holder;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-class smart_ptr
-{
-public:
+template <typename T>
+class smart_ptr {
+ public:
   //////////////////////////////////////////////////////////////////////////////
   // member type definitions
 
@@ -501,7 +505,7 @@ public:
   smart_ptr(void);
 
   // create a pointer containing a *copy* of the object
-  // this copy is taken because the pointer class maintains a dynamically allocated object 
+  // this copy is taken because the pointer class maintains a dynamically allocated object
   // and the T& may not be (usually is not) dynamically allocated
   // constructor form
   smart_ptr(const T& data);
@@ -518,7 +522,7 @@ public:
   // constructor form - must be called in the form smart_ptr<type> x(new type(args))
   explicit smart_ptr(T* data);
   // assignment form
-  smart_ptr<T>& operator= (T* data);
+  smart_ptr<T>& operator=(T* data);
 
   // destructor decrements the reference count and delete only when the last reference is destroyed
   ~smart_ptr(void);
@@ -570,14 +574,16 @@ public:
   // used in the form if(a.aliases(b))
   bool aliases(const smart_ptr<T>&) const;
 
-  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere (rare!)
+  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere
+  // (rare!)
   unsigned alias_count(void) const;
 
   // make this pointer unique with respect to any other references to the same object
   // if this pointer is already unique, it does nothing - otherwise it copies the object
   void make_unique(void);
 
-  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be null too
+  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be
+  // null too
   void clear(void);
 
   // make the pointer unique and null in one step - does not affect other pointers that were pointing to the same object
@@ -593,7 +599,7 @@ public:
   void dump(dump_context& str) const throw();
   void restore(restore_context& str) throw();
 
-protected:
+ protected:
   smart_ptr_holder<T>* m_holder;
 };
 
@@ -605,22 +611,22 @@ protected:
 // these funcions are defined as non-members so that you only need provide
 // the underlying T::operator< and == if you are going to use these functions
 
-template<typename T>
+template <typename T>
 bool operator==(const smart_ptr<T>&, const smart_ptr<T>&);
 
-template<typename T>
+template <typename T>
 bool operator<(const smart_ptr<T>&, const smart_ptr<T>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 // string/print utilities
 
-template<typename T>
+template <typename T>
 std::string smart_ptr_to_string(const smart_ptr<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_smart_ptr(otext& str, const smart_ptr<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_smart_ptr(otext& str, const smart_ptr<T>& ptr, unsigned indent, std::string null_string);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -629,10 +635,10 @@ otext& print_smart_ptr(otext& str, const smart_ptr<T>& ptr, unsigned indent, std
 // similarly the restore routine calls restore_pointer
 // so therefore the class T should have non-member dump/restore functions
 
-template<typename T>
+template <typename T>
 void dump_smart_ptr(dump_context& str, const smart_ptr<T>& data) throw();
 
-template<typename T>
+template <typename T>
 void restore_smart_ptr(restore_context& str, smart_ptr<T>& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -642,10 +648,9 @@ void restore_smart_ptr(restore_context& str, smart_ptr<T>& data) throw();
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-class smart_ptr_clone
-{
-public:
+template <typename T>
+class smart_ptr_clone {
+ public:
   //////////////////////////////////////////////////////////////////////////////
   // member type definitions
 
@@ -660,7 +665,7 @@ public:
   smart_ptr_clone(void);
 
   // create a pointer containing a *copy* of the object
-  // this copy is taken because the pointer class maintains a dynamically allocated object 
+  // this copy is taken because the pointer class maintains a dynamically allocated object
   // and the T& may not be (usually is not) dynamically allocated
   // constructor form
   smart_ptr_clone(const T& data);
@@ -677,7 +682,7 @@ public:
   // constructor form - must be called in the form smart_ptr_clone<type> x(new type(args))
   explicit smart_ptr_clone(T* data);
   // assignment form
-  smart_ptr_clone<T>& operator= (T* data);
+  smart_ptr_clone<T>& operator=(T* data);
 
   // destructor decrements the reference count and delete only when the last reference is destroyed
   ~smart_ptr_clone(void);
@@ -729,14 +734,16 @@ public:
   // used in the form if(a.aliases(b))
   bool aliases(const smart_ptr_clone<T>&) const;
 
-  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere (rare!)
+  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere
+  // (rare!)
   unsigned alias_count(void) const;
 
   // make this pointer unique with respect to any other references to the same object
   // if this pointer is already unique, it does nothing - otherwise it copies the object
   void make_unique(void);
 
-  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be null too
+  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be
+  // null too
   void clear(void);
 
   // make the pointer unique and null in one step - does not affect other pointers that were pointing to the same object
@@ -752,7 +759,7 @@ public:
   void dump(dump_context& str) const throw();
   void restore(restore_context& str) throw();
 
-protected:
+ protected:
   smart_ptr_holder<T>* m_holder;
 };
 
@@ -764,22 +771,22 @@ protected:
 // these funcions are defined as non-members so that you only need provide
 // the underlying T::operator< and == if you are going to use these functions
 
-template<typename T>
+template <typename T>
 bool operator==(const smart_ptr_clone<T>&, const smart_ptr_clone<T>&);
 
-template<typename T>
+template <typename T>
 bool operator<(const smart_ptr_clone<T>&, const smart_ptr_clone<T>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 // string/print utilities
 
-template<typename T>
+template <typename T>
 std::string smart_ptr_clone_to_string(const smart_ptr_clone<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_smart_ptr_clone(otext& str, const smart_ptr_clone<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_smart_ptr_clone(otext& str, const smart_ptr_clone<T>& ptr, unsigned indent, std::string null_string);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -788,10 +795,10 @@ otext& print_smart_ptr_clone(otext& str, const smart_ptr_clone<T>& ptr, unsigned
 // similarly the restore routine calls restore_interface
 // so therefore the class T should implement the persistent interface defined by the class persistent in persistent.hpp
 
-template<typename T>
+template <typename T>
 void dump_smart_ptr_clone(dump_context& str, const smart_ptr_clone<T>& data) throw();
 
-template<typename T>
+template <typename T>
 void restore_smart_ptr_clone(restore_context& str, smart_ptr_clone<T>& data) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -800,10 +807,9 @@ void restore_smart_ptr_clone(restore_context& str, smart_ptr_clone<T>& data) thr
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-template<typename T>
-class smart_ptr_nocopy
-{
-public:
+template <typename T>
+class smart_ptr_nocopy {
+ public:
   //////////////////////////////////////////////////////////////////////////////
   // member type definitions
 
@@ -827,7 +833,7 @@ public:
   // constructor form - must be called in the form smart_ptr_nocopy<type> x(new type(args))
   explicit smart_ptr_nocopy(T* data);
   // assignment form
-  smart_ptr_nocopy<T>& operator= (T* data);
+  smart_ptr_nocopy<T>& operator=(T* data);
 
   // destructor decrements the reference count and delete only when the last reference is destroyed
   ~smart_ptr_nocopy(void);
@@ -877,16 +883,18 @@ public:
   // used in the form if(a.aliases(b))
   bool aliases(const smart_ptr_nocopy<T>&) const;
 
-  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere (rare!)
+  // find the number of aliases - used when you need to know whether an object is still referred to from elsewhere
+  // (rare!)
   unsigned alias_count(void) const;
 
-  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be null too
+  // delete the object and make the pointer null - does not make it unique first, so all other pointers to this will be
+  // null too
   void clear(void);
 
   // make the pointer unique and null in one step - does not affect other pointers that were pointing to the same object
   void clear_unique(void);
 
-protected:
+ protected:
   smart_ptr_holder<T>* m_holder;
 };
 
@@ -898,22 +906,22 @@ protected:
 // these funcions are defined as non-members so that you only need provide
 // the underlying T::operator< and == if you are going to use these functions
 
-template<typename T>
+template <typename T>
 bool operator==(const smart_ptr_nocopy<T>&, const smart_ptr_nocopy<T>&);
 
-template<typename T>
+template <typename T>
 bool operator<(const smart_ptr_nocopy<T>&, const smart_ptr_nocopy<T>&);
 
 ////////////////////////////////////////////////////////////////////////////////
 // string/print utilities
 
-template<typename T>
+template <typename T>
 std::string smart_ptr_nocopy_to_string(const smart_ptr_nocopy<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_smart_ptr_nocopy(otext& str, const smart_ptr_nocopy<T>& ptr, std::string null_string);
 
-template<typename T>
+template <typename T>
 otext& print_smart_ptr_nocopy(otext& str, const smart_ptr_nocopy<T>& ptr, unsigned indent, std::string null_string);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/stlplus/include/RAT/string_utilities.hpp
+++ b/src/stlplus/include/RAT/string_utilities.hpp
@@ -9,17 +9,17 @@
   Utilities for manipulating std::strings, missing from the STL or C++ libraries
 
   ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include "format_types.hpp"
-#include "textio.hpp"
-#include <string>
-#include <vector>
 #include <bitset>
 #include <list>
 #include <map>
 #include <set>
-#include <vector>
 #include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "format_types.hpp"
+#include "os_fixes.hpp"
+#include "textio.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Conversions of Integer types to string
@@ -35,31 +35,32 @@
 // This is a minimum - if the value requires more digits then it will be wider than the width argument
 // However, if it is smaller, then it will be extended to the specified width
 // Then, the radix display prefix is added to this width
-// For example, using the hash representation of 0 in hex with width=4 gives: 16#0000 - so there's 4 digits in the number part
+// For example, using the hash representation of 0 in hex with width=4 gives: 16#0000 - so there's 4 digits in the
+// number part
 
-std::string to_string(bool i,           unsigned radix = 10, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(bool i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
-std::string to_string(short i,          unsigned radix = 10, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(short i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
-std::string to_string(unsigned short i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(unsigned short i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
-std::string to_string(int i,            unsigned radix = 10, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(int i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
-std::string to_string(unsigned int i,   unsigned radix = 10, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(unsigned int i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
-std::string to_string(long i,           unsigned radix = 10, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(long i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
-std::string to_string(unsigned long i,  unsigned radix = 10, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(unsigned long i, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
-std::string to_string(const void*,      unsigned radix = 16, radix_display_t display = radix_c_style_or_hash, unsigned width = 0)
-  throw();
+std::string to_string(const void*, unsigned radix = 16, radix_display_t display = radix_c_style_or_hash,
+                      unsigned width = 0) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
 // convert a real type to string
@@ -70,10 +71,10 @@ std::string to_string(const void*,      unsigned radix = 16, radix_display_t dis
 // The way in which the number is displayed is defined in radix_types.hpp
 // Using any other value for the display type causes std::invalid_argument to be thrown
 
-std::string to_string(float f,  real_display_t display = display_mixed, unsigned width = 0, unsigned precision = 6)
-  throw();
-std::string to_string(double f, real_display_t display = display_mixed, unsigned width = 0, unsigned precision = 6)
-  throw();
+std::string to_string(float f, real_display_t display = display_mixed, unsigned width = 0,
+                      unsigned precision = 6) throw();
+std::string to_string(double f, real_display_t display = display_mixed, unsigned width = 0,
+                      unsigned precision = 6) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
 // Convert a string to string
@@ -98,37 +99,27 @@ std::string to_string(const char* value);
 // The radix must be either zero as explained above, or in the range 2 to 16
 // Any other value will cause std::invalid_argument to be thrown
 
-bool to_bool(const std::string& value, unsigned radix = 0)
-  throw();
+bool to_bool(const std::string& value, unsigned radix = 0) throw();
 
-short to_short(const std::string& value, unsigned radix = 0)
-  throw();
+short to_short(const std::string& value, unsigned radix = 0) throw();
 
-unsigned short to_ushort(const std::string& value, unsigned radix = 0)
-  throw();
+unsigned short to_ushort(const std::string& value, unsigned radix = 0) throw();
 
-int to_int(const std::string& value, unsigned radix = 0)
-  throw();
+int to_int(const std::string& value, unsigned radix = 0) throw();
 
-unsigned int to_uint(const std::string& value, unsigned radix = 0)
-  throw();
+unsigned int to_uint(const std::string& value, unsigned radix = 0) throw();
 
-long to_long(const std::string& value, unsigned radix = 0)
-  throw();
+long to_long(const std::string& value, unsigned radix = 0) throw();
 
-unsigned long to_ulong(const std::string& value, unsigned radix = 0)
-  throw();
+unsigned long to_ulong(const std::string& value, unsigned radix = 0) throw();
 
-void* to_void_star(const std::string& value, unsigned radix = 0)
-  throw();
+void* to_void_star(const std::string& value, unsigned radix = 0) throw();
 
 // Convert a floating-point type
 
-float to_float(const std::string& value)
-  throw();
+float to_float(const std::string& value) throw();
 
-double to_double(const std::string& value)
-  throw();
+double to_double(const std::string& value) throw();
 
 ////////////////////////////////////////////////////////////////////////////////
 // template string conversions for pointers and STL containers
@@ -136,30 +127,33 @@ double to_double(const std::string& value)
 // Note: STLplus containers tend to have built-in string conversion functions consistent with these
 
 template <typename T>
-std::string pointer_to_string(const T* value, const std::string& null_string, const std::string& prefix, const std::string& suffix);
+std::string pointer_to_string(const T* value, const std::string& null_string, const std::string& prefix,
+                              const std::string& suffix);
 
-template<size_t N>
+template <size_t N>
 std::string bitset_to_string(const std::bitset<N>& data);
 
-template<typename T>
+template <typename T>
 std::string list_to_string(const std::list<T>& values, const std::string& separator);
 
-template<typename L, typename R>
-std::string pair_to_string(const std::pair<L,R>& values, const std::string& separator);
+template <typename L, typename R>
+std::string pair_to_string(const std::pair<L, R>& values, const std::string& separator);
 
-template<typename K, typename T, typename P>
-std::string map_to_string(const std::map<K,T,P>& values, const std::string& pair_separator, const std::string& separator);
+template <typename K, typename T, typename P>
+std::string map_to_string(const std::map<K, T, P>& values, const std::string& pair_separator,
+                          const std::string& separator);
 
-template<typename K, typename T, typename P>
-std::string multimap_to_string(const std::multimap<K,T,P>& values, const std::string& pair_separator, const std::string& separator);
+template <typename K, typename T, typename P>
+std::string multimap_to_string(const std::multimap<K, T, P>& values, const std::string& pair_separator,
+                               const std::string& separator);
 
-template<typename K, typename P>
-std::string set_to_string(const std::set<K,P>& values, const std::string& separator);
+template <typename K, typename P>
+std::string set_to_string(const std::set<K, P>& values, const std::string& separator);
 
-template<typename K, typename P>
-std::string multiset_to_string(const std::multiset<K,P>& values, const std::string& separator);
+template <typename K, typename P>
+std::string multiset_to_string(const std::multiset<K, P>& values, const std::string& separator);
 
-template<typename T>
+template <typename T>
 std::string vector_to_string(const std::vector<T>& values, const std::string& separator);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -180,57 +174,37 @@ otext& print_indent(otext& str, unsigned indent);
 // print routines for integer types
 // the arguments are as for the to_string
 
-otext& print(otext& str, const bool& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const bool& value, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+             unsigned width = 0) throw();
 
-otext& print(otext& str, const short& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const short& value, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+             unsigned width = 0) throw();
 
-otext& print(otext& str, const unsigned short& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const unsigned short& value, unsigned radix = 10,
+             radix_display_t display = radix_c_style_or_hash, unsigned width = 0) throw();
 
-otext& print(otext& str, const int& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const int& value, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+             unsigned width = 0) throw();
 
-otext& print(otext& str, const unsigned int& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const unsigned int& value, unsigned radix = 10,
+             radix_display_t display = radix_c_style_or_hash, unsigned width = 0) throw();
 
-otext& print(otext& str, const long& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const long& value, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+             unsigned width = 0) throw();
 
-otext& print(otext& str, const unsigned long& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const unsigned long& value, unsigned radix = 10,
+             radix_display_t display = radix_c_style_or_hash, unsigned width = 0) throw();
 
-otext& print(otext& str, const void*& value,
-             unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
-             unsigned width = 0)
-  throw();
+otext& print(otext& str, const void*& value, unsigned radix = 10, radix_display_t display = radix_c_style_or_hash,
+             unsigned width = 0) throw();
 
 // print routines for floating-point types
 
-otext& print(otext& str, float f, 
-             real_display_t display = display_mixed,
-             unsigned width = 0, unsigned precision = 6)
-  throw();
+otext& print(otext& str, float f, real_display_t display = display_mixed, unsigned width = 0,
+             unsigned precision = 6) throw();
 
-otext& print(otext& str, double f,
-             real_display_t display = display_mixed,
-             unsigned width = 0, unsigned precision = 6)
-  throw();
+otext& print(otext& str, double f, real_display_t display = display_mixed, unsigned width = 0,
+             unsigned precision = 6) throw();
 
 // print routines for string
 // this is needed for completeness, e.g. when calling print_vector on a vector of strings
@@ -244,50 +218,53 @@ otext& print(otext& str, const std::string& value, unsigned indent);
 // STLplus containers have these built-in
 
 template <typename T>
-otext& print_pointer(otext& str, const T* value,
-                     const std::string& null_string, const std::string& prefix, const std::string& suffix);
+otext& print_pointer(otext& str, const T* value, const std::string& null_string, const std::string& prefix,
+                     const std::string& suffix);
 template <typename T>
-otext& print_pointer(otext& str, const T* value, unsigned indent,
-                     const std::string& null_string, const std::string& prefix, const std::string& suffix);
+otext& print_pointer(otext& str, const T* value, unsigned indent, const std::string& null_string,
+                     const std::string& prefix, const std::string& suffix);
 
-template<size_t N>
+template <size_t N>
 otext& print_bitset(otext& str, const std::bitset<N>& value);
-template<size_t N>
+template <size_t N>
 otext& print_bitset(otext& str, const std::bitset<N>& value, unsigned indent);
 
-template<typename T> 
+template <typename T>
 otext& print_list(otext& str, const std::list<T>& values, const std::string& separator);
-template<typename T> 
+template <typename T>
 otext& print_list(otext& str, const std::list<T>& values, unsigned indent);
 
-template<typename L, typename R>
-otext& print_pair(otext& str, const std::pair<L,R>& values, const std::string& separator);
-template<typename L, typename R>
-otext& print_pair(otext& str, const std::pair<L,R>& values, const std::string& separator, unsigned indent);
+template <typename L, typename R>
+otext& print_pair(otext& str, const std::pair<L, R>& values, const std::string& separator);
+template <typename L, typename R>
+otext& print_pair(otext& str, const std::pair<L, R>& values, const std::string& separator, unsigned indent);
 
-template<typename K, typename T, typename P>
-otext& print_map(otext& str, const std::map<K,T,P>& values, const std::string& pair_separator, const std::string& separator);
-template<typename K, typename T, typename P>
-otext& print_map(otext& str, const std::map<K,T,P>& values, const std::string& pair_separator, unsigned indent);
+template <typename K, typename T, typename P>
+otext& print_map(otext& str, const std::map<K, T, P>& values, const std::string& pair_separator,
+                 const std::string& separator);
+template <typename K, typename T, typename P>
+otext& print_map(otext& str, const std::map<K, T, P>& values, const std::string& pair_separator, unsigned indent);
 
-template<typename K, typename T, typename P>
-otext& print_multimap(otext& str, const std::multimap<K,T,P>& values, const std::string& pair_separator, const std::string& separator);
-template<typename K, typename T, typename P>
-otext& print_multimap(otext& str, const std::multimap<K,T,P>& values, const std::string& pair_separator, unsigned indent);
+template <typename K, typename T, typename P>
+otext& print_multimap(otext& str, const std::multimap<K, T, P>& values, const std::string& pair_separator,
+                      const std::string& separator);
+template <typename K, typename T, typename P>
+otext& print_multimap(otext& str, const std::multimap<K, T, P>& values, const std::string& pair_separator,
+                      unsigned indent);
 
-template<typename K, typename P>
-otext& print_set(otext& str, const std::set<K,P>& values, const std::string& separator);
-template<typename K, typename P> 
-otext& print_set(otext& str, const std::set<K,P>& values, unsigned indent);
+template <typename K, typename P>
+otext& print_set(otext& str, const std::set<K, P>& values, const std::string& separator);
+template <typename K, typename P>
+otext& print_set(otext& str, const std::set<K, P>& values, unsigned indent);
 
-template<typename K, typename P> 
-otext& print_multiset(otext& str, const std::multiset<K,P>& values, const std::string& separator);
-template<typename K, typename P> 
-otext& print_multiset(otext& str, const std::multiset<K,P>& values, unsigned indent);
+template <typename K, typename P>
+otext& print_multiset(otext& str, const std::multiset<K, P>& values, const std::string& separator);
+template <typename K, typename P>
+otext& print_multiset(otext& str, const std::multiset<K, P>& values, unsigned indent);
 
-template<typename T> 
+template <typename T>
 otext& print_vector(otext& str, const std::vector<T>& values, const std::string& separator);
-template<typename T> 
+template <typename T>
 otext& print_vector(otext& str, const std::vector<T>& values, unsigned indent);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -299,8 +276,7 @@ otext& print_vector(otext& str, const std::vector<T>& values, unsigned indent);
 // The definitions for the alignment are declared in format_types.hpp
 // Any other value will cause std::invalid_argument to be thrown
 
-std::string pad(const std::string& str, alignment_t alignment, unsigned width, char padch = ' ')
-  throw();
+std::string pad(const std::string& str, alignment_t alignment, unsigned width, char padch = ' ') throw();
 
 // whitespace trimming
 std::string trim_left(const std::string& val);
@@ -315,7 +291,8 @@ std::string uppercase(const std::string& val);
 // for example:
 //   filename = translate(filename, "abcdefghijklmnopqrstuvwxyz", "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
 // converts the filename to uppercase and returns the result (Note that the uppercase function does this more easily).
-// if the from_set is longer than the to_set, then the overlap represents characters to delete (i.e. they map to nothing)
+// if the from_set is longer than the to_set, then the overlap represents characters to delete (i.e. they map to
+// nothing)
 std::string translate(const std::string& input, const std::string& from_set, const std::string& to_set);
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -339,14 +316,14 @@ bool match_wildcard(const std::string& wild, const std::string& match);
 // the splitter is removed
 // a string with no splitter in it will give a single-vector string
 // an empty string gives an empty vector
-std::vector<std::string> split (const std::string& str, const std::string& splitter = "\n");
+std::vector<std::string> split(const std::string& str, const std::string& splitter = "\n");
 
 // the reverse of the above
 // joins the string vector to create a single string with the joiner inserted between the joins
 // Note: the joiner will not be added at the beginning or the end
 // However, there are optional fields to add such prefix and suffix strings
-std::string join (const std::vector<std::string>&,
-                  const std::string& joiner = "\n", const std::string& prefix = "", const std::string& suffix = "");
+std::string join(const std::vector<std::string>&, const std::string& joiner = "\n", const std::string& prefix = "",
+                 const std::string& suffix = "");
 
 ////////////////////////////////////////////////////////////////////////////////
 // special displays

--- a/src/stlplus/include/RAT/stringio.hpp
+++ b/src/stlplus/include/RAT/stringio.hpp
@@ -9,62 +9,65 @@
   Classes for redirecting I/O to/from a string
 
   ------------------------------------------------------------------------------*/
+#include <string>
+
 #include "os_fixes.hpp"
 #include "textio.hpp"
-#include <string>
 
 ////////////////////////////////////////////////////////////////////////////////
 // string Output
 
-class ostext : public otext
-{
-public:
+class ostext : public otext {
+ public:
   ostext(void);
   std::string& get_string(void);
   const std::string& get_string(void) const;
 };
 
-class osbuff : public obuff
-{
-protected:
+class osbuff : public obuff {
+ protected:
   friend class ostext;
   std::string m_data;
-public:
+
+ public:
   osbuff(void);
-protected:
-  virtual unsigned put (unsigned char);
-private:
+
+ protected:
+  virtual unsigned put(unsigned char);
+
+ private:
   // make this class uncopyable
   osbuff(const osbuff&);
-  osbuff& operator = (const osbuff&);
+  osbuff& operator=(const osbuff&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 // string Input
 
-class istext : public itext
-{
-public:
+class istext : public itext {
+ public:
   istext(const std::string& data);
   std::string& get_string(void);
   const std::string& get_string(void) const;
 };
 
-class isbuff : public ibuff
-{
-protected:
+class isbuff : public ibuff {
+ protected:
   friend class istext;
   std::string m_data;
   unsigned m_index;
-public:
+
+ public:
   isbuff(const std::string& data);
-protected:
-  virtual int peek (void);
-  virtual int get (void);
-private:
+
+ protected:
+  virtual int peek(void);
+  virtual int get(void);
+
+ private:
   // make this class uncopyable
   isbuff(const isbuff&);
-  isbuff& operator = (const isbuff&);
+  isbuff& operator=(const isbuff&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/stlplus/include/RAT/textio.hpp
+++ b/src/stlplus/include/RAT/textio.hpp
@@ -7,10 +7,11 @@
   License:   BSD License, see ../docs/license.html
 
   ------------------------------------------------------------------------------*/
-#include "os_fixes.hpp"
-#include "format_types.hpp"
-#include <vector>
 #include <string>
+#include <vector>
+
+#include "format_types.hpp"
+#include "os_fixes.hpp"
 
 ////////////////////////////////////////////////////////////////////////////////
 // Builtin error codes - you can add your own when you create a new derivative
@@ -33,14 +34,13 @@ extern const int textio_open_failed;
 class obuff;
 class itext;
 
-class otext
-{
-protected:
+class otext {
+ protected:
   friend class obuff;
   friend class itext;
   obuff* m_buffer;
 
-public:
+ public:
   ////////////////////////////////////////////////////////////////////////////////
   // Local Types
   // These local enumerations are in the otext namespace
@@ -49,13 +49,12 @@ public:
   // The user of TextIO should always use '\n' for newlines, then TextIO will do the conversions
   // default: native
   // I appended the _mode suffix to avoid conflicts with macros
-  enum newline_t
-  {
-    binary_mode, // no end of line conversion
-    unix_mode,   // Unix conversions (LF)
-    msdos_mode,  // MS-DOS conversion (CR-LF)
-    macos_mode,  // MacOS conversion (CR)
-    // the mode of the platform you compiled this on
+  enum newline_t {
+    binary_mode,  // no end of line conversion
+    unix_mode,    // Unix conversions (LF)
+    msdos_mode,   // MS-DOS conversion (CR-LF)
+    macos_mode,   // MacOS conversion (CR)
+                  // the mode of the platform you compiled this on
 #if defined(_WIN32)
     native_mode = msdos_mode
 #else
@@ -69,8 +68,7 @@ public:
 #endif
   // Open Mode
   // only used for otext devices where the two modes make sense, e.g. files but not pipes
-  enum open_t
-  {
+  enum open_t {
     overwrite,  // destroy previous contents (default)
     append      // append to previous contents
   };
@@ -108,7 +106,7 @@ public:
 
   // copy and assign create aliases - no deep copy is available - no deep copy makes sense!
   otext(const otext&);
-  otext& operator = (const otext&);
+  otext& operator=(const otext&);
 
   // test the buffer's error function
   bool error(void) const;
@@ -168,8 +166,8 @@ public:
   void flush(void);
 
   // test whether the device is capable of accepting/not accepting output
-  operator bool (void) const;
-  bool operator ! (void) const;
+  operator bool(void) const;
+  bool operator!(void) const;
 
   // the pipe operators << are the main functions used with otext and its derivates
   // they are used in the form:
@@ -177,39 +175,39 @@ public:
 
   // single character
   // TODO - wide char
-  otext& operator << (char);
-  otext& operator << (signed char);
-  otext& operator << (unsigned char);
+  otext& operator<<(char);
+  otext& operator<<(signed char);
+  otext& operator<<(unsigned char);
 
   // string output
-  otext& operator << (const char*);
-  otext& operator << (const std::string&);
+  otext& operator<<(const char*);
+  otext& operator<<(const std::string&);
 
   // string vector - writes whole array as a series of newline separated strings
-  otext& operator << (const std::vector<std::string>&);
+  otext& operator<<(const std::vector<std::string>&);
 
   // integer output
-  otext& operator << (bool);
-  otext& operator << (short);
-  otext& operator << (unsigned short);
-  otext& operator << (int);
-  otext& operator << (unsigned int);
-  otext& operator << (long); 
-  otext& operator << (unsigned long);
+  otext& operator<<(bool);
+  otext& operator<<(short);
+  otext& operator<<(unsigned short);
+  otext& operator<<(int);
+  otext& operator<<(unsigned int);
+  otext& operator<<(long);
+  otext& operator<<(unsigned long);
 
   // floating point output
-  otext& operator << (float);
-  otext& operator << (double);
+  otext& operator<<(float);
+  otext& operator<<(double);
 
   // pointer output, compatible with >> operator for void*;
-  otext& operator << (const void*);
+  otext& operator<<(const void*);
 
   // manipulator - applies passed function to stream;
-  otext& operator << (manipulator_function);
+  otext& operator<<(manipulator_function);
 
   // pipe operator - pours one stream into the other until eof();
   // this is an easy way to copy one device into another
-  otext& operator << (itext&);
+  otext& operator<<(itext&);
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -241,22 +239,20 @@ const char null = '\0';
 
 class ibuff;
 
-class itext
-{
-protected:
+class itext {
+ protected:
   friend class otext;
   friend class ibuff;
   ibuff* m_buffer;
 
-public:
+ public:
   ////////////////////////////////////////////////////////////////////////////////
   // Newline conversion
   // When conversion is on, all end-of-line conventions (LF, CR-LF, CR) will be converted into a '\n'
   // When conversion is off, data comes in unmodified - note that this can make the eoln() test act strangely
-  enum newline_t
-  {
-    binary_mode,      // no end of line conversion
-    convert_mode      // recognise and convert all end-of-line conventions
+  enum newline_t {
+    binary_mode,  // no end of line conversion
+    convert_mode  // recognise and convert all end-of-line conventions
   };
 #ifndef __CINT__
   friend std::string to_string(newline_t);
@@ -266,7 +262,7 @@ public:
 
   typedef void (*manipulator_function)(itext&);
 
-public:
+ public:
   // create an uninitialised itext
   itext(void);
 
@@ -275,7 +271,7 @@ public:
 
   // closes the itext if it is open and destroys any structures - including the buffer
   virtual ~itext(void);
-   
+
   // test whether the itext has a buffer attached
   bool initialised(void) const;
 
@@ -287,8 +283,8 @@ public:
 
   // copy and assignment create aliases - it is not sensible to allow a deep copy (think about it)
   itext(const itext&);
-  itext& operator = (const itext&);
-   
+  itext& operator=(const itext&);
+
   // test the buffer's error flag or retrieve its value
   bool error(void) const;
   int error_number(void) const;
@@ -312,7 +308,7 @@ public:
   // Both return -1 to indicate EOF
   int peek(void);
   int get(void);
-   
+
   // number of characters read through the itext member functions
   unsigned long bytes(void) const;
   // line and column for last character read
@@ -321,10 +317,10 @@ public:
   unsigned column(void) const;
 
   // tests for whether an itext has/hasn't got text to be read
-  bool good (void);
-  operator bool (void);
-  bool operator ! (void);
-   
+  bool good(void);
+  operator bool(void);
+  bool operator!(void);
+
   ////////////////////////////////////////////////////////////////////////////////
   // input-pipe operators are the main usage of itext
   // used in the form:
@@ -332,46 +328,46 @@ public:
   // device is any derivative of itext, object is any type with a >> operator defined (you can overload)
 
   // just get next character, including any whitespace or end of line character;
-  itext& operator >> (char&);
-  itext& operator >> (signed char&);
-  itext& operator >> (unsigned char&);
+  itext& operator>>(char&);
+  itext& operator>>(signed char&);
+  itext& operator>>(unsigned char&);
 
   // skipwhite before reading then read until a whitespace is found
   // this is a kind of tokenising operator
-  itext& operator >> (std::string&);
+  itext& operator>>(std::string&);
   // gets the whole line
   bool getline(std::string& line);
 
   // get the whole file as a vector of strings, using newlines to split the input
-  itext& operator >> (std::vector<std::string>&);
+  itext& operator>>(std::vector<std::string>&);
 
   // integer operations: skipwhite then read an integer in any of the recognised formats:
   // decimal: 12345
   // octal:   012345
   // hex:     0x12345
   // hash:    13#12345
-  itext& operator >> (bool&);
-  itext& operator >> (short&);
-  itext& operator >> (unsigned short&);
-  itext& operator >> (int&);
-  itext& operator >> (unsigned int&);
-  itext& operator >> (long&);
-  itext& operator >> (unsigned long&);
+  itext& operator>>(bool&);
+  itext& operator>>(short&);
+  itext& operator>>(unsigned short&);
+  itext& operator>>(int&);
+  itext& operator>>(unsigned int&);
+  itext& operator>>(long&);
+  itext& operator>>(unsigned long&);
 
   // real operations, skipwhite then read floating-point number - fraction and exponent are optional
-  itext& operator >> (float&);
-  itext& operator >> (double&);
+  itext& operator>>(float&);
+  itext& operator>>(double&);
 
   // Hide this function to make some GCC versions happy
   // pointer operator, skipwhite, then reads a pointer written by << operator for void*
-  //itext& operator >> (void*&);
+  // itext& operator >> (void*&);
 
   // manipulator - applies passed manipulator function to stream;
-  itext& operator >> (manipulator_function);
+  itext& operator>>(manipulator_function);
 
   // pipe operator - pours one stream into the other until eof();
   // this is the easiest way to make a copy
-  itext& operator >> (otext&);
+  itext& operator>>(otext&);
 };
 
 // manipulators, used in the form: fin >> skipwhite >> ch
@@ -400,9 +396,8 @@ void close(itext&);
 
 // Output Buffer
 
-class obuff
-{
-public:
+class obuff {
+ public:
   // constructor initialises output buffer with the mode fields - line buffering mode and newline conversion mode
   obuff(bool line_buffer = false, otext::newline_t newline = otext::native_mode);
 
@@ -427,22 +422,22 @@ public:
   unsigned integer_width(void) const;
   void set_integer_width(unsigned);
   // base for integer display - from 2-36, default: 10
-  unsigned integer_radix(void) const; 
-  void set_integer_radix(unsigned); 
+  unsigned integer_radix(void) const;
+  void set_integer_radix(unsigned);
   // how to display an integer - see string_utilities, default: c_style_or_hash
-  radix_display_t integer_display(void) const; 
-  void set_integer_display(radix_display_t); 
+  radix_display_t integer_display(void) const;
+  void set_integer_display(radix_display_t);
 
   // Real formatting fields
   // field width for next formattable real type, default: 0
   unsigned real_width(void) const;
   void set_real_width(unsigned);
   // number of significant digits
-  unsigned real_precision(void) const; 
-  void set_real_precision(unsigned); 
+  unsigned real_precision(void) const;
+  void set_real_precision(unsigned);
   // how to display a real - see string_utilities, default: display_mixed
-  real_display_t real_display(void) const; 
-  void set_real_display(real_display_t); 
+  real_display_t real_display(void) const;
+  void set_real_display(real_display_t);
 
   // Error number
   // zero if there is no error, any integer for an error
@@ -480,12 +475,12 @@ public:
   // the default destructor does nothing - overload this only if you need to
   virtual ~obuff(void);
 
-private:
+ private:
   // disallow copying
-  obuff& operator = (const obuff&);
+  obuff& operator=(const obuff&);
   obuff(const obuff&);
 
-protected:
+ protected:
   friend class otext;
   bool m_line_buffer;
   otext::newline_t m_newline;
@@ -504,9 +499,8 @@ protected:
 
 // Input Buffer
 
-class ibuff
-{
-public:
+class ibuff {
+ public:
   ibuff(itext::newline_t newline = itext::convert_mode);
 
   // Total number of characters read through get()
@@ -530,7 +524,6 @@ public:
   int error_number(void) const;
   virtual std::string error_string(void) const;
 
-
   // Customisation
   // create a new buffer by customising the following functions
   // you should also provide a destructor (also virtual) if your buffer needs closedown actions
@@ -546,12 +539,12 @@ public:
   // default destructor does nothing
   virtual ~ibuff(void);
 
-private:
+ private:
   // disallow copying
-  ibuff& operator = (const ibuff&);
+  ibuff& operator=(const ibuff&);
   ibuff(const ibuff&);
 
-protected:
+ protected:
   friend class itext;
   itext::newline_t m_newline_mode;
   unsigned long m_bytes;


### PR DESCRIPTION
This PR addresses issue #108  and expands upon the Makefile changes made on PR #106 . Previously a pre-commit hook is added to a user's directory when ratpac is installed to prevent improperly formatted code from being introduced to the repo. This led to errors upon commit when `clang-format` is not installed. The following approach is adopted here:
1. The formatting script will now print out the following error message and exit gracefully when `clang-format` is not present. ```clang-format is not installed. Formatting rules won't be auto applied upon commit.
Consider installing clang-format to ensure consistent formatting across the project, especially if you plan to contribute.```
2. Upon pull requests and pushes, a github action will be ran to check if formatting across the repo is consistent throughout. If a formatting check has failed, maintainers can politely ask the contributor to modify their code before they are merged.