### PR TITLE
Create GitHub action to test build ratpac2 and experiment

### DIFF
--- a/.github/workflows/build-experiment.yml
+++ b/.github/workflows/build-experiment.yml
@@ -1,0 +1,39 @@
+name: Build RatpacExperiment
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: 
+      image: stjimmys/ratpac2-deps:latest
+      options: --user root
+    steps:
+    - name: Checkout Ratpac2
+      uses: actions/checkout@v4
+      with:
+        path: ratpac2
+    
+    - name: Checkout RatpacExperiment
+      uses: actions/checkout@v4
+      with:
+        repository: rat-pac/RatpacExperiment
+        path: ratpacExperiment
+    
+    - name: Build Ratpac2
+      working-directory: ratpac2
+      shell: bash
+      run: |
+        source /ratpac-setup/env.sh
+        make -j$(nproc)
+      
+    - name: Build RatpacExperiment
+      working-directory: ratpacExperiment
+      shell: bash
+      run: |
+        source /ratpac-setup/env.sh
+        source ../ratpac2/ratpac.sh
+        make -j$(nproc)


### PR DESCRIPTION
This workflow should run on every PR as well as all pushes to main, as well as over manual workflow dispatch. It clones the ratpac2 and ratpacExperiment repos in a docker (built via RatpacSetup), and attempts to build both repos using specified make commands.

__Note: The image currently used is located in my personal dockerhub account and is built based on a fork of ratpacSetup, this is because CI in the official ratpacSetup repo is not configured for docker builds yet. I will update the docker image used once CIs are setup over there.__