### PR TITLE
fix comparison in splitevdaq

### DIFF
--- a/ratdb/DAQ.ratdb
+++ b/ratdb/DAQ.ratdb
@@ -20,12 +20,12 @@ index: "SplitEVDAQ",
 valid_begin: [0, 0],
 valid_end: [0, 0],
 
-pulse_width: 100.0,
+pulse_width: 10.0, // in ns
 trigger_threshold: 8.0,
 trigger_window: 600.0,
 pmt_lockout: 400.0,
 trigger_lockout: 0.0,
-trigger_resolution: 0.005,
+trigger_resolution: 0.05, // in ns
 lookback: 200.0,
 max_hit_time: 1000000.0,
 trigger_on_noise: 1,

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -91,6 +91,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
   // _| |__| |___| |___
   int nbins = floor((end - start) / fTriggerResolution) + 1;
   double bw = fTriggerResolution;
+
   std::vector<double> triggerTrain(nbins);
   for (auto v : trigPulses) {
     int select = int((v - start) / bw);
@@ -108,7 +109,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
   for (int i = 0; i < nbins; i++) {
     double x = triggerTrain[i];
     if (x > 0) {
-      for (int j = i; j < i + fPulseWidth; j++) {
+      for (int j = i; j < i + int(fPulseWidth/bw); j++) {
         if (j >= nbins) break;
         triggerHistogram[j] += x;
       }


### PR DESCRIPTION
The pulse width (units of ns) was being compared to the trigger bin width (in arb. units based on the desired resolution).  I also adjusted the trigger pulse to 10 ns and the trigger resolution to 0.05 ns (more realistic for Eos, and can be easily changed for other detectors). 