### PR TITLE
fix decay chain issue reading in branching ratio and several other quantities

### DIFF
--- a/src/gen/src/BetaFunction.cc
+++ b/src/gen/src/BetaFunction.cc
@@ -401,7 +401,7 @@ bool BetaFunction::ReadInputFile(const std::string dName, int iZ, int iA, int iT
     std::string iString(dummy);
     if (iString == dProbe) {
       fscanf(inputFile, "%s", tName);
-      fscanf(inputFile, "%d %d %f", &Z, &A, &tau);
+      fscanf(inputFile, "%d %d %lf", &Z, &A, &tau);
       std::string iString2(tName);
       iFound = (dName == iString2);
       iFound = ((iFound) || ((iA == A) && (iZ == Z)));
@@ -414,13 +414,13 @@ bool BetaFunction::ReadInputFile(const std::string dName, int iZ, int iA, int iT
 
         bool iScan = true;
         while (iScan) {
-          bool parseSuccess = fscanf(inputFile, "%f %d %f %d", &iBr, &iSpin, &W0, &nP) == 4;
+          bool parseSuccess = fscanf(inputFile, "%lf %d %lf %d", &iBr, &iSpin, &W0, &nP) == 4;
           SetBranches((double)iBr, iSpin, (double)W0);
           for (int j = 0; j < nReadGamma; j++) {
             parseSuccess &= fscanf(inputFile, "%f", &eP[j]) == 1;
             if (eP[j] > 0.) SetGammas((double)eP[j]);
           }
-          parseSuccess &= fscanf(inputFile, "%f %f %f", &aC[0], &aC[1], &aC[2]) == 3;
+          parseSuccess &= fscanf(inputFile, "%lf %lf %lf", &aC[0], &aC[1], &aC[2]) == 3;
           if (iBr >= 1.) {
             iScan = false;
           }

--- a/src/gen/src/DecayChain.cc
+++ b/src/gen/src/DecayChain.cc
@@ -196,7 +196,7 @@ bool DecayChain::ReadInputFile(const std::string dName) {
           printf("Reading %s \n \n", tName);
         }
         for (int j = 0; j < eP; j++) {
-          fscanf(inputFile, "%s %d %f %d %f", sName, &iChain, &weight, &iDecay, &tau);
+          fscanf(inputFile, "%s %d %lf %d %lf", sName, &iChain, &weight, &iDecay, &tau);
           std::string iString3(sName);
           if (iDecay != NullParticle && !fAlphaDecayStart) {
             AddElement(iString3, iChain, iDecay, (double)tau, (double)weight);


### PR DESCRIPTION
Doubles should be read in using %lf according to the man page for [fscanf](https://cplusplus.com/reference/cstdio/fscanf/). I have no idea why this only broke now.