### PR TITLE
Add ability to export simulation geometry to GDML/JSON

### DIFF
--- a/src/db/include/RAT/DB.hh
+++ b/src/db/include/RAT/DB.hh
@@ -243,6 +243,14 @@ class DB : public DBFieldCallback {
   // DO THIS AFTER loading files from disk, or your changes will be
   // stomped on later.
 
+  /** Obtain a reference to all tables stored in the databse.
+   *
+   *  This is useful if you want to iterate over all the tables in
+   *  the database.
+   *  @todo: Should also implement this for server tables.
+   */
+  const DBTableSet &GetAllTables() { return tables; };
+
   /** Set field in user plane, no table index. */
   template <typename T>
   void Set(const std::string &tblname, const std::string &fieldname, const T &val);
@@ -259,6 +267,11 @@ class DB : public DBFieldCallback {
   template <typename T>
   void SetArrayIndex(const std::string &tblname, const std::string &index, const std::string &fieldname, size_t idx,
                      const T &val);
+
+  /** Dump all tables in the db to a JSON file.
+   * @todo: Currently doesn't support server tables
+   * */
+  void DumpContentsToJson(std::ostream &stream);
 
   /************************DBLink interface********************/
   // This is the low level interface that DBLinks use.

--- a/src/db/include/RAT/json.hh
+++ b/src/db/include/RAT/json.hh
@@ -437,7 +437,7 @@ class Writer {
   // truncate into signed Ultimately produces object-indented text with
   // value-per-line mentality with arrays on a single line which is similar
   // enough to how RATDB looks without too much effort.
-  void putValue(const Value &value);
+  void putValue(const Value &value, const std::string &delim = "\n");
 
  protected:
   // The stream to write to

--- a/src/db/src/DB.cc
+++ b/src/db/src/DB.cc
@@ -467,4 +467,22 @@ std::vector<DBTable *> DB::ReadRATDBFile(const std::string &filename) {
   return contents;
 }
 
+void DB::DumpContentsToJson(std::ostream &stream) {
+  json::Writer writer(stream);
+  stream << "[\n";
+  const DBTableSet &tables = GetAllTables();
+  bool first = true;
+  for (auto table : tables) {
+    if (!first) stream << ",\n";
+    first = false;
+    // include key information in table if it is not already in there
+    table.second->Set("name", table.second->GetName());
+    table.second->Set("index", table.second->GetIndex());
+    table.second->Set("valid_begin", table.second->GetRunBegin());
+    table.second->Set("valid_end", table.second->GetRunEnd());
+    writer.putValue(table.second->GetCompleteJSON(), "");
+  }
+  stream << "\n]\n";
+}
+
 }  // namespace RAT

--- a/src/db/src/json.cc
+++ b/src/db/src/json.cc
@@ -516,9 +516,9 @@ Writer::Writer(std::ostream &stream) : out(stream) {}
 
 Writer::~Writer() {}
 
-void Writer::putValue(const Value &value) {
+void Writer::putValue(const Value &value, const std::string &delim) {
   writeValue(value, "");
-  out << '\n';
+  out << delim;
 }
 
 void Writer::writeValue(const Value &value, const std::string &depth) {

--- a/src/geo/CMakeLists.txt
+++ b/src/geo/CMakeLists.txt
@@ -47,6 +47,12 @@ add_library(geo OBJECT
         src/WaterBoxConstruction.cc
         src/WLSPFactory.cc
         src/WLSPCoverFactory.cc
+        src/gdml/GDMLMessenger.cc
+        src/gdml/GDMLParser.cc
+        src/gdml/GDMLWriteParamvol.cc
+        src/gdml/GDMLWriteSolids.cc
+        src/gdml/GDMLWriteSetup.cc
+        src/gdml/GDMLWriteStructure.cc
         src/pmt/CubicPMTConstruction.cc
         src/pmt/LAPPDConstruction.cc
         src/pmt/PMTArrayFactory.cc

--- a/src/geo/include/RAT/GDMLMessenger.hh
+++ b/src/geo/include/RAT/GDMLMessenger.hh
@@ -1,9 +1,9 @@
 #ifndef GDMLMessenger_hh
 #define GDMLMessenger_hh
 
-#include "globals.hh"
 #include "G4UImessenger.hh"
 #include "G4VPhysicalVolume.hh"
+#include "globals.hh"
 
 class G4UIdirectory;
 class G4UIcmdWithAString;
@@ -14,33 +14,30 @@ class G4UIcmdWithABool;
 namespace RAT {
 class GDMLParser;
 
-class GDMLMessenger : public G4UImessenger
-{
-  public:
+class GDMLMessenger : public G4UImessenger {
+ public:
+  GDMLMessenger(GDMLParser*);
+  ~GDMLMessenger();
 
-    GDMLMessenger(GDMLParser*);
-    ~GDMLMessenger();
+  void SetNewValue(G4UIcommand*, G4String);
 
-    void SetNewValue(G4UIcommand*, G4String);
+ private:
+  GDMLParser* myParser = nullptr;
+  G4LogicalVolume* topvol = nullptr;
 
-  private:
+  G4UIdirectory* persistencyDir = nullptr;
+  G4UIdirectory* gdmlDir = nullptr;
+  G4UIcmdWithAString* ReaderCmd = nullptr;
+  G4UIcmdWithAString* WriterCmd = nullptr;
+  G4UIcmdWithAString* TopVolCmd = nullptr;
+  G4UIcmdWithoutParameter* ClearCmd = nullptr;
+  G4UIcmdWithABool* RegionCmd = nullptr;
+  G4UIcmdWithABool* EcutsCmd = nullptr;
+  G4UIcmdWithABool* SDCmd = nullptr;
+  G4UIcmdWithABool* StripCmd = nullptr;
+  G4UIcmdWithABool* AppendCmd = nullptr;
 
-    GDMLParser* myParser = nullptr;
-    G4LogicalVolume* topvol = nullptr;
-
-    G4UIdirectory* persistencyDir = nullptr;
-    G4UIdirectory* gdmlDir = nullptr;
-    G4UIcmdWithAString* ReaderCmd = nullptr;
-    G4UIcmdWithAString* WriterCmd = nullptr;
-    G4UIcmdWithAString* TopVolCmd = nullptr;
-    G4UIcmdWithoutParameter* ClearCmd = nullptr;
-    G4UIcmdWithABool* RegionCmd = nullptr;
-    G4UIcmdWithABool* EcutsCmd = nullptr;
-    G4UIcmdWithABool* SDCmd = nullptr;
-    G4UIcmdWithABool* StripCmd = nullptr;
-    G4UIcmdWithABool* AppendCmd = nullptr;
-
-    G4bool pFlag = true;  // Append pointers to names flag
+  G4bool pFlag = true;  // Append pointers to names flag
 };
-}
+}  // namespace RAT
 #endif

--- a/src/geo/include/RAT/GDMLMessenger.hh
+++ b/src/geo/include/RAT/GDMLMessenger.hh
@@ -1,0 +1,46 @@
+#ifndef GDMLMessenger_hh
+#define GDMLMessenger_hh
+
+#include "globals.hh"
+#include "G4UImessenger.hh"
+#include "G4VPhysicalVolume.hh"
+
+class G4UIdirectory;
+class G4UIcmdWithAString;
+class G4UIcmdWithADoubleAndUnit;
+class G4UIcmdWithoutParameter;
+class G4UIcmdWithABool;
+
+namespace RAT {
+class GDMLParser;
+
+class GDMLMessenger : public G4UImessenger
+{
+  public:
+
+    GDMLMessenger(GDMLParser*);
+    ~GDMLMessenger();
+
+    void SetNewValue(G4UIcommand*, G4String);
+
+  private:
+
+    GDMLParser* myParser = nullptr;
+    G4LogicalVolume* topvol = nullptr;
+
+    G4UIdirectory* persistencyDir = nullptr;
+    G4UIdirectory* gdmlDir = nullptr;
+    G4UIcmdWithAString* ReaderCmd = nullptr;
+    G4UIcmdWithAString* WriterCmd = nullptr;
+    G4UIcmdWithAString* TopVolCmd = nullptr;
+    G4UIcmdWithoutParameter* ClearCmd = nullptr;
+    G4UIcmdWithABool* RegionCmd = nullptr;
+    G4UIcmdWithABool* EcutsCmd = nullptr;
+    G4UIcmdWithABool* SDCmd = nullptr;
+    G4UIcmdWithABool* StripCmd = nullptr;
+    G4UIcmdWithABool* AppendCmd = nullptr;
+
+    G4bool pFlag = true;  // Append pointers to names flag
+};
+}
+#endif

--- a/src/geo/include/RAT/GDMLParser.hh
+++ b/src/geo/include/RAT/GDMLParser.hh
@@ -1,0 +1,378 @@
+#ifndef GDMLParser_hh
+#define GDMLParser_hh
+
+#include "G4GDMLReadStructure.hh"
+#include "RAT/GDMLWriteStructure.hh"
+#include "G4STRead.hh"
+#include "G4GDMLEvaluator.hh"
+#include "RAT/GDMLMessenger.hh"
+
+#include "G4TransportationManager.hh"
+#include "G4Navigator.hh"
+#include "G4Threading.hh"
+
+#define G4GDML_DEFAULT_SCHEMALOCATION                                          \
+  G4String("http://service-spi.web.cern.ch/service-spi/app/releases/GDML/"     \
+           "schema/gdml.xsd")
+
+namespace RAT {
+class GDMLParser
+{
+  public:
+
+    GDMLParser();
+    GDMLParser(G4GDMLReadStructure*);
+    GDMLParser(G4GDMLReadStructure*, GDMLWriteStructure*);
+    ~GDMLParser();
+    //
+    // Parser constructors & destructor
+
+    inline void Read(const G4String& filename, G4bool Validate = true);
+    //
+    // Imports geometry with world-volume, specified by the GDML filename
+    // in input. Validation against schema is activated by default.
+
+    inline void ReadModule(const G4String& filename, G4bool Validate = true);
+    //
+    // Imports a single GDML module, specified by the GDML filename
+    // in input. Validation against schema is activated by default.
+
+    inline void Write( const G4String& filename,
+                       const G4VPhysicalVolume* pvol = 0,
+                       G4bool storeReferences = true,
+                       const G4String& SchemaLocation = G4GDML_DEFAULT_SCHEMALOCATION);
+    //
+    // Exports on a GDML file, specified by 'filename' a geometry tree
+    // starting from 'pvol' as top volume. Uniqueness of stored entities
+    // is guaranteed by storing pointer-references by default.
+    // Alternative path for the schema location can be specified; by default
+    // the URL to the GDML web site is used.
+
+    inline void Write( const G4String& filename, const G4LogicalVolume* lvol,
+                       G4bool storeReferences = true,
+                       const G4String& SchemaLocation = G4GDML_DEFAULT_SCHEMALOCATION);
+    //
+    // Exports on a GDML file, specified by 'filename' a geometry tree
+    // starting from 'pvol' as top volume. Uniqueness of stored entities
+    // is guaranteed by storing pointer-references by default.
+    // Alternative path for the schema location can be specified; by default
+    // the URL to the GDML web site is used. Same as method above except
+    // that the logical volume must be provided here.
+
+    inline G4LogicalVolume* ParseST(const G4String& name, G4Material* medium,
+                                    G4Material* solid);
+    //
+    // Imports a tessellated geometry stored as STEP-Tools files
+    // 'name.geom' and 'name.tree'. It returns a pointer of a generated
+    // mother volume with 'medium' material associated, including the
+    // imported tessellated geometry with 'solid' material associated.
+
+    // Methods for Reader
+
+    inline G4bool IsValid(const G4String& name) const;
+    inline G4double GetConstant(const G4String& name) const;
+    inline G4double GetVariable(const G4String& name) const;
+    inline G4double GetQuantity(const G4String& name) const;
+    inline G4ThreeVector GetPosition(const G4String& name) const;
+    inline G4ThreeVector GetRotation(const G4String& name) const;
+    inline G4ThreeVector GetScale(const G4String& name) const;
+    inline G4GDMLMatrix GetMatrix(const G4String& name) const;
+    inline G4LogicalVolume* GetVolume(const G4String& name) const;
+    inline G4VPhysicalVolume* GetPhysVolume(const G4String& name) const;
+    inline G4VPhysicalVolume*
+           GetWorldVolume(const G4String& setupName = "Default") const;
+    inline G4GDMLAuxListType
+           GetVolumeAuxiliaryInformation(G4LogicalVolume* lvol) const;
+    inline const G4GDMLAuxMapType* GetAuxMap() const;
+    inline const G4GDMLAuxListType* GetAuxList() const;
+    inline void AddAuxiliary(G4GDMLAuxStructType myaux);
+    inline void StripNamePointers() const;
+    inline void SetStripFlag(G4bool);
+    inline void SetOverlapCheck(G4bool);
+    inline void SetRegionExport(G4bool);
+    inline void SetEnergyCutsExport(G4bool);
+    inline void SetSDExport(G4bool);
+    inline void SetReverseSearch(G4bool);
+
+    inline G4int GetMaxExportLevel() const;  // Manage max number of levels
+    inline void SetMaxExportLevel(G4int);    // to export
+
+    inline void Clear();  // Clears the evaluator
+
+    // Methods for Writer
+
+    inline void AddModule(const G4VPhysicalVolume* const physvol);
+    inline void AddModule(const G4int depth);
+    inline void SetAddPointerToName(G4bool set);
+    inline void AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
+                                   const G4LogicalVolume* const lvol);
+    inline void SetOutputFileOverwrite(G4bool flag);
+
+  private:
+
+    void ImportRegions();
+    void ExportRegions(G4bool storeReferences = true);
+
+  private:
+
+    G4GDMLEvaluator eval;
+    G4GDMLReadStructure* reader = nullptr;
+    GDMLWriteStructure* writer = nullptr;
+    G4GDMLAuxListType *rlist = nullptr, *ullist = nullptr;
+    GDMLMessenger* messenger = nullptr;
+    G4bool urcode = false, uwcode = false, strip = false, rexp = false;
+};
+
+inline void GDMLParser::Read(const G4String& filename, G4bool validate)
+{
+  if(G4Threading::IsMasterThread())
+  {
+    reader->Read(filename, validate, false, strip);
+    ImportRegions();
+  }
+}
+
+// --------------------------------------------------------------------
+inline void GDMLParser::ReadModule(const G4String& filename, G4bool validate)
+{
+  if(G4Threading::IsMasterThread())
+  {
+    reader->Read(filename, validate, true);
+    ImportRegions();
+  }
+}
+
+// --------------------------------------------------------------------
+inline void GDMLParser::Write(const G4String& filename,
+                                const G4VPhysicalVolume* pvol, G4bool refs,
+                                const G4String& schemaLocation)
+{
+  if(G4Threading::IsMasterThread())
+  {
+    const G4int depth     = 0;
+    G4LogicalVolume* lvol = nullptr;
+
+    if(pvol == nullptr)
+    {
+      lvol = G4TransportationManager::GetTransportationManager()
+               ->GetNavigatorForTracking()
+               ->GetWorldVolume()
+               ->GetLogicalVolume();
+    }
+    else
+    {
+      lvol = pvol->GetLogicalVolume();
+    }
+
+    if(rexp)
+    {
+      ExportRegions(refs);
+    }
+    writer->Write(filename, lvol, schemaLocation, depth, refs);
+  }
+}
+
+// --------------------------------------------------------------------
+inline void GDMLParser::Write(const G4String& filename,
+                                const G4LogicalVolume* lvol, G4bool refs,
+                                const G4String& schemaLocation)
+{
+  if(G4Threading::IsMasterThread())
+  {
+    const G4int depth = 0;
+
+    if(lvol == nullptr)
+    {
+      lvol = G4TransportationManager::GetTransportationManager()
+               ->GetNavigatorForTracking()
+               ->GetWorldVolume()
+               ->GetLogicalVolume();
+    }
+    if(rexp)
+    {
+      ExportRegions(refs);
+    }
+    writer->Write(filename, lvol, schemaLocation, depth, refs);
+  }
+}
+
+// --------------------------------------------------------------------
+inline G4LogicalVolume* GDMLParser::ParseST(const G4String& filename,
+                                              G4Material* medium,
+                                              G4Material* solid)
+{
+  if(G4Threading::IsMasterThread())
+  {
+    G4STRead STreader;
+    return STreader.Read(filename, medium, solid);
+  }
+  else
+  {
+    return nullptr;
+  }
+}
+
+// --------------------------------------------------------------------
+// Methods for Reader
+// --------------------------------------------------------------------
+
+inline G4bool GDMLParser::IsValid(const G4String& name) const
+{
+  return reader->IsValidID(name);
+}
+
+inline G4double GDMLParser::GetConstant(const G4String& name) const
+{
+  return reader->GetConstant(name);
+}
+
+inline G4double GDMLParser::GetVariable(const G4String& name) const
+{
+  return reader->GetVariable(name);
+}
+
+inline G4double GDMLParser::GetQuantity(const G4String& name) const
+{
+  return reader->GetQuantity(name);
+}
+
+inline G4ThreeVector GDMLParser::GetPosition(const G4String& name) const
+{
+  return reader->GetPosition(name);
+}
+
+inline G4ThreeVector GDMLParser::GetRotation(const G4String& name) const
+{
+  return reader->GetRotation(name);
+}
+
+inline G4ThreeVector GDMLParser::GetScale(const G4String& name) const
+{
+  return reader->GetScale(name);
+}
+
+inline G4GDMLMatrix GDMLParser::GetMatrix(const G4String& name) const
+{
+  return reader->GetMatrix(name);
+}
+
+inline G4LogicalVolume* GDMLParser::GetVolume(const G4String& name) const
+{
+  return reader->GetVolume(name);
+}
+
+inline G4VPhysicalVolume*
+GDMLParser::GetPhysVolume(const G4String& name) const
+{
+  return reader->GetPhysvol(name);
+}
+
+inline G4VPhysicalVolume*
+GDMLParser::GetWorldVolume(const G4String& setupName) const
+{
+  return reader->GetWorldVolume(setupName);
+}
+
+inline G4GDMLAuxListType
+GDMLParser::GetVolumeAuxiliaryInformation(G4LogicalVolume* logvol) const
+{
+  return reader->GetVolumeAuxiliaryInformation(logvol);
+}
+
+inline const G4GDMLAuxMapType* GDMLParser::GetAuxMap() const
+{
+  return reader->GetAuxMap();
+}
+
+inline const G4GDMLAuxListType* GDMLParser::GetAuxList() const
+{
+  return reader->GetAuxList();
+}
+
+inline void GDMLParser::AddAuxiliary(G4GDMLAuxStructType myaux)
+{
+  return writer->AddAuxiliary(myaux);
+}
+
+inline void GDMLParser::StripNamePointers() const
+{
+  reader->StripNames();
+}
+
+inline void GDMLParser::SetStripFlag(G4bool flag)
+{
+  strip = flag;
+}
+
+inline void GDMLParser::SetOverlapCheck(G4bool flag)
+{
+  reader->OverlapCheck(flag);
+}
+
+inline void GDMLParser::SetRegionExport(G4bool flag)
+{
+  rexp = flag;
+}
+
+inline void GDMLParser::SetEnergyCutsExport(G4bool flag)
+{
+  writer->SetEnergyCutsExport(flag);
+}
+
+inline void GDMLParser::SetSDExport(G4bool flag)
+{
+  writer->SetSDExport(flag);
+}
+
+inline void GDMLParser::SetReverseSearch(G4bool flag)
+{
+  reader->SetReverseSearch(flag);
+}
+
+inline G4int GDMLParser::GetMaxExportLevel() const
+{
+  return writer->GetMaxExportLevel();
+}
+
+inline void GDMLParser::SetMaxExportLevel(G4int level)
+{
+  writer->SetMaxExportLevel(level);
+}
+
+inline void GDMLParser::Clear()
+{
+  reader->Clear();
+}
+
+// --------------------------------------------------------------------
+// Methods for Writer
+// --------------------------------------------------------------------
+
+inline void GDMLParser::AddModule(const G4VPhysicalVolume* const physvol)
+{
+  writer->AddModule(physvol);
+}
+
+inline void GDMLParser::AddModule(const G4int depth)
+{
+  writer->AddModule(depth);
+}
+
+inline void GDMLParser::SetAddPointerToName(G4bool set)
+{
+  writer->SetAddPointerToName(set);
+}
+
+inline void GDMLParser::AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
+                                             const G4LogicalVolume* const lvol)
+{
+  writer->AddVolumeAuxiliary(myaux, lvol);
+}
+
+inline void GDMLParser::SetOutputFileOverwrite(G4bool flag)
+{
+  writer->SetOutputFileOverwrite(flag);
+}
+
+}
+#endif

--- a/src/geo/include/RAT/GDMLParser.hh
+++ b/src/geo/include/RAT/GDMLParser.hh
@@ -1,171 +1,149 @@
 #ifndef GDMLParser_hh
 #define GDMLParser_hh
 
-#include "G4GDMLReadStructure.hh"
-#include "RAT/GDMLWriteStructure.hh"
-#include "G4STRead.hh"
 #include "G4GDMLEvaluator.hh"
-#include "RAT/GDMLMessenger.hh"
-
-#include "G4TransportationManager.hh"
+#include "G4GDMLReadStructure.hh"
 #include "G4Navigator.hh"
+#include "G4STRead.hh"
 #include "G4Threading.hh"
+#include "G4TransportationManager.hh"
+#include "RAT/GDMLMessenger.hh"
+#include "RAT/GDMLWriteStructure.hh"
 
-#define G4GDML_DEFAULT_SCHEMALOCATION                                          \
-  G4String("http://service-spi.web.cern.ch/service-spi/app/releases/GDML/"     \
-           "schema/gdml.xsd")
+#define G4GDML_DEFAULT_SCHEMALOCATION                                 \
+  G4String(                                                           \
+      "http://service-spi.web.cern.ch/service-spi/app/releases/GDML/" \
+      "schema/gdml.xsd")
 
 namespace RAT {
-class GDMLParser
-{
-  public:
+class GDMLParser {
+ public:
+  GDMLParser();
+  GDMLParser(G4GDMLReadStructure*);
+  GDMLParser(G4GDMLReadStructure*, GDMLWriteStructure*);
+  ~GDMLParser();
+  //
+  // Parser constructors & destructor
 
-    GDMLParser();
-    GDMLParser(G4GDMLReadStructure*);
-    GDMLParser(G4GDMLReadStructure*, GDMLWriteStructure*);
-    ~GDMLParser();
-    //
-    // Parser constructors & destructor
+  inline void Read(const G4String& filename, G4bool Validate = true);
+  //
+  // Imports geometry with world-volume, specified by the GDML filename
+  // in input. Validation against schema is activated by default.
 
-    inline void Read(const G4String& filename, G4bool Validate = true);
-    //
-    // Imports geometry with world-volume, specified by the GDML filename
-    // in input. Validation against schema is activated by default.
+  inline void ReadModule(const G4String& filename, G4bool Validate = true);
+  //
+  // Imports a single GDML module, specified by the GDML filename
+  // in input. Validation against schema is activated by default.
 
-    inline void ReadModule(const G4String& filename, G4bool Validate = true);
-    //
-    // Imports a single GDML module, specified by the GDML filename
-    // in input. Validation against schema is activated by default.
+  inline void Write(const G4String& filename, const G4VPhysicalVolume* pvol = 0, G4bool storeReferences = true,
+                    const G4String& SchemaLocation = G4GDML_DEFAULT_SCHEMALOCATION);
+  //
+  // Exports on a GDML file, specified by 'filename' a geometry tree
+  // starting from 'pvol' as top volume. Uniqueness of stored entities
+  // is guaranteed by storing pointer-references by default.
+  // Alternative path for the schema location can be specified; by default
+  // the URL to the GDML web site is used.
 
-    inline void Write( const G4String& filename,
-                       const G4VPhysicalVolume* pvol = 0,
-                       G4bool storeReferences = true,
-                       const G4String& SchemaLocation = G4GDML_DEFAULT_SCHEMALOCATION);
-    //
-    // Exports on a GDML file, specified by 'filename' a geometry tree
-    // starting from 'pvol' as top volume. Uniqueness of stored entities
-    // is guaranteed by storing pointer-references by default.
-    // Alternative path for the schema location can be specified; by default
-    // the URL to the GDML web site is used.
+  inline void Write(const G4String& filename, const G4LogicalVolume* lvol, G4bool storeReferences = true,
+                    const G4String& SchemaLocation = G4GDML_DEFAULT_SCHEMALOCATION);
+  //
+  // Exports on a GDML file, specified by 'filename' a geometry tree
+  // starting from 'pvol' as top volume. Uniqueness of stored entities
+  // is guaranteed by storing pointer-references by default.
+  // Alternative path for the schema location can be specified; by default
+  // the URL to the GDML web site is used. Same as method above except
+  // that the logical volume must be provided here.
 
-    inline void Write( const G4String& filename, const G4LogicalVolume* lvol,
-                       G4bool storeReferences = true,
-                       const G4String& SchemaLocation = G4GDML_DEFAULT_SCHEMALOCATION);
-    //
-    // Exports on a GDML file, specified by 'filename' a geometry tree
-    // starting from 'pvol' as top volume. Uniqueness of stored entities
-    // is guaranteed by storing pointer-references by default.
-    // Alternative path for the schema location can be specified; by default
-    // the URL to the GDML web site is used. Same as method above except
-    // that the logical volume must be provided here.
+  inline G4LogicalVolume* ParseST(const G4String& name, G4Material* medium, G4Material* solid);
+  //
+  // Imports a tessellated geometry stored as STEP-Tools files
+  // 'name.geom' and 'name.tree'. It returns a pointer of a generated
+  // mother volume with 'medium' material associated, including the
+  // imported tessellated geometry with 'solid' material associated.
 
-    inline G4LogicalVolume* ParseST(const G4String& name, G4Material* medium,
-                                    G4Material* solid);
-    //
-    // Imports a tessellated geometry stored as STEP-Tools files
-    // 'name.geom' and 'name.tree'. It returns a pointer of a generated
-    // mother volume with 'medium' material associated, including the
-    // imported tessellated geometry with 'solid' material associated.
+  // Methods for Reader
 
-    // Methods for Reader
+  inline G4bool IsValid(const G4String& name) const;
+  inline G4double GetConstant(const G4String& name) const;
+  inline G4double GetVariable(const G4String& name) const;
+  inline G4double GetQuantity(const G4String& name) const;
+  inline G4ThreeVector GetPosition(const G4String& name) const;
+  inline G4ThreeVector GetRotation(const G4String& name) const;
+  inline G4ThreeVector GetScale(const G4String& name) const;
+  inline G4GDMLMatrix GetMatrix(const G4String& name) const;
+  inline G4LogicalVolume* GetVolume(const G4String& name) const;
+  inline G4VPhysicalVolume* GetPhysVolume(const G4String& name) const;
+  inline G4VPhysicalVolume* GetWorldVolume(const G4String& setupName = "Default") const;
+  inline G4GDMLAuxListType GetVolumeAuxiliaryInformation(G4LogicalVolume* lvol) const;
+  inline const G4GDMLAuxMapType* GetAuxMap() const;
+  inline const G4GDMLAuxListType* GetAuxList() const;
+  inline void AddAuxiliary(G4GDMLAuxStructType myaux);
+  inline void StripNamePointers() const;
+  inline void SetStripFlag(G4bool);
+  inline void SetOverlapCheck(G4bool);
+  inline void SetRegionExport(G4bool);
+  inline void SetEnergyCutsExport(G4bool);
+  inline void SetSDExport(G4bool);
+  inline void SetReverseSearch(G4bool);
 
-    inline G4bool IsValid(const G4String& name) const;
-    inline G4double GetConstant(const G4String& name) const;
-    inline G4double GetVariable(const G4String& name) const;
-    inline G4double GetQuantity(const G4String& name) const;
-    inline G4ThreeVector GetPosition(const G4String& name) const;
-    inline G4ThreeVector GetRotation(const G4String& name) const;
-    inline G4ThreeVector GetScale(const G4String& name) const;
-    inline G4GDMLMatrix GetMatrix(const G4String& name) const;
-    inline G4LogicalVolume* GetVolume(const G4String& name) const;
-    inline G4VPhysicalVolume* GetPhysVolume(const G4String& name) const;
-    inline G4VPhysicalVolume*
-           GetWorldVolume(const G4String& setupName = "Default") const;
-    inline G4GDMLAuxListType
-           GetVolumeAuxiliaryInformation(G4LogicalVolume* lvol) const;
-    inline const G4GDMLAuxMapType* GetAuxMap() const;
-    inline const G4GDMLAuxListType* GetAuxList() const;
-    inline void AddAuxiliary(G4GDMLAuxStructType myaux);
-    inline void StripNamePointers() const;
-    inline void SetStripFlag(G4bool);
-    inline void SetOverlapCheck(G4bool);
-    inline void SetRegionExport(G4bool);
-    inline void SetEnergyCutsExport(G4bool);
-    inline void SetSDExport(G4bool);
-    inline void SetReverseSearch(G4bool);
+  inline G4int GetMaxExportLevel() const;  // Manage max number of levels
+  inline void SetMaxExportLevel(G4int);    // to export
 
-    inline G4int GetMaxExportLevel() const;  // Manage max number of levels
-    inline void SetMaxExportLevel(G4int);    // to export
+  inline void Clear();  // Clears the evaluator
 
-    inline void Clear();  // Clears the evaluator
+  // Methods for Writer
 
-    // Methods for Writer
+  inline void AddModule(const G4VPhysicalVolume* const physvol);
+  inline void AddModule(const G4int depth);
+  inline void SetAddPointerToName(G4bool set);
+  inline void AddVolumeAuxiliary(G4GDMLAuxStructType myaux, const G4LogicalVolume* const lvol);
+  inline void SetOutputFileOverwrite(G4bool flag);
 
-    inline void AddModule(const G4VPhysicalVolume* const physvol);
-    inline void AddModule(const G4int depth);
-    inline void SetAddPointerToName(G4bool set);
-    inline void AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
-                                   const G4LogicalVolume* const lvol);
-    inline void SetOutputFileOverwrite(G4bool flag);
+ private:
+  void ImportRegions();
+  void ExportRegions(G4bool storeReferences = true);
 
-  private:
-
-    void ImportRegions();
-    void ExportRegions(G4bool storeReferences = true);
-
-  private:
-
-    G4GDMLEvaluator eval;
-    G4GDMLReadStructure* reader = nullptr;
-    GDMLWriteStructure* writer = nullptr;
-    G4GDMLAuxListType *rlist = nullptr, *ullist = nullptr;
-    GDMLMessenger* messenger = nullptr;
-    G4bool urcode = false, uwcode = false, strip = false, rexp = false;
+ private:
+  G4GDMLEvaluator eval;
+  G4GDMLReadStructure* reader = nullptr;
+  GDMLWriteStructure* writer = nullptr;
+  G4GDMLAuxListType *rlist = nullptr, *ullist = nullptr;
+  GDMLMessenger* messenger = nullptr;
+  G4bool urcode = false, uwcode = false, strip = false, rexp = false;
 };
 
-inline void GDMLParser::Read(const G4String& filename, G4bool validate)
-{
-  if(G4Threading::IsMasterThread())
-  {
+inline void GDMLParser::Read(const G4String& filename, G4bool validate) {
+  if (G4Threading::IsMasterThread()) {
     reader->Read(filename, validate, false, strip);
     ImportRegions();
   }
 }
 
 // --------------------------------------------------------------------
-inline void GDMLParser::ReadModule(const G4String& filename, G4bool validate)
-{
-  if(G4Threading::IsMasterThread())
-  {
+inline void GDMLParser::ReadModule(const G4String& filename, G4bool validate) {
+  if (G4Threading::IsMasterThread()) {
     reader->Read(filename, validate, true);
     ImportRegions();
   }
 }
 
 // --------------------------------------------------------------------
-inline void GDMLParser::Write(const G4String& filename,
-                                const G4VPhysicalVolume* pvol, G4bool refs,
-                                const G4String& schemaLocation)
-{
-  if(G4Threading::IsMasterThread())
-  {
-    const G4int depth     = 0;
+inline void GDMLParser::Write(const G4String& filename, const G4VPhysicalVolume* pvol, G4bool refs,
+                              const G4String& schemaLocation) {
+  if (G4Threading::IsMasterThread()) {
+    const G4int depth = 0;
     G4LogicalVolume* lvol = nullptr;
 
-    if(pvol == nullptr)
-    {
+    if (pvol == nullptr) {
       lvol = G4TransportationManager::GetTransportationManager()
-               ->GetNavigatorForTracking()
-               ->GetWorldVolume()
-               ->GetLogicalVolume();
-    }
-    else
-    {
+                 ->GetNavigatorForTracking()
+                 ->GetWorldVolume()
+                 ->GetLogicalVolume();
+    } else {
       lvol = pvol->GetLogicalVolume();
     }
 
-    if(rexp)
-    {
+    if (rexp) {
       ExportRegions(refs);
     }
     writer->Write(filename, lvol, schemaLocation, depth, refs);
@@ -173,23 +151,18 @@ inline void GDMLParser::Write(const G4String& filename,
 }
 
 // --------------------------------------------------------------------
-inline void GDMLParser::Write(const G4String& filename,
-                                const G4LogicalVolume* lvol, G4bool refs,
-                                const G4String& schemaLocation)
-{
-  if(G4Threading::IsMasterThread())
-  {
+inline void GDMLParser::Write(const G4String& filename, const G4LogicalVolume* lvol, G4bool refs,
+                              const G4String& schemaLocation) {
+  if (G4Threading::IsMasterThread()) {
     const G4int depth = 0;
 
-    if(lvol == nullptr)
-    {
+    if (lvol == nullptr) {
       lvol = G4TransportationManager::GetTransportationManager()
-               ->GetNavigatorForTracking()
-               ->GetWorldVolume()
-               ->GetLogicalVolume();
+                 ->GetNavigatorForTracking()
+                 ->GetWorldVolume()
+                 ->GetLogicalVolume();
     }
-    if(rexp)
-    {
+    if (rexp) {
       ExportRegions(refs);
     }
     writer->Write(filename, lvol, schemaLocation, depth, refs);
@@ -197,17 +170,11 @@ inline void GDMLParser::Write(const G4String& filename,
 }
 
 // --------------------------------------------------------------------
-inline G4LogicalVolume* GDMLParser::ParseST(const G4String& filename,
-                                              G4Material* medium,
-                                              G4Material* solid)
-{
-  if(G4Threading::IsMasterThread())
-  {
+inline G4LogicalVolume* GDMLParser::ParseST(const G4String& filename, G4Material* medium, G4Material* solid) {
+  if (G4Threading::IsMasterThread()) {
     G4STRead STreader;
     return STreader.Read(filename, medium, solid);
-  }
-  else
-  {
+  } else {
     return nullptr;
   }
 }
@@ -216,163 +183,75 @@ inline G4LogicalVolume* GDMLParser::ParseST(const G4String& filename,
 // Methods for Reader
 // --------------------------------------------------------------------
 
-inline G4bool GDMLParser::IsValid(const G4String& name) const
-{
-  return reader->IsValidID(name);
-}
+inline G4bool GDMLParser::IsValid(const G4String& name) const { return reader->IsValidID(name); }
 
-inline G4double GDMLParser::GetConstant(const G4String& name) const
-{
-  return reader->GetConstant(name);
-}
+inline G4double GDMLParser::GetConstant(const G4String& name) const { return reader->GetConstant(name); }
 
-inline G4double GDMLParser::GetVariable(const G4String& name) const
-{
-  return reader->GetVariable(name);
-}
+inline G4double GDMLParser::GetVariable(const G4String& name) const { return reader->GetVariable(name); }
 
-inline G4double GDMLParser::GetQuantity(const G4String& name) const
-{
-  return reader->GetQuantity(name);
-}
+inline G4double GDMLParser::GetQuantity(const G4String& name) const { return reader->GetQuantity(name); }
 
-inline G4ThreeVector GDMLParser::GetPosition(const G4String& name) const
-{
-  return reader->GetPosition(name);
-}
+inline G4ThreeVector GDMLParser::GetPosition(const G4String& name) const { return reader->GetPosition(name); }
 
-inline G4ThreeVector GDMLParser::GetRotation(const G4String& name) const
-{
-  return reader->GetRotation(name);
-}
+inline G4ThreeVector GDMLParser::GetRotation(const G4String& name) const { return reader->GetRotation(name); }
 
-inline G4ThreeVector GDMLParser::GetScale(const G4String& name) const
-{
-  return reader->GetScale(name);
-}
+inline G4ThreeVector GDMLParser::GetScale(const G4String& name) const { return reader->GetScale(name); }
 
-inline G4GDMLMatrix GDMLParser::GetMatrix(const G4String& name) const
-{
-  return reader->GetMatrix(name);
-}
+inline G4GDMLMatrix GDMLParser::GetMatrix(const G4String& name) const { return reader->GetMatrix(name); }
 
-inline G4LogicalVolume* GDMLParser::GetVolume(const G4String& name) const
-{
-  return reader->GetVolume(name);
-}
+inline G4LogicalVolume* GDMLParser::GetVolume(const G4String& name) const { return reader->GetVolume(name); }
 
-inline G4VPhysicalVolume*
-GDMLParser::GetPhysVolume(const G4String& name) const
-{
-  return reader->GetPhysvol(name);
-}
+inline G4VPhysicalVolume* GDMLParser::GetPhysVolume(const G4String& name) const { return reader->GetPhysvol(name); }
 
-inline G4VPhysicalVolume*
-GDMLParser::GetWorldVolume(const G4String& setupName) const
-{
+inline G4VPhysicalVolume* GDMLParser::GetWorldVolume(const G4String& setupName) const {
   return reader->GetWorldVolume(setupName);
 }
 
-inline G4GDMLAuxListType
-GDMLParser::GetVolumeAuxiliaryInformation(G4LogicalVolume* logvol) const
-{
+inline G4GDMLAuxListType GDMLParser::GetVolumeAuxiliaryInformation(G4LogicalVolume* logvol) const {
   return reader->GetVolumeAuxiliaryInformation(logvol);
 }
 
-inline const G4GDMLAuxMapType* GDMLParser::GetAuxMap() const
-{
-  return reader->GetAuxMap();
-}
+inline const G4GDMLAuxMapType* GDMLParser::GetAuxMap() const { return reader->GetAuxMap(); }
 
-inline const G4GDMLAuxListType* GDMLParser::GetAuxList() const
-{
-  return reader->GetAuxList();
-}
+inline const G4GDMLAuxListType* GDMLParser::GetAuxList() const { return reader->GetAuxList(); }
 
-inline void GDMLParser::AddAuxiliary(G4GDMLAuxStructType myaux)
-{
-  return writer->AddAuxiliary(myaux);
-}
+inline void GDMLParser::AddAuxiliary(G4GDMLAuxStructType myaux) { return writer->AddAuxiliary(myaux); }
 
-inline void GDMLParser::StripNamePointers() const
-{
-  reader->StripNames();
-}
+inline void GDMLParser::StripNamePointers() const { reader->StripNames(); }
 
-inline void GDMLParser::SetStripFlag(G4bool flag)
-{
-  strip = flag;
-}
+inline void GDMLParser::SetStripFlag(G4bool flag) { strip = flag; }
 
-inline void GDMLParser::SetOverlapCheck(G4bool flag)
-{
-  reader->OverlapCheck(flag);
-}
+inline void GDMLParser::SetOverlapCheck(G4bool flag) { reader->OverlapCheck(flag); }
 
-inline void GDMLParser::SetRegionExport(G4bool flag)
-{
-  rexp = flag;
-}
+inline void GDMLParser::SetRegionExport(G4bool flag) { rexp = flag; }
 
-inline void GDMLParser::SetEnergyCutsExport(G4bool flag)
-{
-  writer->SetEnergyCutsExport(flag);
-}
+inline void GDMLParser::SetEnergyCutsExport(G4bool flag) { writer->SetEnergyCutsExport(flag); }
 
-inline void GDMLParser::SetSDExport(G4bool flag)
-{
-  writer->SetSDExport(flag);
-}
+inline void GDMLParser::SetSDExport(G4bool flag) { writer->SetSDExport(flag); }
 
-inline void GDMLParser::SetReverseSearch(G4bool flag)
-{
-  reader->SetReverseSearch(flag);
-}
+inline void GDMLParser::SetReverseSearch(G4bool flag) { reader->SetReverseSearch(flag); }
 
-inline G4int GDMLParser::GetMaxExportLevel() const
-{
-  return writer->GetMaxExportLevel();
-}
+inline G4int GDMLParser::GetMaxExportLevel() const { return writer->GetMaxExportLevel(); }
 
-inline void GDMLParser::SetMaxExportLevel(G4int level)
-{
-  writer->SetMaxExportLevel(level);
-}
+inline void GDMLParser::SetMaxExportLevel(G4int level) { writer->SetMaxExportLevel(level); }
 
-inline void GDMLParser::Clear()
-{
-  reader->Clear();
-}
+inline void GDMLParser::Clear() { reader->Clear(); }
 
 // --------------------------------------------------------------------
 // Methods for Writer
 // --------------------------------------------------------------------
 
-inline void GDMLParser::AddModule(const G4VPhysicalVolume* const physvol)
-{
-  writer->AddModule(physvol);
-}
+inline void GDMLParser::AddModule(const G4VPhysicalVolume* const physvol) { writer->AddModule(physvol); }
 
-inline void GDMLParser::AddModule(const G4int depth)
-{
-  writer->AddModule(depth);
-}
+inline void GDMLParser::AddModule(const G4int depth) { writer->AddModule(depth); }
 
-inline void GDMLParser::SetAddPointerToName(G4bool set)
-{
-  writer->SetAddPointerToName(set);
-}
+inline void GDMLParser::SetAddPointerToName(G4bool set) { writer->SetAddPointerToName(set); }
 
-inline void GDMLParser::AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
-                                             const G4LogicalVolume* const lvol)
-{
+inline void GDMLParser::AddVolumeAuxiliary(G4GDMLAuxStructType myaux, const G4LogicalVolume* const lvol) {
   writer->AddVolumeAuxiliary(myaux, lvol);
 }
 
-inline void GDMLParser::SetOutputFileOverwrite(G4bool flag)
-{
-  writer->SetOutputFileOverwrite(flag);
-}
+inline void GDMLParser::SetOutputFileOverwrite(G4bool flag) { writer->SetOutputFileOverwrite(flag); }
 
-}
+}  // namespace RAT
 #endif

--- a/src/geo/include/RAT/GDMLWriteParamvol.hh
+++ b/src/geo/include/RAT/GDMLWriteParamvol.hh
@@ -20,39 +20,30 @@ class G4VPhysicalVolume;
 
 namespace RAT {
 
-class GDMLWriteParamvol : public GDMLWriteSetup
-{
-  public:
+class GDMLWriteParamvol : public GDMLWriteSetup {
+ public:
+  virtual void ParamvolWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const);
+  virtual void ParamvolAlgorithmWrite(xercesc::DOMElement* paramvolElement, const G4VPhysicalVolume* const paramvol);
 
-    virtual void ParamvolWrite(xercesc::DOMElement*,
-                               const G4VPhysicalVolume* const);
-    virtual void ParamvolAlgorithmWrite(xercesc::DOMElement* paramvolElement,
-                               const G4VPhysicalVolume* const paramvol);
+ protected:
+  GDMLWriteParamvol();
+  virtual ~GDMLWriteParamvol();
 
-  protected:
-
-    GDMLWriteParamvol();
-    virtual ~GDMLWriteParamvol();
-
-    void Box_dimensionsWrite(xercesc::DOMElement*, const G4Box* const);
-    void Trd_dimensionsWrite(xercesc::DOMElement*, const G4Trd* const);
-    void Trap_dimensionsWrite(xercesc::DOMElement*, const G4Trap* const);
-    void Tube_dimensionsWrite(xercesc::DOMElement*, const G4Tubs* const);
-    void Cone_dimensionsWrite(xercesc::DOMElement*, const G4Cons* const);
-    void Sphere_dimensionsWrite(xercesc::DOMElement*, const G4Sphere* const);
-    void Orb_dimensionsWrite(xercesc::DOMElement*, const G4Orb* const);
-    void Torus_dimensionsWrite(xercesc::DOMElement*, const G4Torus* const);
-    void Ellipsoid_dimensionsWrite(xercesc::DOMElement*,
-                                   const G4Ellipsoid* const);
-    void Para_dimensionsWrite(xercesc::DOMElement*, const G4Para* const);
-    void Hype_dimensionsWrite(xercesc::DOMElement*, const G4Hype* const);
-    void Polycone_dimensionsWrite(xercesc::DOMElement*,
-                                  const G4Polycone* const);
-    void Polyhedra_dimensionsWrite(xercesc::DOMElement*,
-                                   const G4Polyhedra* const);
-    void ParametersWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const,
-                         const G4int&);
+  void Box_dimensionsWrite(xercesc::DOMElement*, const G4Box* const);
+  void Trd_dimensionsWrite(xercesc::DOMElement*, const G4Trd* const);
+  void Trap_dimensionsWrite(xercesc::DOMElement*, const G4Trap* const);
+  void Tube_dimensionsWrite(xercesc::DOMElement*, const G4Tubs* const);
+  void Cone_dimensionsWrite(xercesc::DOMElement*, const G4Cons* const);
+  void Sphere_dimensionsWrite(xercesc::DOMElement*, const G4Sphere* const);
+  void Orb_dimensionsWrite(xercesc::DOMElement*, const G4Orb* const);
+  void Torus_dimensionsWrite(xercesc::DOMElement*, const G4Torus* const);
+  void Ellipsoid_dimensionsWrite(xercesc::DOMElement*, const G4Ellipsoid* const);
+  void Para_dimensionsWrite(xercesc::DOMElement*, const G4Para* const);
+  void Hype_dimensionsWrite(xercesc::DOMElement*, const G4Hype* const);
+  void Polycone_dimensionsWrite(xercesc::DOMElement*, const G4Polycone* const);
+  void Polyhedra_dimensionsWrite(xercesc::DOMElement*, const G4Polyhedra* const);
+  void ParametersWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const, const G4int&);
 };
 
-}
+}  // namespace RAT
 #endif

--- a/src/geo/include/RAT/GDMLWriteParamvol.hh
+++ b/src/geo/include/RAT/GDMLWriteParamvol.hh
@@ -1,0 +1,58 @@
+#ifndef GDMLWriteParamvol_hh
+#define GDMLWriteParamvol_hh
+
+#include "RAT/GDMLWriteSetup.hh"
+
+class G4Box;
+class G4Trd;
+class G4Trap;
+class G4Tubs;
+class G4Cons;
+class G4Sphere;
+class G4Orb;
+class G4Torus;
+class G4Ellipsoid;
+class G4Para;
+class G4Hype;
+class G4Polycone;
+class G4Polyhedra;
+class G4VPhysicalVolume;
+
+namespace RAT {
+
+class GDMLWriteParamvol : public GDMLWriteSetup
+{
+  public:
+
+    virtual void ParamvolWrite(xercesc::DOMElement*,
+                               const G4VPhysicalVolume* const);
+    virtual void ParamvolAlgorithmWrite(xercesc::DOMElement* paramvolElement,
+                               const G4VPhysicalVolume* const paramvol);
+
+  protected:
+
+    GDMLWriteParamvol();
+    virtual ~GDMLWriteParamvol();
+
+    void Box_dimensionsWrite(xercesc::DOMElement*, const G4Box* const);
+    void Trd_dimensionsWrite(xercesc::DOMElement*, const G4Trd* const);
+    void Trap_dimensionsWrite(xercesc::DOMElement*, const G4Trap* const);
+    void Tube_dimensionsWrite(xercesc::DOMElement*, const G4Tubs* const);
+    void Cone_dimensionsWrite(xercesc::DOMElement*, const G4Cons* const);
+    void Sphere_dimensionsWrite(xercesc::DOMElement*, const G4Sphere* const);
+    void Orb_dimensionsWrite(xercesc::DOMElement*, const G4Orb* const);
+    void Torus_dimensionsWrite(xercesc::DOMElement*, const G4Torus* const);
+    void Ellipsoid_dimensionsWrite(xercesc::DOMElement*,
+                                   const G4Ellipsoid* const);
+    void Para_dimensionsWrite(xercesc::DOMElement*, const G4Para* const);
+    void Hype_dimensionsWrite(xercesc::DOMElement*, const G4Hype* const);
+    void Polycone_dimensionsWrite(xercesc::DOMElement*,
+                                  const G4Polycone* const);
+    void Polyhedra_dimensionsWrite(xercesc::DOMElement*,
+                                   const G4Polyhedra* const);
+    void ParametersWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const,
+                         const G4int&);
+};
+
+}
+#endif

--- a/src/geo/include/RAT/GDMLWriteSetup.hh
+++ b/src/geo/include/RAT/GDMLWriteSetup.hh
@@ -4,16 +4,13 @@
 #include "RAT/GDMLWriteSolids.hh"
 
 namespace RAT {
-class GDMLWriteSetup : public GDMLWriteSolids
-{
-  public:
+class GDMLWriteSetup : public GDMLWriteSolids {
+ public:
+  virtual void SetupWrite(xercesc::DOMElement*, const G4LogicalVolume* const);
 
-    virtual void SetupWrite(xercesc::DOMElement*, const G4LogicalVolume* const);
-
-  protected:
-
-    GDMLWriteSetup();
-    virtual ~GDMLWriteSetup();
+ protected:
+  GDMLWriteSetup();
+  virtual ~GDMLWriteSetup();
 };
-}
+}  // namespace RAT
 #endif

--- a/src/geo/include/RAT/GDMLWriteSetup.hh
+++ b/src/geo/include/RAT/GDMLWriteSetup.hh
@@ -1,0 +1,19 @@
+#ifndef GDMLWriteSetup_hh
+#define GDMLWriteSetup_hh
+
+#include "RAT/GDMLWriteSolids.hh"
+
+namespace RAT {
+class GDMLWriteSetup : public GDMLWriteSolids
+{
+  public:
+
+    virtual void SetupWrite(xercesc::DOMElement*, const G4LogicalVolume* const);
+
+  protected:
+
+    GDMLWriteSetup();
+    virtual ~GDMLWriteSetup();
+};
+}
+#endif

--- a/src/geo/include/RAT/GDMLWriteSolids.hh
+++ b/src/geo/include/RAT/GDMLWriteSolids.hh
@@ -1,0 +1,121 @@
+#ifndef GDMLWriteSolids_hh
+#define GDMLWriteSolids_hh
+
+#include "G4Types.hh"
+
+#include "G4GDMLWriteMaterials.hh"
+#include "G4MultiUnion.hh"
+
+class G4BooleanSolid;
+class G4ScaledSolid;
+class G4Box;
+class G4Cons;
+class G4EllipticalCone;
+class G4Ellipsoid;
+class G4EllipticalTube;
+class G4ExtrudedSolid;
+class G4Hype;
+class G4Orb;
+class G4Para;
+class G4Paraboloid;
+class G4Polycone;
+class G4GenericPolycone;
+class G4Polyhedra;
+class G4Sphere;
+class G4TessellatedSolid;
+class G4Tet;
+class G4Torus;
+class G4GenericTrap;
+class G4Trap;
+class G4Trd;
+class G4Tubs;
+class G4CutTubs;
+class G4TwistedBox;
+class G4TwistedTrap;
+class G4TwistedTrd;
+class G4TwistedTubs;
+class G4VSolid;
+class G4OpticalSurface;
+
+namespace RAT {
+
+class GDMLWriteSolids : public G4GDMLWriteMaterials
+{
+  class G4ThreeVectorCompare
+  {
+    public:
+
+      G4bool operator()(const G4ThreeVector& t1, const G4ThreeVector& t2) const
+      {
+        if(t1.x() < t2.x())
+          return true;
+
+        if(t1.y() < t2.y())
+          return true;
+
+        if(t1.z() < t2.z())
+          return true;
+
+        return false;
+      }
+  };
+
+  public:
+
+    virtual void AddSolid(const G4VSolid* const);
+    virtual void SolidsWrite(xercesc::DOMElement*);
+
+  protected:
+
+    GDMLWriteSolids();
+    virtual ~GDMLWriteSolids();
+
+    void MultiUnionWrite(xercesc::DOMElement* solElement,
+                         const G4MultiUnion* const);
+    void BooleanWrite(xercesc::DOMElement*, const G4BooleanSolid* const);
+    void ScaledWrite(xercesc::DOMElement*, const G4ScaledSolid* const);
+    void BoxWrite(xercesc::DOMElement*, const G4Box* const);
+    void ConeWrite(xercesc::DOMElement*, const G4Cons* const);
+    void ElconeWrite(xercesc::DOMElement*, const G4EllipticalCone* const);
+    void EllipsoidWrite(xercesc::DOMElement*, const G4Ellipsoid* const);
+    void EltubeWrite(xercesc::DOMElement*, const G4EllipticalTube* const);
+    void XtruWrite(xercesc::DOMElement*, const G4ExtrudedSolid* const);
+    void HypeWrite(xercesc::DOMElement*, const G4Hype* const);
+    void OrbWrite(xercesc::DOMElement*, const G4Orb* const);
+    void ParaWrite(xercesc::DOMElement*, const G4Para* const);
+    void ParaboloidWrite(xercesc::DOMElement*, const G4Paraboloid* const);
+    void PolyconeWrite(xercesc::DOMElement*, const G4Polycone* const);
+    void GenericPolyconeWrite(xercesc::DOMElement*,
+                              const G4GenericPolycone* const);
+    void PolyhedraWrite(xercesc::DOMElement*, const G4Polyhedra* const);
+    void SphereWrite(xercesc::DOMElement*, const G4Sphere* const);
+    void TessellatedWrite(xercesc::DOMElement*,
+                          const G4TessellatedSolid* const);
+    void TetWrite(xercesc::DOMElement*, const G4Tet* const);
+    void TorusWrite(xercesc::DOMElement*, const G4Torus* const);
+    void GenTrapWrite(xercesc::DOMElement*, const G4GenericTrap* const);
+    void TrapWrite(xercesc::DOMElement*, const G4Trap* const);
+    void TrdWrite(xercesc::DOMElement*, const G4Trd* const);
+    void TubeWrite(xercesc::DOMElement*, const G4Tubs* const);
+    void CutTubeWrite(xercesc::DOMElement*, const G4CutTubs* const);
+    void TwistedboxWrite(xercesc::DOMElement*, const G4TwistedBox* const);
+    void TwistedtrapWrite(xercesc::DOMElement*, const G4TwistedTrap* const);
+    void TwistedtrdWrite(xercesc::DOMElement*, const G4TwistedTrd* const);
+    void TwistedtubsWrite(xercesc::DOMElement*, const G4TwistedTubs* const);
+    void ZplaneWrite(xercesc::DOMElement*, const G4double&, const G4double&,
+                     const G4double&);
+    void RZPointWrite(xercesc::DOMElement*, const G4double&, const G4double&);
+    void OpticalSurfaceWrite(xercesc::DOMElement*,
+                             const G4OpticalSurface* const);
+    void PropertyWrite(xercesc::DOMElement*, const G4OpticalSurface* const);
+
+  protected:
+
+    std::vector<const G4VSolid*> solidList;
+    xercesc::DOMElement* solidsElement = nullptr;
+    static const G4int maxTransforms = 8;  // Constant for limiting the number
+                                           // of displacements/reflections
+                                           // applied to a single solid
+};
+}
+#endif

--- a/src/geo/include/RAT/GDMLWriteSolids.hh
+++ b/src/geo/include/RAT/GDMLWriteSolids.hh
@@ -1,10 +1,9 @@
 #ifndef GDMLWriteSolids_hh
 #define GDMLWriteSolids_hh
 
-#include "G4Types.hh"
-
 #include "G4GDMLWriteMaterials.hh"
 #include "G4MultiUnion.hh"
+#include "G4Types.hh"
 
 class G4BooleanSolid;
 class G4ScaledSolid;
@@ -40,84 +39,69 @@ class GLG4TorusStack;
 
 namespace RAT {
 
-class GDMLWriteSolids : public G4GDMLWriteMaterials
-{
-  class G4ThreeVectorCompare
-  {
-    public:
+class GDMLWriteSolids : public G4GDMLWriteMaterials {
+  class G4ThreeVectorCompare {
+   public:
+    G4bool operator()(const G4ThreeVector& t1, const G4ThreeVector& t2) const {
+      if (t1.x() < t2.x()) return true;
 
-      G4bool operator()(const G4ThreeVector& t1, const G4ThreeVector& t2) const
-      {
-        if(t1.x() < t2.x())
-          return true;
+      if (t1.y() < t2.y()) return true;
 
-        if(t1.y() < t2.y())
-          return true;
+      if (t1.z() < t2.z()) return true;
 
-        if(t1.z() < t2.z())
-          return true;
-
-        return false;
-      }
+      return false;
+    }
   };
 
-  public:
+ public:
+  virtual void AddSolid(const G4VSolid* const);
+  virtual void SolidsWrite(xercesc::DOMElement*);
 
-    virtual void AddSolid(const G4VSolid* const);
-    virtual void SolidsWrite(xercesc::DOMElement*);
+ protected:
+  GDMLWriteSolids();
+  virtual ~GDMLWriteSolids();
 
-  protected:
+  void MultiUnionWrite(xercesc::DOMElement* solElement, const G4MultiUnion* const);
+  void BooleanWrite(xercesc::DOMElement*, const G4BooleanSolid* const);
+  void ScaledWrite(xercesc::DOMElement*, const G4ScaledSolid* const);
+  void BoxWrite(xercesc::DOMElement*, const G4Box* const);
+  void ConeWrite(xercesc::DOMElement*, const G4Cons* const);
+  void ElconeWrite(xercesc::DOMElement*, const G4EllipticalCone* const);
+  void EllipsoidWrite(xercesc::DOMElement*, const G4Ellipsoid* const);
+  void EltubeWrite(xercesc::DOMElement*, const G4EllipticalTube* const);
+  void XtruWrite(xercesc::DOMElement*, const G4ExtrudedSolid* const);
+  void HypeWrite(xercesc::DOMElement*, const G4Hype* const);
+  void OrbWrite(xercesc::DOMElement*, const G4Orb* const);
+  void ParaWrite(xercesc::DOMElement*, const G4Para* const);
+  void ParaboloidWrite(xercesc::DOMElement*, const G4Paraboloid* const);
+  void PolyconeWrite(xercesc::DOMElement*, const G4Polycone* const);
+  void GenericPolyconeWrite(xercesc::DOMElement*, const G4GenericPolycone* const);
+  void PolyhedraWrite(xercesc::DOMElement*, const G4Polyhedra* const);
+  void SphereWrite(xercesc::DOMElement*, const G4Sphere* const);
+  void TessellatedWrite(xercesc::DOMElement*, const G4TessellatedSolid* const);
+  void TetWrite(xercesc::DOMElement*, const G4Tet* const);
+  void TorusWrite(xercesc::DOMElement*, const G4Torus* const);
+  void GenTrapWrite(xercesc::DOMElement*, const G4GenericTrap* const);
+  void TrapWrite(xercesc::DOMElement*, const G4Trap* const);
+  void TrdWrite(xercesc::DOMElement*, const G4Trd* const);
+  void TubeWrite(xercesc::DOMElement*, const G4Tubs* const);
+  void CutTubeWrite(xercesc::DOMElement*, const G4CutTubs* const);
+  void TwistedboxWrite(xercesc::DOMElement*, const G4TwistedBox* const);
+  void TwistedtrapWrite(xercesc::DOMElement*, const G4TwistedTrap* const);
+  void TwistedtrdWrite(xercesc::DOMElement*, const G4TwistedTrd* const);
+  void TwistedtubsWrite(xercesc::DOMElement*, const G4TwistedTubs* const);
+  void GLG4TorusStackWrite(xercesc::DOMElement*, const GLG4TorusStack* const);
+  void ZplaneWrite(xercesc::DOMElement*, const G4double&, const G4double&, const G4double&);
+  void RZPointWrite(xercesc::DOMElement*, const G4double&, const G4double&);
+  void OpticalSurfaceWrite(xercesc::DOMElement*, const G4OpticalSurface* const);
+  void PropertyWrite(xercesc::DOMElement*, const G4OpticalSurface* const);
 
-    GDMLWriteSolids();
-    virtual ~GDMLWriteSolids();
-
-    void MultiUnionWrite(xercesc::DOMElement* solElement,
-                         const G4MultiUnion* const);
-    void BooleanWrite(xercesc::DOMElement*, const G4BooleanSolid* const);
-    void ScaledWrite(xercesc::DOMElement*, const G4ScaledSolid* const);
-    void BoxWrite(xercesc::DOMElement*, const G4Box* const);
-    void ConeWrite(xercesc::DOMElement*, const G4Cons* const);
-    void ElconeWrite(xercesc::DOMElement*, const G4EllipticalCone* const);
-    void EllipsoidWrite(xercesc::DOMElement*, const G4Ellipsoid* const);
-    void EltubeWrite(xercesc::DOMElement*, const G4EllipticalTube* const);
-    void XtruWrite(xercesc::DOMElement*, const G4ExtrudedSolid* const);
-    void HypeWrite(xercesc::DOMElement*, const G4Hype* const);
-    void OrbWrite(xercesc::DOMElement*, const G4Orb* const);
-    void ParaWrite(xercesc::DOMElement*, const G4Para* const);
-    void ParaboloidWrite(xercesc::DOMElement*, const G4Paraboloid* const);
-    void PolyconeWrite(xercesc::DOMElement*, const G4Polycone* const);
-    void GenericPolyconeWrite(xercesc::DOMElement*,
-                              const G4GenericPolycone* const);
-    void PolyhedraWrite(xercesc::DOMElement*, const G4Polyhedra* const);
-    void SphereWrite(xercesc::DOMElement*, const G4Sphere* const);
-    void TessellatedWrite(xercesc::DOMElement*,
-                          const G4TessellatedSolid* const);
-    void TetWrite(xercesc::DOMElement*, const G4Tet* const);
-    void TorusWrite(xercesc::DOMElement*, const G4Torus* const);
-    void GenTrapWrite(xercesc::DOMElement*, const G4GenericTrap* const);
-    void TrapWrite(xercesc::DOMElement*, const G4Trap* const);
-    void TrdWrite(xercesc::DOMElement*, const G4Trd* const);
-    void TubeWrite(xercesc::DOMElement*, const G4Tubs* const);
-    void CutTubeWrite(xercesc::DOMElement*, const G4CutTubs* const);
-    void TwistedboxWrite(xercesc::DOMElement*, const G4TwistedBox* const);
-    void TwistedtrapWrite(xercesc::DOMElement*, const G4TwistedTrap* const);
-    void TwistedtrdWrite(xercesc::DOMElement*, const G4TwistedTrd* const);
-    void TwistedtubsWrite(xercesc::DOMElement*, const G4TwistedTubs* const);
-    void GLG4TorusStackWrite(xercesc::DOMElement*, const GLG4TorusStack* const);
-    void ZplaneWrite(xercesc::DOMElement*, const G4double&, const G4double&,
-                     const G4double&);
-    void RZPointWrite(xercesc::DOMElement*, const G4double&, const G4double&);
-    void OpticalSurfaceWrite(xercesc::DOMElement*,
-                             const G4OpticalSurface* const);
-    void PropertyWrite(xercesc::DOMElement*, const G4OpticalSurface* const);
-
-  protected:
-
-    std::vector<const G4VSolid*> solidList;
-    xercesc::DOMElement* solidsElement = nullptr;
-    static const G4int maxTransforms = 8;  // Constant for limiting the number
-                                           // of displacements/reflections
-                                           // applied to a single solid
+ protected:
+  std::vector<const G4VSolid*> solidList;
+  xercesc::DOMElement* solidsElement = nullptr;
+  static const G4int maxTransforms = 8;  // Constant for limiting the number
+                                         // of displacements/reflections
+                                         // applied to a single solid
 };
-}
+}  // namespace RAT
 #endif

--- a/src/geo/include/RAT/GDMLWriteSolids.hh
+++ b/src/geo/include/RAT/GDMLWriteSolids.hh
@@ -36,6 +36,7 @@ class G4TwistedTrd;
 class G4TwistedTubs;
 class G4VSolid;
 class G4OpticalSurface;
+class GLG4TorusStack;
 
 namespace RAT {
 
@@ -102,6 +103,7 @@ class GDMLWriteSolids : public G4GDMLWriteMaterials
     void TwistedtrapWrite(xercesc::DOMElement*, const G4TwistedTrap* const);
     void TwistedtrdWrite(xercesc::DOMElement*, const G4TwistedTrd* const);
     void TwistedtubsWrite(xercesc::DOMElement*, const G4TwistedTubs* const);
+    void GLG4TorusStackWrite(xercesc::DOMElement*, const GLG4TorusStack* const);
     void ZplaneWrite(xercesc::DOMElement*, const G4double&, const G4double&,
                      const G4double&);
     void RZPointWrite(xercesc::DOMElement*, const G4double&, const G4double&);

--- a/src/geo/include/RAT/GDMLWriteStructure.hh
+++ b/src/geo/include/RAT/GDMLWriteStructure.hh
@@ -1,8 +1,8 @@
 #ifndef GDMLWriteStructure_hh
 #define GDMLWriteStructure_hh
 
-#include "G4Types.hh"
 #include "G4Transform3D.hh"
+#include "G4Types.hh"
 #include "RAT/GDMLWriteParamvol.hh"
 
 class G4LogicalVolume;
@@ -17,73 +17,63 @@ class G4AssemblyTriplet;
 
 namespace RAT {
 
-class GDMLWriteStructure : public GDMLWriteParamvol
-{
-  public:
+class GDMLWriteStructure : public GDMLWriteParamvol {
+ public:
+  GDMLWriteStructure();
+  virtual ~GDMLWriteStructure();
 
-    GDMLWriteStructure();
-    virtual ~GDMLWriteStructure();
+  virtual void StructureWrite(xercesc::DOMElement*);
+  void AddVolumeAuxiliary(G4GDMLAuxStructType myaux, const G4LogicalVolume* const);
 
-    virtual void StructureWrite(xercesc::DOMElement*);
-    void AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
-                            const G4LogicalVolume* const);
+  void SetEnergyCutsExport(G4bool);
+  void SetSDExport(G4bool);
 
-    void SetEnergyCutsExport(G4bool);
-    void SetSDExport(G4bool);
+  G4int GetMaxExportLevel() const;
+  void SetMaxExportLevel(G4int);
 
-    G4int GetMaxExportLevel() const;
-    void SetMaxExportLevel(G4int);
+ protected:
+  void DivisionvolWrite(xercesc::DOMElement*, const G4PVDivision* const);
+  void PhysvolWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const topVol, const G4Transform3D& transform,
+                    const G4String& moduleName);
+  void ReplicavolWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const);
+  void AssemblyWrite(xercesc::DOMElement*, const int assemblyID);
+  G4Transform3D TraverseVolumeTree(const G4LogicalVolume* const topVol, const G4int depth);
+  void SurfacesWrite();
+  void BorderSurfaceCache(const G4LogicalBorderSurface* const);
+  void SkinSurfaceCache(const G4LogicalSkinSurface* const);
+  const G4LogicalBorderSurface* GetBorderSurface(const G4VPhysicalVolume* const);
+  const G4LogicalSkinSurface* GetSkinSurface(const G4LogicalVolume* const);
+  G4bool FindOpticalSurface(const G4SurfaceProperty*);
+  void ExportEnergyCuts(const G4LogicalVolume* const);
+  void ExportSD(const G4LogicalVolume* const);
 
-  protected:
+ protected:
+  xercesc::DOMElement* structureElement = nullptr;
+  std::vector<xercesc::DOMElement*> borderElementVec;
+  std::vector<xercesc::DOMElement*> skinElementVec;
+  std::map<const G4LogicalVolume*, G4GDMLAuxListType> auxmap;
 
-    void DivisionvolWrite(xercesc::DOMElement*, const G4PVDivision* const);
-    void PhysvolWrite(xercesc::DOMElement*,
-                      const G4VPhysicalVolume* const topVol,
-                      const G4Transform3D& transform,
-                      const G4String& moduleName);
-    void ReplicavolWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const);
-    void AssemblyWrite(xercesc::DOMElement*, const int assemblyID);
-    G4Transform3D TraverseVolumeTree(const G4LogicalVolume* const topVol,
-                                     const G4int depth);
-    void SurfacesWrite();
-    void BorderSurfaceCache(const G4LogicalBorderSurface* const);
-    void SkinSurfaceCache(const G4LogicalSkinSurface* const);
-    const G4LogicalBorderSurface* GetBorderSurface(
-                          const G4VPhysicalVolume* const);
-    const G4LogicalSkinSurface* GetSkinSurface(const G4LogicalVolume* const);
-    G4bool FindOpticalSurface(const G4SurfaceProperty*);
-    void ExportEnergyCuts(const G4LogicalVolume* const);
-    void ExportSD(const G4LogicalVolume* const);
+ private:  // cache for optical surfaces...
+  std::vector<const G4OpticalSurface*> opt_vec;
 
-  protected:
+  G4ReflectionFactory* reflFactory = nullptr;
 
-    xercesc::DOMElement* structureElement = nullptr;
-    std::vector<xercesc::DOMElement*> borderElementVec;
-    std::vector<xercesc::DOMElement*> skinElementVec;
-    std::map<const G4LogicalVolume*, G4GDMLAuxListType> auxmap;
+  G4bool cexport = false;
+  // Flag for optional export of energy cuts per volume
+  G4bool sdexport = false;
+  // Flag for optional export of SD per volume
+  G4int maxLevel = 0;
+  // Maximum number of levels to export
+  static G4int levelNo;
+  // Counter for level being exported
 
-  private:  // cache for optical surfaces...
-
-    std::vector<const G4OpticalSurface*> opt_vec;
-
-    G4ReflectionFactory* reflFactory = nullptr;
-
-    G4bool cexport = false;
-      // Flag for optional export of energy cuts per volume
-    G4bool sdexport= false;
-      // Flag for optional export of SD per volume
-    G4int maxLevel = 0;
-      // Maximum number of levels to export
-    static G4int levelNo;
-      // Counter for level being exported
-
-    std::map<const G4VPhysicalVolume*, G4int> assemblyVolMap;
-      // Map of phys volumes to assembly IDs
-    std::map<const G4VPhysicalVolume*, G4int> imprintsMap;
-      // Map of phys volumes to imprints IDs
-    std::vector<G4int> addedAssemblies;
-      // Vector of assemblies IDs already added to the structure
+  std::map<const G4VPhysicalVolume*, G4int> assemblyVolMap;
+  // Map of phys volumes to assembly IDs
+  std::map<const G4VPhysicalVolume*, G4int> imprintsMap;
+  // Map of phys volumes to imprints IDs
+  std::vector<G4int> addedAssemblies;
+  // Vector of assemblies IDs already added to the structure
 };
 
-}
+}  // namespace RAT
 #endif

--- a/src/geo/include/RAT/GDMLWriteStructure.hh
+++ b/src/geo/include/RAT/GDMLWriteStructure.hh
@@ -1,0 +1,89 @@
+#ifndef GDMLWriteStructure_hh
+#define GDMLWriteStructure_hh
+
+#include "G4Types.hh"
+#include "G4Transform3D.hh"
+#include "RAT/GDMLWriteParamvol.hh"
+
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class G4PVDivision;
+class G4LogicalBorderSurface;
+class G4LogicalSkinSurface;
+class G4OpticalSurface;
+class G4SurfaceProperty;
+class G4ReflectionFactory;
+class G4AssemblyTriplet;
+
+namespace RAT {
+
+class GDMLWriteStructure : public GDMLWriteParamvol
+{
+  public:
+
+    GDMLWriteStructure();
+    virtual ~GDMLWriteStructure();
+
+    virtual void StructureWrite(xercesc::DOMElement*);
+    void AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
+                            const G4LogicalVolume* const);
+
+    void SetEnergyCutsExport(G4bool);
+    void SetSDExport(G4bool);
+
+    G4int GetMaxExportLevel() const;
+    void SetMaxExportLevel(G4int);
+
+  protected:
+
+    void DivisionvolWrite(xercesc::DOMElement*, const G4PVDivision* const);
+    void PhysvolWrite(xercesc::DOMElement*,
+                      const G4VPhysicalVolume* const topVol,
+                      const G4Transform3D& transform,
+                      const G4String& moduleName);
+    void ReplicavolWrite(xercesc::DOMElement*, const G4VPhysicalVolume* const);
+    void AssemblyWrite(xercesc::DOMElement*, const int assemblyID);
+    G4Transform3D TraverseVolumeTree(const G4LogicalVolume* const topVol,
+                                     const G4int depth);
+    void SurfacesWrite();
+    void BorderSurfaceCache(const G4LogicalBorderSurface* const);
+    void SkinSurfaceCache(const G4LogicalSkinSurface* const);
+    const G4LogicalBorderSurface* GetBorderSurface(
+                          const G4VPhysicalVolume* const);
+    const G4LogicalSkinSurface* GetSkinSurface(const G4LogicalVolume* const);
+    G4bool FindOpticalSurface(const G4SurfaceProperty*);
+    void ExportEnergyCuts(const G4LogicalVolume* const);
+    void ExportSD(const G4LogicalVolume* const);
+
+  protected:
+
+    xercesc::DOMElement* structureElement = nullptr;
+    std::vector<xercesc::DOMElement*> borderElementVec;
+    std::vector<xercesc::DOMElement*> skinElementVec;
+    std::map<const G4LogicalVolume*, G4GDMLAuxListType> auxmap;
+
+  private:  // cache for optical surfaces...
+
+    std::vector<const G4OpticalSurface*> opt_vec;
+
+    G4ReflectionFactory* reflFactory = nullptr;
+
+    G4bool cexport = false;
+      // Flag for optional export of energy cuts per volume
+    G4bool sdexport= false;
+      // Flag for optional export of SD per volume
+    G4int maxLevel = 0;
+      // Maximum number of levels to export
+    static G4int levelNo;
+      // Counter for level being exported
+
+    std::map<const G4VPhysicalVolume*, G4int> assemblyVolMap;
+      // Map of phys volumes to assembly IDs
+    std::map<const G4VPhysicalVolume*, G4int> imprintsMap;
+      // Map of phys volumes to imprints IDs
+    std::vector<G4int> addedAssemblies;
+      // Vector of assemblies IDs already added to the structure
+};
+
+}
+#endif

--- a/src/geo/include/RAT/GLG4TorusStack.hh
+++ b/src/geo/include/RAT/GLG4TorusStack.hh
@@ -80,8 +80,9 @@ class GLG4TorusStack : public G4CSGSolid {
   G4double GetZEdge(int i) const { return z_edge[i]; }
   G4double GetRhoEdge(int i) const { return rho_edge[i]; }
   G4double GetZo(int i) const { return z_o[i]; }
-  G4double GetA(int i) const { return a[i]; }
-  G4double GetB(int i) const { return b[i]; }
+  G4double GetRo(int i) const { return r_o[i]; }
+  G4double GetRadius(int i) const { return radius[i]; }
+  GLG4TorusStack *GetInner() const { return inner; }
 
   EInside Inside(const G4ThreeVector &p) const;
 
@@ -151,8 +152,8 @@ class GLG4TorusStack : public G4CSGSolid {
   double *z_edge;                  // n+1 edges of Z-segments
   double *rho_edge;                // n+1 2-d distance from Z-axis at each edge
   double *z_o;                     // z-origins, one for each toroid segment (n total)
-  double *a;                       // swept radii, one for each toroid segment (n total)
-  double *b;                       // torus radii, one for each toroid segment (n total)
+  double *r_o;                     // swept radii, one for each toroid segment (n total)
+  double *radius;                  // torus radii, one for each toroid segment (n total)
   double max_rho;                  // maxium distance of surface from Z axis
   double myRadTolerance;           // because Geant4.1.0 default is too small
   static double surfaceTolerance;  // in GEANT4.9.0 it is not a global const

--- a/src/geo/include/RAT/GLG4TorusStack.hh
+++ b/src/geo/include/RAT/GLG4TorusStack.hh
@@ -76,8 +76,9 @@ class GLG4TorusStack : public G4CSGSolid {
   G4bool CalculateExtent(const EAxis pAxis, const G4VoxelLimits &pVoxelLimit, const G4AffineTransform &pTransform,
                          G4double &pmin, G4double &pmax) const;
 
-  G4double GetN() const { return n; }
+  G4int GetN() const { return n; }
   G4double GetZEdge(int i) const { return z_edge[i]; }
+  G4double GetRhoEdge(int i) const { return rho_edge[i]; }
   G4double GetZo(int i) const { return z_o[i]; }
   G4double GetA(int i) const { return a[i]; }
   G4double GetB(int i) const { return b[i]; }

--- a/src/geo/src/DetectorConstruction.cc
+++ b/src/geo/src/DetectorConstruction.cc
@@ -16,6 +16,7 @@
 #include <RAT/Materials.hh>
 #include <RAT/PhotonThinning.hh>
 #include <RAT/Rat.hh>
+#include <RAT/json.hh>
 #include <string>
 
 namespace RAT {
@@ -89,13 +90,17 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     bool dump_geo = ldetector->GetZ("dump_geometry");
     if (dump_geo) {
       try {
-        std::string dump_file_name = ldetector->GetS("dump_file_name");
-        info << "Writing gdml geometry file to " << dump_file_name << newline;
+        std::string gdml_dump_file_name = ldetector->GetS("gdml_dump");
+        info << "Writing gdml geometry file to " << gdml_dump_file_name << newline;
         GDMLParser parser;
         parser.SetOutputFileOverwrite(true);
-        parser.Write(dump_file_name, fWorldPhys);
+        parser.Write(gdml_dump_file_name, fWorldPhys);
+
+        std::string ratdb_dump_file_name = ldetector->GetS("ratdb_dump");
+        std::ofstream ratdb_dump_file(ratdb_dump_file_name);
+        db->DumpContentsToJson(ratdb_dump_file);
       } catch (DBNotFoundError) {
-        Log::Die("Geometry dump is requested, but variable dump_file_name is not set!");
+        Log::Die("Geometry dump is requested, but variable gdml_dump or ratdb_dump is not set!");
       }
     }
   } catch (DBNotFoundError &e) {

--- a/src/geo/src/DetectorConstruction.cc
+++ b/src/geo/src/DetectorConstruction.cc
@@ -1,5 +1,4 @@
 #include <TVector3.h>
-
 #include <G4GeometryManager.hh>
 #include <G4LogicalVolumeStore.hh>
 #include <G4PhysicalVolumeStore.hh>
@@ -16,6 +15,7 @@
 #include <RAT/PhotonThinning.hh>
 #include <RAT/Rat.hh>
 #include <string>
+#include <RAT/GDMLParser.hh>
 
 namespace RAT {
 

--- a/src/geo/src/DetectorConstruction.cc
+++ b/src/geo/src/DetectorConstruction.cc
@@ -1,4 +1,5 @@
 #include <TVector3.h>
+
 #include <G4GeometryManager.hh>
 #include <G4LogicalVolumeStore.hh>
 #include <G4PhysicalVolumeStore.hh>
@@ -9,13 +10,13 @@
 #include <RAT/DB.hh>
 #include <RAT/DetectorConstruction.hh>
 #include <RAT/DetectorFactory.hh>
+#include <RAT/GDMLParser.hh>
 #include <RAT/GeoBuilder.hh>
 #include <RAT/Log.hh>
 #include <RAT/Materials.hh>
 #include <RAT/PhotonThinning.hh>
 #include <RAT/Rat.hh>
 #include <string>
-#include <RAT/GDMLParser.hh>
 
 namespace RAT {
 
@@ -82,6 +83,24 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
 
   GeoBuilder geo;
   fWorldPhys = geo.ConstructAll();
+
+  // Dump gdml Geo
+  try {
+    bool dump_geo = ldetector->GetZ("dump_geometry");
+    if (dump_geo) {
+      try {
+        std::string dump_file_name = ldetector->GetS("dump_file_name");
+        info << "Writing gdml geometry file to " << dump_file_name << newline;
+        GDMLParser parser;
+        parser.SetOutputFileOverwrite(true);
+        parser.Write(dump_file_name, fWorldPhys);
+      } catch (DBNotFoundError) {
+        Log::Die("Geometry dump is requested, but variable dump_file_name is not set!");
+      }
+    }
+  } catch (DBNotFoundError &e) {
+    info << "dump_geometry is not defined, gdml is not exported." << newline;
+  }
 
   return fWorldPhys;
 }

--- a/src/geo/src/gdml/GDMLMessenger.cc
+++ b/src/geo/src/gdml/GDMLMessenger.cc
@@ -1,0 +1,167 @@
+#include "RAT/GDMLMessenger.hh"
+#include "RAT/GDMLParser.hh"
+
+#include "globals.hh"
+#include "G4RunManager.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcmdWithAString.hh"
+#include "G4UIcmdWithABool.hh"
+#include "G4UIcmdWithoutParameter.hh"
+#include "G4GeometryManager.hh"
+#include "G4LogicalVolumeStore.hh"
+#include "G4PhysicalVolumeStore.hh"
+#include "G4SolidStore.hh"
+
+namespace RAT {
+
+// --------------------------------------------------------------------
+GDMLMessenger::GDMLMessenger(GDMLParser* myPars)
+  : myParser(myPars)
+{
+  persistencyDir = new G4UIdirectory("/persistency/");
+  persistencyDir->SetGuidance("UI commands specific to persistency.");
+
+  gdmlDir = new G4UIdirectory("/persistency/gdml/");
+  gdmlDir->SetGuidance("GDML parser and writer.");
+
+  ReaderCmd = new G4UIcmdWithAString("/persistency/gdml/read", this);
+  ReaderCmd->SetGuidance("Read GDML file.");
+  ReaderCmd->SetParameterName("filename", false);
+  ReaderCmd->AvailableForStates(G4State_PreInit, G4State_Idle);
+  ReaderCmd->SetToBeBroadcasted(false);
+
+  TopVolCmd = new G4UIcmdWithAString("/persistency/gdml/topvol", this);
+  TopVolCmd->SetGuidance("Set the top volume for writing the GDML file.");
+  TopVolCmd->SetParameterName("topvol", false);
+  TopVolCmd->SetToBeBroadcasted(false);
+
+  WriterCmd = new G4UIcmdWithAString("/persistency/gdml/write", this);
+  WriterCmd->SetGuidance("Write GDML file.");
+  WriterCmd->SetParameterName("filename", false);
+  WriterCmd->AvailableForStates(G4State_Idle);
+  WriterCmd->SetToBeBroadcasted(false);
+
+  StripCmd = new G4UIcmdWithABool("/persistency/gdml/strip_pointers", this);
+  StripCmd->SetGuidance("Enable/disable stripping of pointers on names");
+  StripCmd->SetGuidance("when reading a GDML file.");
+  StripCmd->SetParameterName("strip_pointers", true);
+  StripCmd->SetDefaultValue(true);
+  StripCmd->AvailableForStates(G4State_Idle);
+  StripCmd->SetToBeBroadcasted(false);
+
+  AppendCmd = new G4UIcmdWithABool("/persistency/gdml/add_pointers", this);
+  AppendCmd->SetGuidance("Enable/disable appending of pointers to names");
+  AppendCmd->SetGuidance("when writing a GDML file.");
+  AppendCmd->SetParameterName("append_pointers", true);
+  AppendCmd->SetDefaultValue(true);
+  AppendCmd->AvailableForStates(G4State_Idle);
+  AppendCmd->SetToBeBroadcasted(false);
+
+  RegionCmd = new G4UIcmdWithABool("/persistency/gdml/export_regions", this);
+  RegionCmd->SetGuidance("Enable export of geometrical regions");
+  RegionCmd->SetGuidance("for storing production cuts.");
+  RegionCmd->SetParameterName("export_regions", false);
+  RegionCmd->SetDefaultValue(false);
+  RegionCmd->AvailableForStates(G4State_Idle);
+  RegionCmd->SetToBeBroadcasted(false);
+
+  EcutsCmd = new G4UIcmdWithABool("/persistency/gdml/export_Ecuts", this);
+  EcutsCmd->SetGuidance("Enable export of energy cuts associated");
+  EcutsCmd->SetGuidance("to logical volumes.");
+  EcutsCmd->SetGuidance("NOTE: may increase considerably the size of the");
+  EcutsCmd->SetGuidance("      GDML file!  Information is anyhow not used");
+  EcutsCmd->SetGuidance("      for import.");
+  EcutsCmd->SetParameterName("export_Ecuts", false);
+  EcutsCmd->SetDefaultValue(false);
+  EcutsCmd->AvailableForStates(G4State_Idle);
+  EcutsCmd->SetToBeBroadcasted(false);
+
+  SDCmd = new G4UIcmdWithABool("/persistency/gdml/export_SD", this);
+  SDCmd->SetGuidance("Enable export of SD associated");
+  SDCmd->SetGuidance("to logical volumes.");
+  SDCmd->SetParameterName("export_SD", false);
+  SDCmd->SetDefaultValue(false);
+  SDCmd->AvailableForStates(G4State_Idle);
+  SDCmd->SetToBeBroadcasted(false);
+
+  ClearCmd = new G4UIcmdWithoutParameter("/persistency/gdml/clear", this);
+  ClearCmd->SetGuidance("Clear geometry (before reading a new one from GDML).");
+  ClearCmd->AvailableForStates(G4State_Idle);
+  ClearCmd->SetToBeBroadcasted(false);
+}
+
+// --------------------------------------------------------------------
+GDMLMessenger::~GDMLMessenger()
+{
+  delete ReaderCmd;
+  delete WriterCmd;
+  delete ClearCmd;
+  delete TopVolCmd;
+  delete RegionCmd;
+  delete EcutsCmd;
+  delete SDCmd;
+  delete persistencyDir;
+  delete gdmlDir;
+  delete StripCmd;
+  delete AppendCmd;
+}
+
+// --------------------------------------------------------------------
+void GDMLMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
+{
+  if(command == StripCmd)
+  {
+    G4bool mode = StripCmd->GetNewBoolValue(newValue);
+    myParser->SetStripFlag(mode);
+  }
+
+  if(command == AppendCmd)
+  {
+    pFlag = AppendCmd->GetNewBoolValue(newValue);
+    myParser->SetAddPointerToName(pFlag);
+  }
+
+  if(command == ReaderCmd)
+  {
+    G4GeometryManager::GetInstance()->OpenGeometry();
+    myParser->Read(newValue);
+    G4RunManager::GetRunManager()->DefineWorldVolume(
+      myParser->GetWorldVolume());
+    G4RunManager::GetRunManager()->GeometryDirectlyUpdated();
+  }
+
+  if(command == RegionCmd)
+  {
+    G4bool mode = RegionCmd->GetNewBoolValue(newValue);
+    myParser->SetRegionExport(mode);
+  }
+
+  if(command == EcutsCmd)
+  {
+    G4bool mode = EcutsCmd->GetNewBoolValue(newValue);
+    myParser->SetEnergyCutsExport(mode);
+  }
+
+  if(command == SDCmd)
+  {
+    G4bool mode = SDCmd->GetNewBoolValue(newValue);
+    myParser->SetSDExport(mode);
+  }
+
+  if(command == TopVolCmd)
+  {
+    topvol = G4LogicalVolumeStore::GetInstance()->GetVolume(newValue);
+  }
+
+  if(command == WriterCmd)
+  {
+    myParser->Write(newValue, topvol, pFlag);
+  }
+
+  if(command == ClearCmd)
+  {
+    myParser->Clear();
+    G4RunManager::GetRunManager()->ReinitializeGeometry(true);
+  }
+}
+}

--- a/src/geo/src/gdml/GDMLMessenger.cc
+++ b/src/geo/src/gdml/GDMLMessenger.cc
@@ -1,23 +1,21 @@
 #include "RAT/GDMLMessenger.hh"
-#include "RAT/GDMLParser.hh"
 
-#include "globals.hh"
-#include "G4RunManager.hh"
-#include "G4UIdirectory.hh"
-#include "G4UIcmdWithAString.hh"
-#include "G4UIcmdWithABool.hh"
-#include "G4UIcmdWithoutParameter.hh"
 #include "G4GeometryManager.hh"
 #include "G4LogicalVolumeStore.hh"
 #include "G4PhysicalVolumeStore.hh"
+#include "G4RunManager.hh"
 #include "G4SolidStore.hh"
+#include "G4UIcmdWithABool.hh"
+#include "G4UIcmdWithAString.hh"
+#include "G4UIcmdWithoutParameter.hh"
+#include "G4UIdirectory.hh"
+#include "RAT/GDMLParser.hh"
+#include "globals.hh"
 
 namespace RAT {
 
 // --------------------------------------------------------------------
-GDMLMessenger::GDMLMessenger(GDMLParser* myPars)
-  : myParser(myPars)
-{
+GDMLMessenger::GDMLMessenger(GDMLParser* myPars) : myParser(myPars) {
   persistencyDir = new G4UIdirectory("/persistency/");
   persistencyDir->SetGuidance("UI commands specific to persistency.");
 
@@ -91,8 +89,7 @@ GDMLMessenger::GDMLMessenger(GDMLParser* myPars)
 }
 
 // --------------------------------------------------------------------
-GDMLMessenger::~GDMLMessenger()
-{
+GDMLMessenger::~GDMLMessenger() {
   delete ReaderCmd;
   delete WriterCmd;
   delete ClearCmd;
@@ -107,61 +104,50 @@ GDMLMessenger::~GDMLMessenger()
 }
 
 // --------------------------------------------------------------------
-void GDMLMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
-{
-  if(command == StripCmd)
-  {
+void GDMLMessenger::SetNewValue(G4UIcommand* command, G4String newValue) {
+  if (command == StripCmd) {
     G4bool mode = StripCmd->GetNewBoolValue(newValue);
     myParser->SetStripFlag(mode);
   }
 
-  if(command == AppendCmd)
-  {
+  if (command == AppendCmd) {
     pFlag = AppendCmd->GetNewBoolValue(newValue);
     myParser->SetAddPointerToName(pFlag);
   }
 
-  if(command == ReaderCmd)
-  {
+  if (command == ReaderCmd) {
     G4GeometryManager::GetInstance()->OpenGeometry();
     myParser->Read(newValue);
-    G4RunManager::GetRunManager()->DefineWorldVolume(
-      myParser->GetWorldVolume());
+    G4RunManager::GetRunManager()->DefineWorldVolume(myParser->GetWorldVolume());
     G4RunManager::GetRunManager()->GeometryDirectlyUpdated();
   }
 
-  if(command == RegionCmd)
-  {
+  if (command == RegionCmd) {
     G4bool mode = RegionCmd->GetNewBoolValue(newValue);
     myParser->SetRegionExport(mode);
   }
 
-  if(command == EcutsCmd)
-  {
+  if (command == EcutsCmd) {
     G4bool mode = EcutsCmd->GetNewBoolValue(newValue);
     myParser->SetEnergyCutsExport(mode);
   }
 
-  if(command == SDCmd)
-  {
+  if (command == SDCmd) {
     G4bool mode = SDCmd->GetNewBoolValue(newValue);
     myParser->SetSDExport(mode);
   }
 
-  if(command == TopVolCmd)
-  {
+  if (command == TopVolCmd) {
     topvol = G4LogicalVolumeStore::GetInstance()->GetVolume(newValue);
   }
 
-  if(command == WriterCmd)
-  {
+  if (command == WriterCmd) {
     myParser->Write(newValue, topvol, pFlag);
   }
 
-  if(command == ClearCmd)
-  {
+  if (command == ClearCmd) {
     myParser->Clear();
     G4RunManager::GetRunManager()->ReinitializeGeometry(true);
   }
 }
-}
+}  // namespace RAT

--- a/src/geo/src/gdml/GDMLParser.cc
+++ b/src/geo/src/gdml/GDMLParser.cc
@@ -1,0 +1,327 @@
+#include <RAT/GDMLParser.hh>
+#include <RAT/GDMLWriteStructure.hh>
+#include "G4UnitsTable.hh"
+#include "G4LogicalVolumeStore.hh"
+#include "G4RegionStore.hh"
+#include "G4UserLimits.hh"
+#include "G4ProductionCuts.hh"
+#include "G4ReflectionFactory.hh"
+#include "G4Track.hh"
+
+namespace RAT {
+
+// --------------------------------------------------------------------
+GDMLParser::GDMLParser()
+  : strip(true)
+{
+  reader    = new G4GDMLReadStructure;
+  writer    = new GDMLWriteStructure;
+  messenger = new GDMLMessenger(this);
+
+  xercesc::XMLPlatformUtils::Initialize();
+}
+
+// --------------------------------------------------------------------
+GDMLParser::GDMLParser(G4GDMLReadStructure* extr)
+  : urcode(true), strip(true)
+{
+  reader    = extr;
+  writer    = new GDMLWriteStructure;
+  messenger = new GDMLMessenger(this);
+
+  xercesc::XMLPlatformUtils::Initialize();
+}
+
+// --------------------------------------------------------------------
+GDMLParser::GDMLParser(G4GDMLReadStructure* extr,
+                           GDMLWriteStructure* extw)
+  : urcode(true), uwcode(true), strip(true)
+{
+  reader    = extr;
+  writer    = extw;
+  messenger = new GDMLMessenger(this);
+
+  xercesc::XMLPlatformUtils::Initialize();
+}
+
+// --------------------------------------------------------------------
+GDMLParser::~GDMLParser()
+{
+  xercesc::XMLPlatformUtils::Terminate();
+  if(!urcode)
+  {
+    delete reader;
+  }
+  if(!uwcode)
+  {
+    delete writer;
+  }
+  delete ullist;
+  delete rlist;
+
+  delete messenger;
+}
+
+// --------------------------------------------------------------------
+void GDMLParser::ImportRegions()
+{
+  G4ReflectionFactory* reflFactory     = G4ReflectionFactory::Instance();
+  const G4GDMLAuxListType* auxInfoList = GetAuxList();
+  for(auto iaux = auxInfoList->cbegin(); iaux != auxInfoList->cend(); ++iaux)
+  {
+    if(iaux->type != "Region")
+      continue;
+
+    G4String name = iaux->value;
+    if(strip)
+    {
+      reader->StripName(name);
+    }
+    if(G4StrUtil::contains(name, "DefaultRegionForTheWorld"))
+      continue;
+
+    if(!iaux->auxList)
+    {
+      G4Exception("GDMLParser::ImportRegions()", "ReadError", FatalException,
+                  "Invalid definition of geometrical region!");
+    }
+    else  // Create region and loop over all region attributes
+    {
+      G4Region* aRegion       = new G4Region(name);
+      G4ProductionCuts* pcuts = new G4ProductionCuts();
+      aRegion->SetProductionCuts(pcuts);
+      for(auto raux = iaux->auxList->cbegin();
+               raux != iaux->auxList->cend(); ++raux)
+      {
+        const G4String& tag = raux->type;
+        if(tag == "volume")
+        {
+          G4String volname = raux->value;
+          if(strip)
+          {
+            reader->StripName(volname);
+          }
+          G4LogicalVolumeStore* store = G4LogicalVolumeStore::GetInstance();
+          auto pos = store->GetMap().find(volname);
+          if(pos != store->GetMap().cend())
+          {
+            // Scan for all possible volumes with same name
+            // and set them as root logical volumes for the region...
+            // Issue a notification in case more than one logical volume
+            // with same name exist and get set.
+            //
+            if (pos->second.size()>1)
+            {
+              std::ostringstream message;
+              message << "There exists more than ONE logical volume "
+                      << "in store named: " << volname << "." << G4endl
+                      << "NOTE: assigning all such volumes as root logical "
+                      << "volumes for region: " << name << "!";
+              G4Exception("GDMLParser::ImportRegions()",
+                          "Notification", JustWarning, message);
+            }
+            for (auto vpos = pos->second.cbegin();
+                      vpos != pos->second.cend(); ++vpos)
+            {
+              aRegion->AddRootLogicalVolume(*vpos);
+              if(reflFactory->IsConstituent(*vpos))
+                aRegion->AddRootLogicalVolume(reflFactory->GetReflectedLV(*vpos));
+            }
+          }
+          else
+          {
+            std::ostringstream message;
+            message << "Volume NOT found in store !" << G4endl
+                    << "        Volume " << volname << " NOT found in store !"
+                    << G4endl
+                    << "        No region is being set.";
+            G4Exception("GDMLParser::ImportRegions()",
+                        "InvalidSetup", JustWarning, message);
+          }
+        }
+        else if(tag == "pcut")
+        {
+          const G4String& cvalue = raux->value;
+          const G4String& cunit  = raux->unit;
+          if(G4UnitDefinition::GetCategory(cunit) != "Length")
+          {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
+                        FatalException, "Invalid unit for length!");
+          }
+          G4double cut =
+            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          pcuts->SetProductionCut(cut, "proton");
+        }
+        else if(tag == "ecut")
+        {
+          const G4String& cvalue = raux->value;
+          const G4String& cunit  = raux->unit;
+          if(G4UnitDefinition::GetCategory(cunit) != "Length")
+          {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
+                        FatalException, "Invalid unit for length!");
+          }
+          G4double cut =
+            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          pcuts->SetProductionCut(cut, "e-");
+        }
+        else if(tag == "poscut")
+        {
+          const G4String& cvalue = raux->value;
+          const G4String& cunit  = raux->unit;
+          if(G4UnitDefinition::GetCategory(cunit) != "Length")
+          {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
+                        FatalException, "Invalid unit for length!");
+          }
+          G4double cut =
+            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          pcuts->SetProductionCut(cut, "e+");
+        }
+        else if(tag == "gamcut")
+        {
+          const G4String& cvalue = raux->value;
+          const G4String& cunit  = raux->unit;
+          if(G4UnitDefinition::GetCategory(cunit) != "Length")
+          {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
+                        FatalException, "Invalid unit for length!");
+          }
+          G4double cut =
+            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          pcuts->SetProductionCut(cut, "gamma");
+        }
+        else if(tag == "ulimits")
+        {
+          G4double ustepMax = DBL_MAX, utrakMax = DBL_MAX, utimeMax = DBL_MAX;
+          G4double uekinMin = 0., urangMin = 0.;
+          const G4String& ulname = raux->value;
+          for(auto uaux = raux->auxList->cbegin();
+                   uaux != raux->auxList->cend(); ++uaux)
+          {
+            const G4String& ultag  = uaux->type;
+            const G4String& uvalue = uaux->value;
+            const G4String& uunit  = uaux->unit;
+            G4double ulvalue = eval.Evaluate(uvalue) * eval.Evaluate(uunit);
+            if(ultag == "ustepMax")
+            {
+              ustepMax = ulvalue;
+            }
+            else if(ultag == "utrakMax")
+            {
+              utrakMax = ulvalue;
+            }
+            else if(ultag == "utimeMax")
+            {
+              utimeMax = ulvalue;
+            }
+            else if(ultag == "uekinMin")
+            {
+              uekinMin = ulvalue;
+            }
+            else if(ultag == "urangMin")
+            {
+              urangMin = ulvalue;
+            }
+            else
+            {
+              G4Exception("GDMLParser::ImportRegions()", "ReadError",
+                          FatalException, "Invalid definition of user-limits!");
+            }
+          }
+          G4UserLimits* ulimits = new G4UserLimits(
+            ulname, ustepMax, utrakMax, utimeMax, uekinMin, urangMin);
+          aRegion->SetUserLimits(ulimits);
+        }
+        else
+          continue;  // Ignore unknown tags
+      }
+    }
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLParser::ExportRegions(G4bool storeReferences)
+{
+  G4RegionStore* rstore            = G4RegionStore::GetInstance();
+  G4ReflectionFactory* reflFactory = G4ReflectionFactory::Instance();
+  for(std::size_t i = 0; i < rstore->size(); ++i)
+     // Skip default regions associated to worlds
+  {
+    const G4String& tname = (*rstore)[i]->GetName();
+    if(G4StrUtil::contains(tname, "DefaultRegionForParallelWorld"))
+      continue;
+    const G4String& rname    = writer->GenerateName(tname, (*rstore)[i]);
+    rlist                    = new G4GDMLAuxListType();
+    G4GDMLAuxStructType raux = { "Region", rname, "", rlist };
+    auto rlvol_iter = (*rstore)[i]->GetRootLogicalVolumeIterator();
+    for(std::size_t j = 0; j < (*rstore)[i]->GetNumberOfRootVolumes(); ++j)
+    {
+      G4LogicalVolume* rlvol = *rlvol_iter;
+      if(reflFactory->IsReflected(rlvol))
+        continue;
+      G4String vname = writer->GenerateName(rlvol->GetName(), rlvol);
+      if(!storeReferences)
+      {
+        reader->StripName(vname);
+      }
+      G4GDMLAuxStructType rsubaux = { "volume", vname, "", 0 };
+      rlist->push_back(rsubaux);
+      ++rlvol_iter;
+    }
+    G4double gam_cut
+      = (*rstore)[i]->GetProductionCuts()->GetProductionCut("gamma");
+    G4GDMLAuxStructType caux1
+      = { "gamcut", eval.ConvertToString(gam_cut), "mm", 0 };
+    rlist->push_back(caux1);
+    G4double e_cut = (*rstore)[i]->GetProductionCuts()->GetProductionCut("e-");
+    G4GDMLAuxStructType caux2
+      = { "ecut", eval.ConvertToString(e_cut), "mm", 0 };
+    rlist->push_back(caux2);
+    G4double pos_cut
+      = (*rstore)[i]->GetProductionCuts()->GetProductionCut("e+");
+    G4GDMLAuxStructType caux3
+      = { "poscut", eval.ConvertToString(pos_cut), "mm", 0 };
+    rlist->push_back(caux3);
+    G4double p_cut
+      = (*rstore)[i]->GetProductionCuts()->GetProductionCut("proton");
+    G4GDMLAuxStructType caux4
+      = { "pcut", eval.ConvertToString(p_cut), "mm", 0 };
+    rlist->push_back(caux4);
+    if((*rstore)[i]->GetUserLimits())
+    {
+      const G4Track fake_trk;
+      ullist                   = new G4GDMLAuxListType();
+      const G4String& utype    = (*rstore)[i]->GetUserLimits()->GetType();
+      G4GDMLAuxStructType uaux = { "ulimits", utype, "mm", ullist };
+      G4double max_step
+        = (*rstore)[i]->GetUserLimits()->GetMaxAllowedStep(fake_trk);
+      G4GDMLAuxStructType ulaux1
+        = { "ustepMax", eval.ConvertToString(max_step), "mm", 0 };
+      ullist->push_back(ulaux1);
+      G4double max_trk
+        = (*rstore)[i]->GetUserLimits()->GetUserMaxTrackLength(fake_trk);
+      G4GDMLAuxStructType ulaux2
+        = { "utrakMax", eval.ConvertToString(max_trk), "mm", 0 };
+      ullist->push_back(ulaux2);
+      G4double max_time
+        = (*rstore)[i]->GetUserLimits()->GetUserMaxTime(fake_trk);
+      G4GDMLAuxStructType ulaux3
+        = { "utimeMax", eval.ConvertToString(max_time), "mm", 0 };
+      ullist->push_back(ulaux3);
+      G4double min_ekin
+        = (*rstore)[i]->GetUserLimits()->GetUserMinEkine(fake_trk);
+      G4GDMLAuxStructType ulaux4
+        = { "uekinMin", eval.ConvertToString(min_ekin), "mm", 0 };
+      ullist->push_back(ulaux4);
+      G4double min_rng
+        = (*rstore)[i]->GetUserLimits()->GetUserMinRange(fake_trk);
+      G4GDMLAuxStructType ulaux5
+        = { "urangMin", eval.ConvertToString(min_rng), "mm", 0 };
+      ullist->push_back(ulaux5);
+      rlist->push_back(uaux);
+    }
+    AddAuxiliary(raux);
+  }
+}
+}

--- a/src/geo/src/gdml/GDMLParser.cc
+++ b/src/geo/src/gdml/GDMLParser.cc
@@ -1,59 +1,50 @@
 #include <RAT/GDMLParser.hh>
 #include <RAT/GDMLWriteStructure.hh>
-#include "G4UnitsTable.hh"
+
 #include "G4LogicalVolumeStore.hh"
-#include "G4RegionStore.hh"
-#include "G4UserLimits.hh"
 #include "G4ProductionCuts.hh"
 #include "G4ReflectionFactory.hh"
+#include "G4RegionStore.hh"
 #include "G4Track.hh"
+#include "G4UnitsTable.hh"
+#include "G4UserLimits.hh"
 
 namespace RAT {
 
 // --------------------------------------------------------------------
-GDMLParser::GDMLParser()
-  : strip(true)
-{
-  reader    = new G4GDMLReadStructure;
-  writer    = new GDMLWriteStructure;
+GDMLParser::GDMLParser() : strip(true) {
+  reader = new G4GDMLReadStructure;
+  writer = new GDMLWriteStructure;
   messenger = new GDMLMessenger(this);
 
   xercesc::XMLPlatformUtils::Initialize();
 }
 
 // --------------------------------------------------------------------
-GDMLParser::GDMLParser(G4GDMLReadStructure* extr)
-  : urcode(true), strip(true)
-{
-  reader    = extr;
-  writer    = new GDMLWriteStructure;
+GDMLParser::GDMLParser(G4GDMLReadStructure* extr) : urcode(true), strip(true) {
+  reader = extr;
+  writer = new GDMLWriteStructure;
   messenger = new GDMLMessenger(this);
 
   xercesc::XMLPlatformUtils::Initialize();
 }
 
 // --------------------------------------------------------------------
-GDMLParser::GDMLParser(G4GDMLReadStructure* extr,
-                           GDMLWriteStructure* extw)
-  : urcode(true), uwcode(true), strip(true)
-{
-  reader    = extr;
-  writer    = extw;
+GDMLParser::GDMLParser(G4GDMLReadStructure* extr, GDMLWriteStructure* extw) : urcode(true), uwcode(true), strip(true) {
+  reader = extr;
+  writer = extw;
   messenger = new GDMLMessenger(this);
 
   xercesc::XMLPlatformUtils::Initialize();
 }
 
 // --------------------------------------------------------------------
-GDMLParser::~GDMLParser()
-{
+GDMLParser::~GDMLParser() {
   xercesc::XMLPlatformUtils::Terminate();
-  if(!urcode)
-  {
+  if (!urcode) {
     delete reader;
   }
-  if(!uwcode)
-  {
+  if (!uwcode) {
     delete writer;
   }
   delete ullist;
@@ -63,177 +54,118 @@ GDMLParser::~GDMLParser()
 }
 
 // --------------------------------------------------------------------
-void GDMLParser::ImportRegions()
-{
-  G4ReflectionFactory* reflFactory     = G4ReflectionFactory::Instance();
+void GDMLParser::ImportRegions() {
+  G4ReflectionFactory* reflFactory = G4ReflectionFactory::Instance();
   const G4GDMLAuxListType* auxInfoList = GetAuxList();
-  for(auto iaux = auxInfoList->cbegin(); iaux != auxInfoList->cend(); ++iaux)
-  {
-    if(iaux->type != "Region")
-      continue;
+  for (auto iaux = auxInfoList->cbegin(); iaux != auxInfoList->cend(); ++iaux) {
+    if (iaux->type != "Region") continue;
 
     G4String name = iaux->value;
-    if(strip)
-    {
+    if (strip) {
       reader->StripName(name);
     }
-    if(G4StrUtil::contains(name, "DefaultRegionForTheWorld"))
-      continue;
+    if (G4StrUtil::contains(name, "DefaultRegionForTheWorld")) continue;
 
-    if(!iaux->auxList)
-    {
+    if (!iaux->auxList) {
       G4Exception("GDMLParser::ImportRegions()", "ReadError", FatalException,
                   "Invalid definition of geometrical region!");
-    }
-    else  // Create region and loop over all region attributes
+    } else  // Create region and loop over all region attributes
     {
-      G4Region* aRegion       = new G4Region(name);
+      G4Region* aRegion = new G4Region(name);
       G4ProductionCuts* pcuts = new G4ProductionCuts();
       aRegion->SetProductionCuts(pcuts);
-      for(auto raux = iaux->auxList->cbegin();
-               raux != iaux->auxList->cend(); ++raux)
-      {
+      for (auto raux = iaux->auxList->cbegin(); raux != iaux->auxList->cend(); ++raux) {
         const G4String& tag = raux->type;
-        if(tag == "volume")
-        {
+        if (tag == "volume") {
           G4String volname = raux->value;
-          if(strip)
-          {
+          if (strip) {
             reader->StripName(volname);
           }
           G4LogicalVolumeStore* store = G4LogicalVolumeStore::GetInstance();
           auto pos = store->GetMap().find(volname);
-          if(pos != store->GetMap().cend())
-          {
+          if (pos != store->GetMap().cend()) {
             // Scan for all possible volumes with same name
             // and set them as root logical volumes for the region...
             // Issue a notification in case more than one logical volume
             // with same name exist and get set.
             //
-            if (pos->second.size()>1)
-            {
+            if (pos->second.size() > 1) {
               std::ostringstream message;
               message << "There exists more than ONE logical volume "
                       << "in store named: " << volname << "." << G4endl
                       << "NOTE: assigning all such volumes as root logical "
                       << "volumes for region: " << name << "!";
-              G4Exception("GDMLParser::ImportRegions()",
-                          "Notification", JustWarning, message);
+              G4Exception("GDMLParser::ImportRegions()", "Notification", JustWarning, message);
             }
-            for (auto vpos = pos->second.cbegin();
-                      vpos != pos->second.cend(); ++vpos)
-            {
+            for (auto vpos = pos->second.cbegin(); vpos != pos->second.cend(); ++vpos) {
               aRegion->AddRootLogicalVolume(*vpos);
-              if(reflFactory->IsConstituent(*vpos))
-                aRegion->AddRootLogicalVolume(reflFactory->GetReflectedLV(*vpos));
+              if (reflFactory->IsConstituent(*vpos)) aRegion->AddRootLogicalVolume(reflFactory->GetReflectedLV(*vpos));
             }
-          }
-          else
-          {
+          } else {
             std::ostringstream message;
-            message << "Volume NOT found in store !" << G4endl
-                    << "        Volume " << volname << " NOT found in store !"
-                    << G4endl
-                    << "        No region is being set.";
-            G4Exception("GDMLParser::ImportRegions()",
-                        "InvalidSetup", JustWarning, message);
+            message << "Volume NOT found in store !" << G4endl << "        Volume " << volname
+                    << " NOT found in store !" << G4endl << "        No region is being set.";
+            G4Exception("GDMLParser::ImportRegions()", "InvalidSetup", JustWarning, message);
           }
-        }
-        else if(tag == "pcut")
-        {
+        } else if (tag == "pcut") {
           const G4String& cvalue = raux->value;
-          const G4String& cunit  = raux->unit;
-          if(G4UnitDefinition::GetCategory(cunit) != "Length")
-          {
-            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
-                        FatalException, "Invalid unit for length!");
+          const G4String& cunit = raux->unit;
+          if (G4UnitDefinition::GetCategory(cunit) != "Length") {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead", FatalException, "Invalid unit for length!");
           }
-          G4double cut =
-            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          G4double cut = eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
           pcuts->SetProductionCut(cut, "proton");
-        }
-        else if(tag == "ecut")
-        {
+        } else if (tag == "ecut") {
           const G4String& cvalue = raux->value;
-          const G4String& cunit  = raux->unit;
-          if(G4UnitDefinition::GetCategory(cunit) != "Length")
-          {
-            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
-                        FatalException, "Invalid unit for length!");
+          const G4String& cunit = raux->unit;
+          if (G4UnitDefinition::GetCategory(cunit) != "Length") {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead", FatalException, "Invalid unit for length!");
           }
-          G4double cut =
-            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          G4double cut = eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
           pcuts->SetProductionCut(cut, "e-");
-        }
-        else if(tag == "poscut")
-        {
+        } else if (tag == "poscut") {
           const G4String& cvalue = raux->value;
-          const G4String& cunit  = raux->unit;
-          if(G4UnitDefinition::GetCategory(cunit) != "Length")
-          {
-            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
-                        FatalException, "Invalid unit for length!");
+          const G4String& cunit = raux->unit;
+          if (G4UnitDefinition::GetCategory(cunit) != "Length") {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead", FatalException, "Invalid unit for length!");
           }
-          G4double cut =
-            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          G4double cut = eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
           pcuts->SetProductionCut(cut, "e+");
-        }
-        else if(tag == "gamcut")
-        {
+        } else if (tag == "gamcut") {
           const G4String& cvalue = raux->value;
-          const G4String& cunit  = raux->unit;
-          if(G4UnitDefinition::GetCategory(cunit) != "Length")
-          {
-            G4Exception("GDMLParser::ImportRegions()", "InvalidRead",
-                        FatalException, "Invalid unit for length!");
+          const G4String& cunit = raux->unit;
+          if (G4UnitDefinition::GetCategory(cunit) != "Length") {
+            G4Exception("GDMLParser::ImportRegions()", "InvalidRead", FatalException, "Invalid unit for length!");
           }
-          G4double cut =
-            eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
+          G4double cut = eval.Evaluate(cvalue) * G4UnitDefinition::GetValueOf(cunit);
           pcuts->SetProductionCut(cut, "gamma");
-        }
-        else if(tag == "ulimits")
-        {
+        } else if (tag == "ulimits") {
           G4double ustepMax = DBL_MAX, utrakMax = DBL_MAX, utimeMax = DBL_MAX;
           G4double uekinMin = 0., urangMin = 0.;
           const G4String& ulname = raux->value;
-          for(auto uaux = raux->auxList->cbegin();
-                   uaux != raux->auxList->cend(); ++uaux)
-          {
-            const G4String& ultag  = uaux->type;
+          for (auto uaux = raux->auxList->cbegin(); uaux != raux->auxList->cend(); ++uaux) {
+            const G4String& ultag = uaux->type;
             const G4String& uvalue = uaux->value;
-            const G4String& uunit  = uaux->unit;
+            const G4String& uunit = uaux->unit;
             G4double ulvalue = eval.Evaluate(uvalue) * eval.Evaluate(uunit);
-            if(ultag == "ustepMax")
-            {
+            if (ultag == "ustepMax") {
               ustepMax = ulvalue;
-            }
-            else if(ultag == "utrakMax")
-            {
+            } else if (ultag == "utrakMax") {
               utrakMax = ulvalue;
-            }
-            else if(ultag == "utimeMax")
-            {
+            } else if (ultag == "utimeMax") {
               utimeMax = ulvalue;
-            }
-            else if(ultag == "uekinMin")
-            {
+            } else if (ultag == "uekinMin") {
               uekinMin = ulvalue;
-            }
-            else if(ultag == "urangMin")
-            {
+            } else if (ultag == "urangMin") {
               urangMin = ulvalue;
-            }
-            else
-            {
-              G4Exception("GDMLParser::ImportRegions()", "ReadError",
-                          FatalException, "Invalid definition of user-limits!");
+            } else {
+              G4Exception("GDMLParser::ImportRegions()", "ReadError", FatalException,
+                          "Invalid definition of user-limits!");
             }
           }
-          G4UserLimits* ulimits = new G4UserLimits(
-            ulname, ustepMax, utrakMax, utimeMax, uekinMin, urangMin);
+          G4UserLimits* ulimits = new G4UserLimits(ulname, ustepMax, utrakMax, utimeMax, uekinMin, urangMin);
           aRegion->SetUserLimits(ulimits);
-        }
-        else
+        } else
           continue;  // Ignore unknown tags
       }
     }
@@ -241,87 +173,64 @@ void GDMLParser::ImportRegions()
 }
 
 // --------------------------------------------------------------------
-void GDMLParser::ExportRegions(G4bool storeReferences)
-{
-  G4RegionStore* rstore            = G4RegionStore::GetInstance();
+void GDMLParser::ExportRegions(G4bool storeReferences) {
+  G4RegionStore* rstore = G4RegionStore::GetInstance();
   G4ReflectionFactory* reflFactory = G4ReflectionFactory::Instance();
-  for(std::size_t i = 0; i < rstore->size(); ++i)
-     // Skip default regions associated to worlds
+  for (std::size_t i = 0; i < rstore->size(); ++i)
+  // Skip default regions associated to worlds
   {
     const G4String& tname = (*rstore)[i]->GetName();
-    if(G4StrUtil::contains(tname, "DefaultRegionForParallelWorld"))
-      continue;
-    const G4String& rname    = writer->GenerateName(tname, (*rstore)[i]);
-    rlist                    = new G4GDMLAuxListType();
-    G4GDMLAuxStructType raux = { "Region", rname, "", rlist };
+    if (G4StrUtil::contains(tname, "DefaultRegionForParallelWorld")) continue;
+    const G4String& rname = writer->GenerateName(tname, (*rstore)[i]);
+    rlist = new G4GDMLAuxListType();
+    G4GDMLAuxStructType raux = {"Region", rname, "", rlist};
     auto rlvol_iter = (*rstore)[i]->GetRootLogicalVolumeIterator();
-    for(std::size_t j = 0; j < (*rstore)[i]->GetNumberOfRootVolumes(); ++j)
-    {
+    for (std::size_t j = 0; j < (*rstore)[i]->GetNumberOfRootVolumes(); ++j) {
       G4LogicalVolume* rlvol = *rlvol_iter;
-      if(reflFactory->IsReflected(rlvol))
-        continue;
+      if (reflFactory->IsReflected(rlvol)) continue;
       G4String vname = writer->GenerateName(rlvol->GetName(), rlvol);
-      if(!storeReferences)
-      {
+      if (!storeReferences) {
         reader->StripName(vname);
       }
-      G4GDMLAuxStructType rsubaux = { "volume", vname, "", 0 };
+      G4GDMLAuxStructType rsubaux = {"volume", vname, "", 0};
       rlist->push_back(rsubaux);
       ++rlvol_iter;
     }
-    G4double gam_cut
-      = (*rstore)[i]->GetProductionCuts()->GetProductionCut("gamma");
-    G4GDMLAuxStructType caux1
-      = { "gamcut", eval.ConvertToString(gam_cut), "mm", 0 };
+    G4double gam_cut = (*rstore)[i]->GetProductionCuts()->GetProductionCut("gamma");
+    G4GDMLAuxStructType caux1 = {"gamcut", eval.ConvertToString(gam_cut), "mm", 0};
     rlist->push_back(caux1);
     G4double e_cut = (*rstore)[i]->GetProductionCuts()->GetProductionCut("e-");
-    G4GDMLAuxStructType caux2
-      = { "ecut", eval.ConvertToString(e_cut), "mm", 0 };
+    G4GDMLAuxStructType caux2 = {"ecut", eval.ConvertToString(e_cut), "mm", 0};
     rlist->push_back(caux2);
-    G4double pos_cut
-      = (*rstore)[i]->GetProductionCuts()->GetProductionCut("e+");
-    G4GDMLAuxStructType caux3
-      = { "poscut", eval.ConvertToString(pos_cut), "mm", 0 };
+    G4double pos_cut = (*rstore)[i]->GetProductionCuts()->GetProductionCut("e+");
+    G4GDMLAuxStructType caux3 = {"poscut", eval.ConvertToString(pos_cut), "mm", 0};
     rlist->push_back(caux3);
-    G4double p_cut
-      = (*rstore)[i]->GetProductionCuts()->GetProductionCut("proton");
-    G4GDMLAuxStructType caux4
-      = { "pcut", eval.ConvertToString(p_cut), "mm", 0 };
+    G4double p_cut = (*rstore)[i]->GetProductionCuts()->GetProductionCut("proton");
+    G4GDMLAuxStructType caux4 = {"pcut", eval.ConvertToString(p_cut), "mm", 0};
     rlist->push_back(caux4);
-    if((*rstore)[i]->GetUserLimits())
-    {
+    if ((*rstore)[i]->GetUserLimits()) {
       const G4Track fake_trk;
-      ullist                   = new G4GDMLAuxListType();
-      const G4String& utype    = (*rstore)[i]->GetUserLimits()->GetType();
-      G4GDMLAuxStructType uaux = { "ulimits", utype, "mm", ullist };
-      G4double max_step
-        = (*rstore)[i]->GetUserLimits()->GetMaxAllowedStep(fake_trk);
-      G4GDMLAuxStructType ulaux1
-        = { "ustepMax", eval.ConvertToString(max_step), "mm", 0 };
+      ullist = new G4GDMLAuxListType();
+      const G4String& utype = (*rstore)[i]->GetUserLimits()->GetType();
+      G4GDMLAuxStructType uaux = {"ulimits", utype, "mm", ullist};
+      G4double max_step = (*rstore)[i]->GetUserLimits()->GetMaxAllowedStep(fake_trk);
+      G4GDMLAuxStructType ulaux1 = {"ustepMax", eval.ConvertToString(max_step), "mm", 0};
       ullist->push_back(ulaux1);
-      G4double max_trk
-        = (*rstore)[i]->GetUserLimits()->GetUserMaxTrackLength(fake_trk);
-      G4GDMLAuxStructType ulaux2
-        = { "utrakMax", eval.ConvertToString(max_trk), "mm", 0 };
+      G4double max_trk = (*rstore)[i]->GetUserLimits()->GetUserMaxTrackLength(fake_trk);
+      G4GDMLAuxStructType ulaux2 = {"utrakMax", eval.ConvertToString(max_trk), "mm", 0};
       ullist->push_back(ulaux2);
-      G4double max_time
-        = (*rstore)[i]->GetUserLimits()->GetUserMaxTime(fake_trk);
-      G4GDMLAuxStructType ulaux3
-        = { "utimeMax", eval.ConvertToString(max_time), "mm", 0 };
+      G4double max_time = (*rstore)[i]->GetUserLimits()->GetUserMaxTime(fake_trk);
+      G4GDMLAuxStructType ulaux3 = {"utimeMax", eval.ConvertToString(max_time), "mm", 0};
       ullist->push_back(ulaux3);
-      G4double min_ekin
-        = (*rstore)[i]->GetUserLimits()->GetUserMinEkine(fake_trk);
-      G4GDMLAuxStructType ulaux4
-        = { "uekinMin", eval.ConvertToString(min_ekin), "mm", 0 };
+      G4double min_ekin = (*rstore)[i]->GetUserLimits()->GetUserMinEkine(fake_trk);
+      G4GDMLAuxStructType ulaux4 = {"uekinMin", eval.ConvertToString(min_ekin), "mm", 0};
       ullist->push_back(ulaux4);
-      G4double min_rng
-        = (*rstore)[i]->GetUserLimits()->GetUserMinRange(fake_trk);
-      G4GDMLAuxStructType ulaux5
-        = { "urangMin", eval.ConvertToString(min_rng), "mm", 0 };
+      G4double min_rng = (*rstore)[i]->GetUserLimits()->GetUserMinRange(fake_trk);
+      G4GDMLAuxStructType ulaux5 = {"urangMin", eval.ConvertToString(min_rng), "mm", 0};
       ullist->push_back(ulaux5);
       rlist->push_back(uaux);
     }
     AddAuxiliary(raux);
   }
 }
-}
+}  // namespace RAT

--- a/src/geo/src/gdml/GDMLWriteParamvol.cc
+++ b/src/geo/src/gdml/GDMLWriteParamvol.cc
@@ -1,250 +1,170 @@
 #include "RAT/GDMLWriteParamvol.hh"
-#include "RAT/GDMLWriteSolids.hh"
 
-#include "G4SystemOfUnits.hh"
 #include "G4Box.hh"
-#include "G4Trd.hh"
-#include "G4Trap.hh"
-#include "G4Tubs.hh"
 #include "G4Cons.hh"
-#include "G4Sphere.hh"
-#include "G4Orb.hh"
-#include "G4Torus.hh"
 #include "G4Ellipsoid.hh"
-#include "G4Para.hh"
 #include "G4Hype.hh"
+#include "G4LogicalVolume.hh"
+#include "G4Orb.hh"
+#include "G4PVParameterised.hh"
+#include "G4Para.hh"
 #include "G4Polycone.hh"
 #include "G4Polyhedra.hh"
-#include "G4LogicalVolume.hh"
-#include "G4VPhysicalVolume.hh"
-#include "G4PVParameterised.hh"
+#include "G4Sphere.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4Torus.hh"
+#include "G4Trap.hh"
+#include "G4Trd.hh"
+#include "G4Tubs.hh"
 #include "G4VPVParameterisation.hh"
+#include "G4VPhysicalVolume.hh"
+#include "RAT/GDMLWriteSolids.hh"
 
 namespace RAT {
 
 // --------------------------------------------------------------------
-GDMLWriteParamvol::GDMLWriteParamvol()
-  : GDMLWriteSetup()
-{
-}
+GDMLWriteParamvol::GDMLWriteParamvol() : GDMLWriteSetup() {}
 
 // --------------------------------------------------------------------
-GDMLWriteParamvol::~GDMLWriteParamvol()
-{
-}
+GDMLWriteParamvol::~GDMLWriteParamvol() {}
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Box_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Box* const box)
-{
+void GDMLWriteParamvol::Box_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Box* const box) {
   xercesc::DOMElement* box_dimensionsElement = NewElement("box_dimensions");
-  box_dimensionsElement->setAttributeNode(
-    NewAttribute("x", 2.0 * box->GetXHalfLength() / mm));
-  box_dimensionsElement->setAttributeNode(
-    NewAttribute("y", 2.0 * box->GetYHalfLength() / mm));
-  box_dimensionsElement->setAttributeNode(
-    NewAttribute("z", 2.0 * box->GetZHalfLength() / mm));
+  box_dimensionsElement->setAttributeNode(NewAttribute("x", 2.0 * box->GetXHalfLength() / mm));
+  box_dimensionsElement->setAttributeNode(NewAttribute("y", 2.0 * box->GetYHalfLength() / mm));
+  box_dimensionsElement->setAttributeNode(NewAttribute("z", 2.0 * box->GetZHalfLength() / mm));
   box_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(box_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Trd_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Trd* const trd)
-{
+void GDMLWriteParamvol::Trd_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Trd* const trd) {
   xercesc::DOMElement* trd_dimensionsElement = NewElement("trd_dimensions");
-  trd_dimensionsElement->setAttributeNode(
-    NewAttribute("x1", 2.0 * trd->GetXHalfLength1() / mm));
-  trd_dimensionsElement->setAttributeNode(
-    NewAttribute("x2", 2.0 * trd->GetXHalfLength2() / mm));
-  trd_dimensionsElement->setAttributeNode(
-    NewAttribute("y1", 2.0 * trd->GetYHalfLength1() / mm));
-  trd_dimensionsElement->setAttributeNode(
-    NewAttribute("y2", 2.0 * trd->GetYHalfLength2() / mm));
-  trd_dimensionsElement->setAttributeNode(
-    NewAttribute("z", 2.0 * trd->GetZHalfLength() / mm));
+  trd_dimensionsElement->setAttributeNode(NewAttribute("x1", 2.0 * trd->GetXHalfLength1() / mm));
+  trd_dimensionsElement->setAttributeNode(NewAttribute("x2", 2.0 * trd->GetXHalfLength2() / mm));
+  trd_dimensionsElement->setAttributeNode(NewAttribute("y1", 2.0 * trd->GetYHalfLength1() / mm));
+  trd_dimensionsElement->setAttributeNode(NewAttribute("y2", 2.0 * trd->GetYHalfLength2() / mm));
+  trd_dimensionsElement->setAttributeNode(NewAttribute("z", 2.0 * trd->GetZHalfLength() / mm));
   trd_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(trd_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Trap_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Trap* const trap)
-{
+void GDMLWriteParamvol::Trap_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Trap* const trap) {
   const G4ThreeVector simaxis = trap->GetSymAxis();
-  const G4double phi =
-    (simaxis.z() != 1.0) ? (std::atan(simaxis.y() / simaxis.x())) : (0.0);
-  const G4double theta  = std::acos(simaxis.z());
+  const G4double phi = (simaxis.z() != 1.0) ? (std::atan(simaxis.y() / simaxis.x())) : (0.0);
+  const G4double theta = std::acos(simaxis.z());
   const G4double alpha1 = std::atan(trap->GetTanAlpha1());
   const G4double alpha2 = std::atan(trap->GetTanAlpha2());
 
   xercesc::DOMElement* trap_dimensionsElement = NewElement("trap");
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("z", 2.0 * trap->GetZHalfLength() / mm));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("theta", theta / degree));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("z", 2.0 * trap->GetZHalfLength() / mm));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("theta", theta / degree));
   trap_dimensionsElement->setAttributeNode(NewAttribute("phi", phi / degree));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("y1", 2.0 * trap->GetYHalfLength1() / mm));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("x1", 2.0 * trap->GetXHalfLength1() / mm));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("x2", 2.0 * trap->GetXHalfLength2() / mm));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("alpha1", alpha1 / degree));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("y2", 2.0 * trap->GetYHalfLength2() / mm));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("x3", 2.0 * trap->GetXHalfLength3() / mm));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("x4", 2.0 * trap->GetXHalfLength4() / mm));
-  trap_dimensionsElement->setAttributeNode(
-    NewAttribute("alpha2", alpha2 / degree));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("y1", 2.0 * trap->GetYHalfLength1() / mm));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("x1", 2.0 * trap->GetXHalfLength1() / mm));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("x2", 2.0 * trap->GetXHalfLength2() / mm));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("alpha1", alpha1 / degree));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("y2", 2.0 * trap->GetYHalfLength2() / mm));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("x3", 2.0 * trap->GetXHalfLength3() / mm));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("x4", 2.0 * trap->GetXHalfLength4() / mm));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("alpha2", alpha2 / degree));
   trap_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   trap_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(trap_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Tube_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Tubs* const tube)
-{
+void GDMLWriteParamvol::Tube_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Tubs* const tube) {
   xercesc::DOMElement* tube_dimensionsElement = NewElement("tube_dimensions");
-  tube_dimensionsElement->setAttributeNode(
-    NewAttribute("InR", tube->GetInnerRadius() / mm));
-  tube_dimensionsElement->setAttributeNode(
-    NewAttribute("OutR", tube->GetOuterRadius() / mm));
-  tube_dimensionsElement->setAttributeNode(
-    NewAttribute("hz", 2.0 * tube->GetZHalfLength() / mm));
-  tube_dimensionsElement->setAttributeNode(
-    NewAttribute("StartPhi", tube->GetStartPhiAngle() / degree));
-  tube_dimensionsElement->setAttributeNode(
-    NewAttribute("DeltaPhi", tube->GetDeltaPhiAngle() / degree));
+  tube_dimensionsElement->setAttributeNode(NewAttribute("InR", tube->GetInnerRadius() / mm));
+  tube_dimensionsElement->setAttributeNode(NewAttribute("OutR", tube->GetOuterRadius() / mm));
+  tube_dimensionsElement->setAttributeNode(NewAttribute("hz", 2.0 * tube->GetZHalfLength() / mm));
+  tube_dimensionsElement->setAttributeNode(NewAttribute("StartPhi", tube->GetStartPhiAngle() / degree));
+  tube_dimensionsElement->setAttributeNode(NewAttribute("DeltaPhi", tube->GetDeltaPhiAngle() / degree));
   tube_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   tube_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(tube_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Cone_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Cons* const cone)
-{
+void GDMLWriteParamvol::Cone_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Cons* const cone) {
   xercesc::DOMElement* cone_dimensionsElement = NewElement("cone_dimensions");
-  cone_dimensionsElement->setAttributeNode(
-    NewAttribute("rmin1", cone->GetInnerRadiusMinusZ() / mm));
-  cone_dimensionsElement->setAttributeNode(
-    NewAttribute("rmax1", cone->GetOuterRadiusMinusZ() / mm));
-  cone_dimensionsElement->setAttributeNode(
-    NewAttribute("rmin2", cone->GetInnerRadiusPlusZ() / mm));
-  cone_dimensionsElement->setAttributeNode(
-    NewAttribute("rmax2", cone->GetOuterRadiusPlusZ() / mm));
-  cone_dimensionsElement->setAttributeNode(
-    NewAttribute("z", 2.0 * cone->GetZHalfLength() / mm));
-  cone_dimensionsElement->setAttributeNode(
-    NewAttribute("startphi", cone->GetStartPhiAngle() / degree));
-  cone_dimensionsElement->setAttributeNode(
-    NewAttribute("deltaphi", cone->GetDeltaPhiAngle() / degree));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("rmin1", cone->GetInnerRadiusMinusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("rmax1", cone->GetOuterRadiusMinusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("rmin2", cone->GetInnerRadiusPlusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("rmax2", cone->GetOuterRadiusPlusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("z", 2.0 * cone->GetZHalfLength() / mm));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("startphi", cone->GetStartPhiAngle() / degree));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("deltaphi", cone->GetDeltaPhiAngle() / degree));
   cone_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   cone_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(cone_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Sphere_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Sphere* const sphere)
-{
-  xercesc::DOMElement* sphere_dimensionsElement =
-    NewElement("sphere_dimensions");
-  sphere_dimensionsElement->setAttributeNode(
-    NewAttribute("rmin", sphere->GetInnerRadius() / mm));
-  sphere_dimensionsElement->setAttributeNode(
-    NewAttribute("rmax", sphere->GetOuterRadius() / mm));
-  sphere_dimensionsElement->setAttributeNode(
-    NewAttribute("startphi", sphere->GetStartPhiAngle() / degree));
-  sphere_dimensionsElement->setAttributeNode(
-    NewAttribute("deltaphi", sphere->GetDeltaPhiAngle() / degree));
-  sphere_dimensionsElement->setAttributeNode(
-    NewAttribute("starttheta", sphere->GetStartThetaAngle() / degree));
-  sphere_dimensionsElement->setAttributeNode(
-    NewAttribute("deltatheta", sphere->GetDeltaThetaAngle() / degree));
+void GDMLWriteParamvol::Sphere_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Sphere* const sphere) {
+  xercesc::DOMElement* sphere_dimensionsElement = NewElement("sphere_dimensions");
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("rmin", sphere->GetInnerRadius() / mm));
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("rmax", sphere->GetOuterRadius() / mm));
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("startphi", sphere->GetStartPhiAngle() / degree));
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("deltaphi", sphere->GetDeltaPhiAngle() / degree));
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("starttheta", sphere->GetStartThetaAngle() / degree));
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("deltatheta", sphere->GetDeltaThetaAngle() / degree));
   sphere_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   sphere_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(sphere_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Orb_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Orb* const orb)
-{
+void GDMLWriteParamvol::Orb_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Orb* const orb) {
   xercesc::DOMElement* orb_dimensionsElement = NewElement("orb_dimensions");
-  orb_dimensionsElement->setAttributeNode(
-    NewAttribute("r", orb->GetRadius() / mm));
+  orb_dimensionsElement->setAttributeNode(NewAttribute("r", orb->GetRadius() / mm));
   orb_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(orb_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Torus_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Torus* const torus)
-{
+void GDMLWriteParamvol::Torus_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Torus* const torus) {
   xercesc::DOMElement* torus_dimensionsElement = NewElement("torus_dimensions");
-  torus_dimensionsElement->setAttributeNode(
-    NewAttribute("rmin", torus->GetRmin() / mm));
-  torus_dimensionsElement->setAttributeNode(
-    NewAttribute("rmax", torus->GetRmax() / mm));
-  torus_dimensionsElement->setAttributeNode(
-    NewAttribute("rtor", torus->GetRtor() / mm));
-  torus_dimensionsElement->setAttributeNode(
-    NewAttribute("startphi", torus->GetSPhi() / degree));
-  torus_dimensionsElement->setAttributeNode(
-    NewAttribute("deltaphi", torus->GetDPhi() / degree));
+  torus_dimensionsElement->setAttributeNode(NewAttribute("rmin", torus->GetRmin() / mm));
+  torus_dimensionsElement->setAttributeNode(NewAttribute("rmax", torus->GetRmax() / mm));
+  torus_dimensionsElement->setAttributeNode(NewAttribute("rtor", torus->GetRtor() / mm));
+  torus_dimensionsElement->setAttributeNode(NewAttribute("startphi", torus->GetSPhi() / degree));
+  torus_dimensionsElement->setAttributeNode(NewAttribute("deltaphi", torus->GetDPhi() / degree));
   torus_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   torus_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(torus_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Ellipsoid_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Ellipsoid* const ellipsoid)
-{
-  xercesc::DOMElement* ellipsoid_dimensionsElement =
-    NewElement("ellipsoid_dimensions");
-  ellipsoid_dimensionsElement->setAttributeNode(
-    NewAttribute("ax", ellipsoid->GetSemiAxisMax(0) / mm));
-  ellipsoid_dimensionsElement->setAttributeNode(
-    NewAttribute("by", ellipsoid->GetSemiAxisMax(1) / mm));
-  ellipsoid_dimensionsElement->setAttributeNode(
-    NewAttribute("cz", ellipsoid->GetSemiAxisMax(2) / mm));
-  ellipsoid_dimensionsElement->setAttributeNode(
-    NewAttribute("zcut1", ellipsoid->GetZBottomCut() / mm));
-  ellipsoid_dimensionsElement->setAttributeNode(
-    NewAttribute("zcut2", ellipsoid->GetZTopCut() / mm));
+void GDMLWriteParamvol::Ellipsoid_dimensionsWrite(xercesc::DOMElement* parametersElement,
+                                                  const G4Ellipsoid* const ellipsoid) {
+  xercesc::DOMElement* ellipsoid_dimensionsElement = NewElement("ellipsoid_dimensions");
+  ellipsoid_dimensionsElement->setAttributeNode(NewAttribute("ax", ellipsoid->GetSemiAxisMax(0) / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(NewAttribute("by", ellipsoid->GetSemiAxisMax(1) / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(NewAttribute("cz", ellipsoid->GetSemiAxisMax(2) / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(NewAttribute("zcut1", ellipsoid->GetZBottomCut() / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(NewAttribute("zcut2", ellipsoid->GetZTopCut() / mm));
   ellipsoid_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(ellipsoid_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Para_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Para* const para)
-{
+void GDMLWriteParamvol::Para_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Para* const para) {
   const G4ThreeVector simaxis = para->GetSymAxis();
 
   const G4double alpha = std::atan(para->GetTanAlpha());
   const G4double theta = std::acos(simaxis.z());
-  const G4double phi =
-    (simaxis.z() != 1.0) ? (std::atan(simaxis.y() / simaxis.x())) : (0.0);
+  const G4double phi = (simaxis.z() != 1.0) ? (std::atan(simaxis.y() / simaxis.x())) : (0.0);
 
   xercesc::DOMElement* para_dimensionsElement = NewElement("para_dimensions");
-  para_dimensionsElement->setAttributeNode(
-    NewAttribute("x", 2.0 * para->GetXHalfLength() / mm));
-  para_dimensionsElement->setAttributeNode(
-    NewAttribute("y", 2.0 * para->GetYHalfLength() / mm));
-  para_dimensionsElement->setAttributeNode(
-    NewAttribute("z", 2.0 * para->GetZHalfLength() / mm));
-  para_dimensionsElement->setAttributeNode(
-    NewAttribute("alpha", alpha / degree));
-  para_dimensionsElement->setAttributeNode(
-    NewAttribute("theta", theta / degree));
+  para_dimensionsElement->setAttributeNode(NewAttribute("x", 2.0 * para->GetXHalfLength() / mm));
+  para_dimensionsElement->setAttributeNode(NewAttribute("y", 2.0 * para->GetYHalfLength() / mm));
+  para_dimensionsElement->setAttributeNode(NewAttribute("z", 2.0 * para->GetZHalfLength() / mm));
+  para_dimensionsElement->setAttributeNode(NewAttribute("alpha", alpha / degree));
+  para_dimensionsElement->setAttributeNode(NewAttribute("theta", theta / degree));
   para_dimensionsElement->setAttributeNode(NewAttribute("phi", phi / degree));
   para_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   para_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
@@ -252,91 +172,72 @@ void GDMLWriteParamvol::Para_dimensionsWrite(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Hype_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Hype* const hype)
-{
+void GDMLWriteParamvol::Hype_dimensionsWrite(xercesc::DOMElement* parametersElement, const G4Hype* const hype) {
   xercesc::DOMElement* hype_dimensionsElement = NewElement("hype_dimensions");
-  hype_dimensionsElement->setAttributeNode(
-    NewAttribute("rmin", hype->GetInnerRadius() / mm));
-  hype_dimensionsElement->setAttributeNode(
-    NewAttribute("rmax", hype->GetOuterRadius() / mm));
-  hype_dimensionsElement->setAttributeNode(
-    NewAttribute("inst", hype->GetInnerStereo() / degree));
-  hype_dimensionsElement->setAttributeNode(
-    NewAttribute("outst", hype->GetOuterStereo() / degree));
-  hype_dimensionsElement->setAttributeNode(
-    NewAttribute("z", 2.0 * hype->GetZHalfLength() / mm));
+  hype_dimensionsElement->setAttributeNode(NewAttribute("rmin", hype->GetInnerRadius() / mm));
+  hype_dimensionsElement->setAttributeNode(NewAttribute("rmax", hype->GetOuterRadius() / mm));
+  hype_dimensionsElement->setAttributeNode(NewAttribute("inst", hype->GetInnerStereo() / degree));
+  hype_dimensionsElement->setAttributeNode(NewAttribute("outst", hype->GetOuterStereo() / degree));
+  hype_dimensionsElement->setAttributeNode(NewAttribute("z", 2.0 * hype->GetZHalfLength() / mm));
   hype_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   hype_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   parametersElement->appendChild(hype_dimensionsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Polycone_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Polycone* const pcone)
-{
-  xercesc::DOMElement* pcone_dimensionsElement =
-    NewElement("polycone_dimensions");
+void GDMLWriteParamvol::Polycone_dimensionsWrite(xercesc::DOMElement* parametersElement,
+                                                 const G4Polycone* const pcone) {
+  xercesc::DOMElement* pcone_dimensionsElement = NewElement("polycone_dimensions");
 
+  pcone_dimensionsElement->setAttributeNode(NewAttribute("numRZ", pcone->GetOriginalParameters()->Num_z_planes));
   pcone_dimensionsElement->setAttributeNode(
-    NewAttribute("numRZ", pcone->GetOriginalParameters()->Num_z_planes));
-  pcone_dimensionsElement->setAttributeNode(NewAttribute(
-    "startPhi", pcone->GetOriginalParameters()->Start_angle / degree));
-  pcone_dimensionsElement->setAttributeNode(NewAttribute(
-    "openPhi", pcone->GetOriginalParameters()->Opening_angle / degree));
+      NewAttribute("startPhi", pcone->GetOriginalParameters()->Start_angle / degree));
+  pcone_dimensionsElement->setAttributeNode(
+      NewAttribute("openPhi", pcone->GetOriginalParameters()->Opening_angle / degree));
   pcone_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   pcone_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
 
   parametersElement->appendChild(pcone_dimensionsElement);
-  const size_t num_zplanes   = pcone->GetOriginalParameters()->Num_z_planes;
-  const G4double* z_array    = pcone->GetOriginalParameters()->Z_values;
+  const size_t num_zplanes = pcone->GetOriginalParameters()->Num_z_planes;
+  const G4double* z_array = pcone->GetOriginalParameters()->Z_values;
   const G4double* rmin_array = pcone->GetOriginalParameters()->Rmin;
   const G4double* rmax_array = pcone->GetOriginalParameters()->Rmax;
 
-  for(std::size_t i = 0; i < num_zplanes; ++i)
-  {
-    ZplaneWrite(pcone_dimensionsElement, z_array[i], rmin_array[i],
-                rmax_array[i]);
+  for (std::size_t i = 0; i < num_zplanes; ++i) {
+    ZplaneWrite(pcone_dimensionsElement, z_array[i], rmin_array[i], rmax_array[i]);
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::Polyhedra_dimensionsWrite(
-  xercesc::DOMElement* parametersElement, const G4Polyhedra* const polyhedra)
-{
-  xercesc::DOMElement* polyhedra_dimensionsElement =
-    NewElement("polyhedra_dimensions");
+void GDMLWriteParamvol::Polyhedra_dimensionsWrite(xercesc::DOMElement* parametersElement,
+                                                  const G4Polyhedra* const polyhedra) {
+  xercesc::DOMElement* polyhedra_dimensionsElement = NewElement("polyhedra_dimensions");
 
   polyhedra_dimensionsElement->setAttributeNode(
-    NewAttribute("numRZ", polyhedra->GetOriginalParameters()->Num_z_planes));
+      NewAttribute("numRZ", polyhedra->GetOriginalParameters()->Num_z_planes));
+  polyhedra_dimensionsElement->setAttributeNode(NewAttribute("numSide", polyhedra->GetOriginalParameters()->numSide));
   polyhedra_dimensionsElement->setAttributeNode(
-    NewAttribute("numSide", polyhedra->GetOriginalParameters()->numSide));
-  polyhedra_dimensionsElement->setAttributeNode(NewAttribute(
-    "startPhi", polyhedra->GetOriginalParameters()->Start_angle / degree));
-  polyhedra_dimensionsElement->setAttributeNode(NewAttribute(
-    "openPhi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
+      NewAttribute("startPhi", polyhedra->GetOriginalParameters()->Start_angle / degree));
+  polyhedra_dimensionsElement->setAttributeNode(
+      NewAttribute("openPhi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
   polyhedra_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   polyhedra_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
 
   parametersElement->appendChild(polyhedra_dimensionsElement);
-  const size_t num_zplanes   = polyhedra->GetOriginalParameters()->Num_z_planes;
-  const G4double* z_array    = polyhedra->GetOriginalParameters()->Z_values;
+  const size_t num_zplanes = polyhedra->GetOriginalParameters()->Num_z_planes;
+  const G4double* z_array = polyhedra->GetOriginalParameters()->Z_values;
   const G4double* rmin_array = polyhedra->GetOriginalParameters()->Rmin;
   const G4double* rmax_array = polyhedra->GetOriginalParameters()->Rmax;
 
-  for(std::size_t i = 0; i < num_zplanes; ++i)
-  {
-    ZplaneWrite(polyhedra_dimensionsElement, z_array[i], rmin_array[i],
-                rmax_array[i]);
+  for (std::size_t i = 0; i < num_zplanes; ++i) {
+    ZplaneWrite(polyhedra_dimensionsElement, z_array[i], rmin_array[i], rmax_array[i]);
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::ParametersWrite(xercesc::DOMElement* paramvolElement,
-                   const G4VPhysicalVolume* const paramvol, const G4int& index)
-{
-  paramvol->GetParameterisation()->ComputeTransformation(
-    index, const_cast<G4VPhysicalVolume*>(paramvol));
+void GDMLWriteParamvol::ParametersWrite(xercesc::DOMElement* paramvolElement, const G4VPhysicalVolume* const paramvol,
+                                        const G4int& index) {
+  paramvol->GetParameterisation()->ComputeTransformation(index, const_cast<G4VPhysicalVolume*>(paramvol));
   G4ThreeVector Angles;
   G4String name = GenerateName(paramvol->GetName(), paramvol);
   std::stringstream os;
@@ -347,119 +248,69 @@ void GDMLWriteParamvol::ParametersWrite(xercesc::DOMElement* paramvolElement,
   xercesc::DOMElement* parametersElement = NewElement("parameters");
   parametersElement->setAttributeNode(NewAttribute("number", index + 1));
 
-  PositionWrite(parametersElement, name + sncopie + "_pos",
-                paramvol->GetObjectTranslation());
+  PositionWrite(parametersElement, name + sncopie + "_pos", paramvol->GetObjectTranslation());
   Angles = GetAngles(paramvol->GetObjectRotationValue());
-  if(Angles.mag2() > DBL_EPSILON)
-  {
-    RotationWrite(parametersElement, name + sncopie + "_rot",
-                  GetAngles(paramvol->GetObjectRotationValue()));
+  if (Angles.mag2() > DBL_EPSILON) {
+    RotationWrite(parametersElement, name + sncopie + "_rot", GetAngles(paramvol->GetObjectRotationValue()));
   }
   paramvolElement->appendChild(parametersElement);
 
   G4VSolid* solid = paramvol->GetLogicalVolume()->GetSolid();
 
-  if(G4Box* box = dynamic_cast<G4Box*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *box, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  if (G4Box* box = dynamic_cast<G4Box*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*box, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Box_dimensionsWrite(parametersElement, box);
-  }
-  else if(G4Trd* trd = dynamic_cast<G4Trd*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *trd, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Trd* trd = dynamic_cast<G4Trd*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*trd, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Trd_dimensionsWrite(parametersElement, trd);
-  }
-  else if(G4Trap* trap = dynamic_cast<G4Trap*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *trap, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Trap* trap = dynamic_cast<G4Trap*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*trap, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Trap_dimensionsWrite(parametersElement, trap);
-  }
-  else if(G4Tubs* tube = dynamic_cast<G4Tubs*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *tube, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Tubs* tube = dynamic_cast<G4Tubs*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*tube, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Tube_dimensionsWrite(parametersElement, tube);
-  }
-  else if(G4Cons* cone = dynamic_cast<G4Cons*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *cone, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Cons* cone = dynamic_cast<G4Cons*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*cone, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Cone_dimensionsWrite(parametersElement, cone);
-  }
-  else if(G4Sphere* sphere = dynamic_cast<G4Sphere*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *sphere, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Sphere* sphere = dynamic_cast<G4Sphere*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*sphere, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Sphere_dimensionsWrite(parametersElement, sphere);
-  }
-  else if(G4Orb* orb = dynamic_cast<G4Orb*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *orb, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Orb* orb = dynamic_cast<G4Orb*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*orb, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Orb_dimensionsWrite(parametersElement, orb);
-  }
-  else if(G4Torus* torus = dynamic_cast<G4Torus*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *torus, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Torus* torus = dynamic_cast<G4Torus*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*torus, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Torus_dimensionsWrite(parametersElement, torus);
-  }
-  else if(G4Ellipsoid* ellipsoid = dynamic_cast<G4Ellipsoid*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *ellipsoid, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Ellipsoid* ellipsoid = dynamic_cast<G4Ellipsoid*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*ellipsoid, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Ellipsoid_dimensionsWrite(parametersElement, ellipsoid);
-  }
-  else if(G4Para* para = dynamic_cast<G4Para*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *para, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Para* para = dynamic_cast<G4Para*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*para, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Para_dimensionsWrite(parametersElement, para);
-  }
-  else if(G4Hype* hype = dynamic_cast<G4Hype*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *hype, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Hype* hype = dynamic_cast<G4Hype*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*hype, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Hype_dimensionsWrite(parametersElement, hype);
-  }
-  else if(G4Polycone* pcone = dynamic_cast<G4Polycone*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *pcone, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Polycone* pcone = dynamic_cast<G4Polycone*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*pcone, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Polycone_dimensionsWrite(parametersElement, pcone);
-  }
-  else if(G4Polyhedra* polyhedra = dynamic_cast<G4Polyhedra*>(solid))
-  {
-    paramvol->GetParameterisation()->ComputeDimensions(
-      *polyhedra, index, const_cast<G4VPhysicalVolume*>(paramvol));
+  } else if (G4Polyhedra* polyhedra = dynamic_cast<G4Polyhedra*>(solid)) {
+    paramvol->GetParameterisation()->ComputeDimensions(*polyhedra, index, const_cast<G4VPhysicalVolume*>(paramvol));
     Polyhedra_dimensionsWrite(parametersElement, polyhedra);
-  }
-  else
-  {
-    G4String error_msg = "Solid '" + solid->GetName() +
-                         "' cannot be used in parameterised volume!";
-    G4Exception("GDMLWriteParamvol::ParametersWrite()", "InvalidSetup",
-                FatalException, error_msg);
+  } else {
+    G4String error_msg = "Solid '" + solid->GetName() + "' cannot be used in parameterised volume!";
+    G4Exception("GDMLWriteParamvol::ParametersWrite()", "InvalidSetup", FatalException, error_msg);
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::ParamvolWrite(xercesc::DOMElement* volumeElement,
-                                        const G4VPhysicalVolume* const paramvol)
-{
-  const G4String volumeref = GenerateName(
-    paramvol->GetLogicalVolume()->GetName(), paramvol->GetLogicalVolume());
+void GDMLWriteParamvol::ParamvolWrite(xercesc::DOMElement* volumeElement, const G4VPhysicalVolume* const paramvol) {
+  const G4String volumeref = GenerateName(paramvol->GetLogicalVolume()->GetName(), paramvol->GetLogicalVolume());
   xercesc::DOMElement* paramvolElement = NewElement("paramvol");
-  paramvolElement->setAttributeNode(
-    NewAttribute("ncopies", paramvol->GetMultiplicity()));
+  paramvolElement->setAttributeNode(NewAttribute("ncopies", paramvol->GetMultiplicity()));
   xercesc::DOMElement* volumerefElement = NewElement("volumeref");
   volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
 
-  xercesc::DOMElement* algorithmElement =
-    NewElement("parameterised_position_size");
+  xercesc::DOMElement* algorithmElement = NewElement("parameterised_position_size");
   paramvolElement->appendChild(volumerefElement);
   paramvolElement->appendChild(algorithmElement);
   ParamvolAlgorithmWrite(algorithmElement, paramvol);
@@ -467,17 +318,14 @@ void GDMLWriteParamvol::ParamvolWrite(xercesc::DOMElement* volumeElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteParamvol::ParamvolAlgorithmWrite(
-  xercesc::DOMElement* paramvolElement, const G4VPhysicalVolume* const paramvol)
-{
-  const G4String volumeref = GenerateName(
-    paramvol->GetLogicalVolume()->GetName(), paramvol->GetLogicalVolume());
+void GDMLWriteParamvol::ParamvolAlgorithmWrite(xercesc::DOMElement* paramvolElement,
+                                               const G4VPhysicalVolume* const paramvol) {
+  const G4String volumeref = GenerateName(paramvol->GetLogicalVolume()->GetName(), paramvol->GetLogicalVolume());
 
   const G4int parameterCount = paramvol->GetMultiplicity();
 
-  for(G4int i = 0; i < parameterCount; ++i)
-  {
+  for (G4int i = 0; i < parameterCount; ++i) {
     ParametersWrite(paramvolElement, paramvol, i);
   }
 }
-}
+}  // namespace RAT

--- a/src/geo/src/gdml/GDMLWriteParamvol.cc
+++ b/src/geo/src/gdml/GDMLWriteParamvol.cc
@@ -1,0 +1,483 @@
+#include "RAT/GDMLWriteParamvol.hh"
+#include "RAT/GDMLWriteSolids.hh"
+
+#include "G4SystemOfUnits.hh"
+#include "G4Box.hh"
+#include "G4Trd.hh"
+#include "G4Trap.hh"
+#include "G4Tubs.hh"
+#include "G4Cons.hh"
+#include "G4Sphere.hh"
+#include "G4Orb.hh"
+#include "G4Torus.hh"
+#include "G4Ellipsoid.hh"
+#include "G4Para.hh"
+#include "G4Hype.hh"
+#include "G4Polycone.hh"
+#include "G4Polyhedra.hh"
+#include "G4LogicalVolume.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4PVParameterised.hh"
+#include "G4VPVParameterisation.hh"
+
+namespace RAT {
+
+// --------------------------------------------------------------------
+GDMLWriteParamvol::GDMLWriteParamvol()
+  : GDMLWriteSetup()
+{
+}
+
+// --------------------------------------------------------------------
+GDMLWriteParamvol::~GDMLWriteParamvol()
+{
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Box_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Box* const box)
+{
+  xercesc::DOMElement* box_dimensionsElement = NewElement("box_dimensions");
+  box_dimensionsElement->setAttributeNode(
+    NewAttribute("x", 2.0 * box->GetXHalfLength() / mm));
+  box_dimensionsElement->setAttributeNode(
+    NewAttribute("y", 2.0 * box->GetYHalfLength() / mm));
+  box_dimensionsElement->setAttributeNode(
+    NewAttribute("z", 2.0 * box->GetZHalfLength() / mm));
+  box_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(box_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Trd_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Trd* const trd)
+{
+  xercesc::DOMElement* trd_dimensionsElement = NewElement("trd_dimensions");
+  trd_dimensionsElement->setAttributeNode(
+    NewAttribute("x1", 2.0 * trd->GetXHalfLength1() / mm));
+  trd_dimensionsElement->setAttributeNode(
+    NewAttribute("x2", 2.0 * trd->GetXHalfLength2() / mm));
+  trd_dimensionsElement->setAttributeNode(
+    NewAttribute("y1", 2.0 * trd->GetYHalfLength1() / mm));
+  trd_dimensionsElement->setAttributeNode(
+    NewAttribute("y2", 2.0 * trd->GetYHalfLength2() / mm));
+  trd_dimensionsElement->setAttributeNode(
+    NewAttribute("z", 2.0 * trd->GetZHalfLength() / mm));
+  trd_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(trd_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Trap_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Trap* const trap)
+{
+  const G4ThreeVector simaxis = trap->GetSymAxis();
+  const G4double phi =
+    (simaxis.z() != 1.0) ? (std::atan(simaxis.y() / simaxis.x())) : (0.0);
+  const G4double theta  = std::acos(simaxis.z());
+  const G4double alpha1 = std::atan(trap->GetTanAlpha1());
+  const G4double alpha2 = std::atan(trap->GetTanAlpha2());
+
+  xercesc::DOMElement* trap_dimensionsElement = NewElement("trap");
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("z", 2.0 * trap->GetZHalfLength() / mm));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("theta", theta / degree));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("phi", phi / degree));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("y1", 2.0 * trap->GetYHalfLength1() / mm));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("x1", 2.0 * trap->GetXHalfLength1() / mm));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("x2", 2.0 * trap->GetXHalfLength2() / mm));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("alpha1", alpha1 / degree));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("y2", 2.0 * trap->GetYHalfLength2() / mm));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("x3", 2.0 * trap->GetXHalfLength3() / mm));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("x4", 2.0 * trap->GetXHalfLength4() / mm));
+  trap_dimensionsElement->setAttributeNode(
+    NewAttribute("alpha2", alpha2 / degree));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  trap_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(trap_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Tube_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Tubs* const tube)
+{
+  xercesc::DOMElement* tube_dimensionsElement = NewElement("tube_dimensions");
+  tube_dimensionsElement->setAttributeNode(
+    NewAttribute("InR", tube->GetInnerRadius() / mm));
+  tube_dimensionsElement->setAttributeNode(
+    NewAttribute("OutR", tube->GetOuterRadius() / mm));
+  tube_dimensionsElement->setAttributeNode(
+    NewAttribute("hz", 2.0 * tube->GetZHalfLength() / mm));
+  tube_dimensionsElement->setAttributeNode(
+    NewAttribute("StartPhi", tube->GetStartPhiAngle() / degree));
+  tube_dimensionsElement->setAttributeNode(
+    NewAttribute("DeltaPhi", tube->GetDeltaPhiAngle() / degree));
+  tube_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  tube_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(tube_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Cone_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Cons* const cone)
+{
+  xercesc::DOMElement* cone_dimensionsElement = NewElement("cone_dimensions");
+  cone_dimensionsElement->setAttributeNode(
+    NewAttribute("rmin1", cone->GetInnerRadiusMinusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(
+    NewAttribute("rmax1", cone->GetOuterRadiusMinusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(
+    NewAttribute("rmin2", cone->GetInnerRadiusPlusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(
+    NewAttribute("rmax2", cone->GetOuterRadiusPlusZ() / mm));
+  cone_dimensionsElement->setAttributeNode(
+    NewAttribute("z", 2.0 * cone->GetZHalfLength() / mm));
+  cone_dimensionsElement->setAttributeNode(
+    NewAttribute("startphi", cone->GetStartPhiAngle() / degree));
+  cone_dimensionsElement->setAttributeNode(
+    NewAttribute("deltaphi", cone->GetDeltaPhiAngle() / degree));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  cone_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(cone_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Sphere_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Sphere* const sphere)
+{
+  xercesc::DOMElement* sphere_dimensionsElement =
+    NewElement("sphere_dimensions");
+  sphere_dimensionsElement->setAttributeNode(
+    NewAttribute("rmin", sphere->GetInnerRadius() / mm));
+  sphere_dimensionsElement->setAttributeNode(
+    NewAttribute("rmax", sphere->GetOuterRadius() / mm));
+  sphere_dimensionsElement->setAttributeNode(
+    NewAttribute("startphi", sphere->GetStartPhiAngle() / degree));
+  sphere_dimensionsElement->setAttributeNode(
+    NewAttribute("deltaphi", sphere->GetDeltaPhiAngle() / degree));
+  sphere_dimensionsElement->setAttributeNode(
+    NewAttribute("starttheta", sphere->GetStartThetaAngle() / degree));
+  sphere_dimensionsElement->setAttributeNode(
+    NewAttribute("deltatheta", sphere->GetDeltaThetaAngle() / degree));
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  sphere_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(sphere_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Orb_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Orb* const orb)
+{
+  xercesc::DOMElement* orb_dimensionsElement = NewElement("orb_dimensions");
+  orb_dimensionsElement->setAttributeNode(
+    NewAttribute("r", orb->GetRadius() / mm));
+  orb_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(orb_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Torus_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Torus* const torus)
+{
+  xercesc::DOMElement* torus_dimensionsElement = NewElement("torus_dimensions");
+  torus_dimensionsElement->setAttributeNode(
+    NewAttribute("rmin", torus->GetRmin() / mm));
+  torus_dimensionsElement->setAttributeNode(
+    NewAttribute("rmax", torus->GetRmax() / mm));
+  torus_dimensionsElement->setAttributeNode(
+    NewAttribute("rtor", torus->GetRtor() / mm));
+  torus_dimensionsElement->setAttributeNode(
+    NewAttribute("startphi", torus->GetSPhi() / degree));
+  torus_dimensionsElement->setAttributeNode(
+    NewAttribute("deltaphi", torus->GetDPhi() / degree));
+  torus_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  torus_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(torus_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Ellipsoid_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Ellipsoid* const ellipsoid)
+{
+  xercesc::DOMElement* ellipsoid_dimensionsElement =
+    NewElement("ellipsoid_dimensions");
+  ellipsoid_dimensionsElement->setAttributeNode(
+    NewAttribute("ax", ellipsoid->GetSemiAxisMax(0) / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(
+    NewAttribute("by", ellipsoid->GetSemiAxisMax(1) / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(
+    NewAttribute("cz", ellipsoid->GetSemiAxisMax(2) / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(
+    NewAttribute("zcut1", ellipsoid->GetZBottomCut() / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(
+    NewAttribute("zcut2", ellipsoid->GetZTopCut() / mm));
+  ellipsoid_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(ellipsoid_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Para_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Para* const para)
+{
+  const G4ThreeVector simaxis = para->GetSymAxis();
+
+  const G4double alpha = std::atan(para->GetTanAlpha());
+  const G4double theta = std::acos(simaxis.z());
+  const G4double phi =
+    (simaxis.z() != 1.0) ? (std::atan(simaxis.y() / simaxis.x())) : (0.0);
+
+  xercesc::DOMElement* para_dimensionsElement = NewElement("para_dimensions");
+  para_dimensionsElement->setAttributeNode(
+    NewAttribute("x", 2.0 * para->GetXHalfLength() / mm));
+  para_dimensionsElement->setAttributeNode(
+    NewAttribute("y", 2.0 * para->GetYHalfLength() / mm));
+  para_dimensionsElement->setAttributeNode(
+    NewAttribute("z", 2.0 * para->GetZHalfLength() / mm));
+  para_dimensionsElement->setAttributeNode(
+    NewAttribute("alpha", alpha / degree));
+  para_dimensionsElement->setAttributeNode(
+    NewAttribute("theta", theta / degree));
+  para_dimensionsElement->setAttributeNode(NewAttribute("phi", phi / degree));
+  para_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  para_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(para_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Hype_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Hype* const hype)
+{
+  xercesc::DOMElement* hype_dimensionsElement = NewElement("hype_dimensions");
+  hype_dimensionsElement->setAttributeNode(
+    NewAttribute("rmin", hype->GetInnerRadius() / mm));
+  hype_dimensionsElement->setAttributeNode(
+    NewAttribute("rmax", hype->GetOuterRadius() / mm));
+  hype_dimensionsElement->setAttributeNode(
+    NewAttribute("inst", hype->GetInnerStereo() / degree));
+  hype_dimensionsElement->setAttributeNode(
+    NewAttribute("outst", hype->GetOuterStereo() / degree));
+  hype_dimensionsElement->setAttributeNode(
+    NewAttribute("z", 2.0 * hype->GetZHalfLength() / mm));
+  hype_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  hype_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  parametersElement->appendChild(hype_dimensionsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Polycone_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Polycone* const pcone)
+{
+  xercesc::DOMElement* pcone_dimensionsElement =
+    NewElement("polycone_dimensions");
+
+  pcone_dimensionsElement->setAttributeNode(
+    NewAttribute("numRZ", pcone->GetOriginalParameters()->Num_z_planes));
+  pcone_dimensionsElement->setAttributeNode(NewAttribute(
+    "startPhi", pcone->GetOriginalParameters()->Start_angle / degree));
+  pcone_dimensionsElement->setAttributeNode(NewAttribute(
+    "openPhi", pcone->GetOriginalParameters()->Opening_angle / degree));
+  pcone_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  pcone_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+
+  parametersElement->appendChild(pcone_dimensionsElement);
+  const size_t num_zplanes   = pcone->GetOriginalParameters()->Num_z_planes;
+  const G4double* z_array    = pcone->GetOriginalParameters()->Z_values;
+  const G4double* rmin_array = pcone->GetOriginalParameters()->Rmin;
+  const G4double* rmax_array = pcone->GetOriginalParameters()->Rmax;
+
+  for(std::size_t i = 0; i < num_zplanes; ++i)
+  {
+    ZplaneWrite(pcone_dimensionsElement, z_array[i], rmin_array[i],
+                rmax_array[i]);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::Polyhedra_dimensionsWrite(
+  xercesc::DOMElement* parametersElement, const G4Polyhedra* const polyhedra)
+{
+  xercesc::DOMElement* polyhedra_dimensionsElement =
+    NewElement("polyhedra_dimensions");
+
+  polyhedra_dimensionsElement->setAttributeNode(
+    NewAttribute("numRZ", polyhedra->GetOriginalParameters()->Num_z_planes));
+  polyhedra_dimensionsElement->setAttributeNode(
+    NewAttribute("numSide", polyhedra->GetOriginalParameters()->numSide));
+  polyhedra_dimensionsElement->setAttributeNode(NewAttribute(
+    "startPhi", polyhedra->GetOriginalParameters()->Start_angle / degree));
+  polyhedra_dimensionsElement->setAttributeNode(NewAttribute(
+    "openPhi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
+  polyhedra_dimensionsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  polyhedra_dimensionsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+
+  parametersElement->appendChild(polyhedra_dimensionsElement);
+  const size_t num_zplanes   = polyhedra->GetOriginalParameters()->Num_z_planes;
+  const G4double* z_array    = polyhedra->GetOriginalParameters()->Z_values;
+  const G4double* rmin_array = polyhedra->GetOriginalParameters()->Rmin;
+  const G4double* rmax_array = polyhedra->GetOriginalParameters()->Rmax;
+
+  for(std::size_t i = 0; i < num_zplanes; ++i)
+  {
+    ZplaneWrite(polyhedra_dimensionsElement, z_array[i], rmin_array[i],
+                rmax_array[i]);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::ParametersWrite(xercesc::DOMElement* paramvolElement,
+                   const G4VPhysicalVolume* const paramvol, const G4int& index)
+{
+  paramvol->GetParameterisation()->ComputeTransformation(
+    index, const_cast<G4VPhysicalVolume*>(paramvol));
+  G4ThreeVector Angles;
+  G4String name = GenerateName(paramvol->GetName(), paramvol);
+  std::stringstream os;
+  os.precision(15);
+  os << index;
+  G4String sncopie = os.str();
+
+  xercesc::DOMElement* parametersElement = NewElement("parameters");
+  parametersElement->setAttributeNode(NewAttribute("number", index + 1));
+
+  PositionWrite(parametersElement, name + sncopie + "_pos",
+                paramvol->GetObjectTranslation());
+  Angles = GetAngles(paramvol->GetObjectRotationValue());
+  if(Angles.mag2() > DBL_EPSILON)
+  {
+    RotationWrite(parametersElement, name + sncopie + "_rot",
+                  GetAngles(paramvol->GetObjectRotationValue()));
+  }
+  paramvolElement->appendChild(parametersElement);
+
+  G4VSolid* solid = paramvol->GetLogicalVolume()->GetSolid();
+
+  if(G4Box* box = dynamic_cast<G4Box*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *box, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Box_dimensionsWrite(parametersElement, box);
+  }
+  else if(G4Trd* trd = dynamic_cast<G4Trd*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *trd, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Trd_dimensionsWrite(parametersElement, trd);
+  }
+  else if(G4Trap* trap = dynamic_cast<G4Trap*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *trap, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Trap_dimensionsWrite(parametersElement, trap);
+  }
+  else if(G4Tubs* tube = dynamic_cast<G4Tubs*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *tube, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Tube_dimensionsWrite(parametersElement, tube);
+  }
+  else if(G4Cons* cone = dynamic_cast<G4Cons*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *cone, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Cone_dimensionsWrite(parametersElement, cone);
+  }
+  else if(G4Sphere* sphere = dynamic_cast<G4Sphere*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *sphere, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Sphere_dimensionsWrite(parametersElement, sphere);
+  }
+  else if(G4Orb* orb = dynamic_cast<G4Orb*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *orb, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Orb_dimensionsWrite(parametersElement, orb);
+  }
+  else if(G4Torus* torus = dynamic_cast<G4Torus*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *torus, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Torus_dimensionsWrite(parametersElement, torus);
+  }
+  else if(G4Ellipsoid* ellipsoid = dynamic_cast<G4Ellipsoid*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *ellipsoid, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Ellipsoid_dimensionsWrite(parametersElement, ellipsoid);
+  }
+  else if(G4Para* para = dynamic_cast<G4Para*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *para, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Para_dimensionsWrite(parametersElement, para);
+  }
+  else if(G4Hype* hype = dynamic_cast<G4Hype*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *hype, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Hype_dimensionsWrite(parametersElement, hype);
+  }
+  else if(G4Polycone* pcone = dynamic_cast<G4Polycone*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *pcone, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Polycone_dimensionsWrite(parametersElement, pcone);
+  }
+  else if(G4Polyhedra* polyhedra = dynamic_cast<G4Polyhedra*>(solid))
+  {
+    paramvol->GetParameterisation()->ComputeDimensions(
+      *polyhedra, index, const_cast<G4VPhysicalVolume*>(paramvol));
+    Polyhedra_dimensionsWrite(parametersElement, polyhedra);
+  }
+  else
+  {
+    G4String error_msg = "Solid '" + solid->GetName() +
+                         "' cannot be used in parameterised volume!";
+    G4Exception("GDMLWriteParamvol::ParametersWrite()", "InvalidSetup",
+                FatalException, error_msg);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::ParamvolWrite(xercesc::DOMElement* volumeElement,
+                                        const G4VPhysicalVolume* const paramvol)
+{
+  const G4String volumeref = GenerateName(
+    paramvol->GetLogicalVolume()->GetName(), paramvol->GetLogicalVolume());
+  xercesc::DOMElement* paramvolElement = NewElement("paramvol");
+  paramvolElement->setAttributeNode(
+    NewAttribute("ncopies", paramvol->GetMultiplicity()));
+  xercesc::DOMElement* volumerefElement = NewElement("volumeref");
+  volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
+
+  xercesc::DOMElement* algorithmElement =
+    NewElement("parameterised_position_size");
+  paramvolElement->appendChild(volumerefElement);
+  paramvolElement->appendChild(algorithmElement);
+  ParamvolAlgorithmWrite(algorithmElement, paramvol);
+  volumeElement->appendChild(paramvolElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteParamvol::ParamvolAlgorithmWrite(
+  xercesc::DOMElement* paramvolElement, const G4VPhysicalVolume* const paramvol)
+{
+  const G4String volumeref = GenerateName(
+    paramvol->GetLogicalVolume()->GetName(), paramvol->GetLogicalVolume());
+
+  const G4int parameterCount = paramvol->GetMultiplicity();
+
+  for(G4int i = 0; i < parameterCount; ++i)
+  {
+    ParametersWrite(paramvolElement, paramvol, i);
+  }
+}
+}

--- a/src/geo/src/gdml/GDMLWriteSetup.cc
+++ b/src/geo/src/gdml/GDMLWriteSetup.cc
@@ -1,0 +1,33 @@
+#include "RAT/GDMLWriteSetup.hh"
+#include "G4LogicalVolume.hh"
+
+namespace RAT {
+// --------------------------------------------------------------------
+GDMLWriteSetup::GDMLWriteSetup()
+  : GDMLWriteSolids()
+{
+}
+
+// --------------------------------------------------------------------
+GDMLWriteSetup::~GDMLWriteSetup()
+{
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSetup::SetupWrite(xercesc::DOMElement* gdmlElement,
+                                  const G4LogicalVolume* const logvol)
+{
+#ifdef G4VERBOSE
+  G4cout << "GDML: Writing setup..." << G4endl;
+#endif
+  const G4String worldref = GenerateName(logvol->GetName(), logvol);
+
+  xercesc::DOMElement* setupElement = NewElement("setup");
+  setupElement->setAttributeNode(NewAttribute("version", "1.0"));
+  setupElement->setAttributeNode(NewAttribute("name", "Default"));
+  xercesc::DOMElement* worldElement = NewElement("world");
+  worldElement->setAttributeNode(NewAttribute("ref", worldref));
+  setupElement->appendChild(worldElement);
+  gdmlElement->appendChild(setupElement);
+}
+}

--- a/src/geo/src/gdml/GDMLWriteSetup.cc
+++ b/src/geo/src/gdml/GDMLWriteSetup.cc
@@ -1,22 +1,16 @@
 #include "RAT/GDMLWriteSetup.hh"
+
 #include "G4LogicalVolume.hh"
 
 namespace RAT {
 // --------------------------------------------------------------------
-GDMLWriteSetup::GDMLWriteSetup()
-  : GDMLWriteSolids()
-{
-}
+GDMLWriteSetup::GDMLWriteSetup() : GDMLWriteSolids() {}
 
 // --------------------------------------------------------------------
-GDMLWriteSetup::~GDMLWriteSetup()
-{
-}
+GDMLWriteSetup::~GDMLWriteSetup() {}
 
 // --------------------------------------------------------------------
-void GDMLWriteSetup::SetupWrite(xercesc::DOMElement* gdmlElement,
-                                  const G4LogicalVolume* const logvol)
-{
+void GDMLWriteSetup::SetupWrite(xercesc::DOMElement* gdmlElement, const G4LogicalVolume* const logvol) {
 #ifdef G4VERBOSE
   G4cout << "GDML: Writing setup..." << G4endl;
 #endif
@@ -30,4 +24,4 @@ void GDMLWriteSetup::SetupWrite(xercesc::DOMElement* gdmlElement,
   setupElement->appendChild(worldElement);
   gdmlElement->appendChild(setupElement);
 }
-}
+}  // namespace RAT

--- a/src/geo/src/gdml/GDMLWriteSolids.cc
+++ b/src/geo/src/gdml/GDMLWriteSolids.cc
@@ -803,7 +803,7 @@ void GDMLWriteSolids::GLG4TorusStackWrite(xercesc::DOMElement* solElement, const
     if (i < n_segments) {
       xercesc::DOMElement* originElement = NewElement("origin");
       originElement->setAttributeNode(NewAttribute("z", torusStack->GetZo(i) / mm));
-      originElement->setAttributeNode(NewAttribute("rho", torusStack->GetA(i) / mm));
+      originElement->setAttributeNode(NewAttribute("rho", torusStack->GetRo(i) / mm));
       torusStackElement->appendChild(originElement);
     }
   }

--- a/src/geo/src/gdml/GDMLWriteSolids.cc
+++ b/src/geo/src/gdml/GDMLWriteSolids.cc
@@ -1,0 +1,1289 @@
+#include "RAT/GDMLWriteSolids.hh"
+
+#include "G4SystemOfUnits.hh"
+#include "G4BooleanSolid.hh"
+#include "G4ScaledSolid.hh"
+#include "G4Box.hh"
+#include "G4Cons.hh"
+#include "G4Ellipsoid.hh"
+#include "G4EllipticalCone.hh"
+#include "G4EllipticalTube.hh"
+#include "G4ExtrudedSolid.hh"
+#include "G4Hype.hh"
+#include "G4Orb.hh"
+#include "G4Para.hh"
+#include "G4Paraboloid.hh"
+#include "G4IntersectionSolid.hh"
+#include "G4Polycone.hh"
+#include "G4GenericPolycone.hh"
+#include "G4Polyhedra.hh"
+#include "G4ReflectedSolid.hh"
+#include "G4Sphere.hh"
+#include "G4SubtractionSolid.hh"
+#include "G4GenericTrap.hh"
+#include "G4TessellatedSolid.hh"
+#include "G4Tet.hh"
+#include "G4Torus.hh"
+#include "G4Trap.hh"
+#include "G4Trd.hh"
+#include "G4Tubs.hh"
+#include "G4CutTubs.hh"
+#include "G4TwistedBox.hh"
+#include "G4TwistedTrap.hh"
+#include "G4TwistedTrd.hh"
+#include "G4TwistedTubs.hh"
+#include "G4UnionSolid.hh"
+#include "G4OpticalSurface.hh"
+#include "G4SurfaceProperty.hh"
+#include "G4MaterialPropertiesTable.hh"
+
+namespace RAT {
+
+// --------------------------------------------------------------------
+GDMLWriteSolids::GDMLWriteSolids()
+  : G4GDMLWriteMaterials()
+{
+}
+
+// --------------------------------------------------------------------
+GDMLWriteSolids::~GDMLWriteSolids()
+{
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::MultiUnionWrite(xercesc::DOMElement* solElement,
+                                        const G4MultiUnion* const munionSolid)
+{
+  G4int numSolids = munionSolid->GetNumberOfSolids();
+  G4String tag("multiUnion");
+
+  G4VSolid* solid;
+  G4Transform3D transform;
+
+  const G4String& name = GenerateName(munionSolid->GetName(), munionSolid);
+  xercesc::DOMElement* multiUnionElement = NewElement(tag);
+  multiUnionElement->setAttributeNode(NewAttribute("name", name));
+
+  for(G4int i = 0; i < numSolids; ++i)
+  {
+    solid     = munionSolid->GetSolid(i);
+    transform = munionSolid->GetTransformation(i);
+
+    HepGeom::Rotate3D rot3d;
+    HepGeom::Translate3D transl;
+    HepGeom::Scale3D scale;
+    transform.getDecomposition(scale, rot3d, transl);
+
+    G4ThreeVector pos = transl.getTranslation();
+    G4RotationMatrix rotm(CLHEP::HepRep3x3(rot3d.xx(), rot3d.xy(), rot3d.xz(),
+                                           rot3d.yx(), rot3d.yy(), rot3d.yz(),
+                                           rot3d.zx(), rot3d.zy(), rot3d.zz()));
+    G4ThreeVector rot = GetAngles(rotm);
+
+    AddSolid(solid);
+    const G4String& solidref = GenerateName(solid->GetName(), solid);
+    std::ostringstream os;
+    os << i + 1;
+    const G4String& nodeName          = "Node-" + G4String(os.str());
+    xercesc::DOMElement* solidElement = NewElement("solid");
+    solidElement->setAttributeNode(NewAttribute("ref", solidref));
+    xercesc::DOMElement* multiUnionNodeElement = NewElement("multiUnionNode");
+    multiUnionNodeElement->setAttributeNode(NewAttribute("name", name+"_"+nodeName));
+    multiUnionNodeElement->appendChild(solidElement);  // Append solid to node
+    if((std::fabs(pos.x()) > kLinearPrecision) ||
+       (std::fabs(pos.y()) > kLinearPrecision) ||
+       (std::fabs(pos.z()) > kLinearPrecision))
+    {
+      PositionWrite(multiUnionNodeElement,name+"_"+nodeName+"_pos",pos);
+    }
+    if((std::fabs(rot.x()) > kAngularPrecision) ||
+       (std::fabs(rot.y()) > kAngularPrecision) ||
+       (std::fabs(rot.z()) > kAngularPrecision))
+    {
+      RotationWrite(multiUnionNodeElement,name+"_"+nodeName+"_rot",rot);
+    }
+    multiUnionElement->appendChild(multiUnionNodeElement);  // Append node
+  }
+
+  solElement->appendChild(multiUnionElement);
+  // Add the multiUnion solid AFTER the constituent nodes!
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::BooleanWrite(xercesc::DOMElement* solElement,
+                                     const G4BooleanSolid* const boolean)
+{
+  G4int displaced = 0;
+
+  G4String tag("undefined");
+  if(dynamic_cast<const G4IntersectionSolid*>(boolean))
+  {
+    tag = "intersection";
+  }
+  else if(dynamic_cast<const G4SubtractionSolid*>(boolean))
+  {
+    tag = "subtraction";
+  }
+  else if(dynamic_cast<const G4UnionSolid*>(boolean))
+  {
+    tag = "union";
+  }
+
+  G4VSolid* firstPtr  = const_cast<G4VSolid*>(boolean->GetConstituentSolid(0));
+  G4VSolid* secondPtr = const_cast<G4VSolid*>(boolean->GetConstituentSolid(1));
+
+  G4ThreeVector firstpos, firstrot, pos, rot;
+
+  // Solve possible displacement of referenced solids!
+  //
+  while(true)
+  {
+    if(displaced > 8)
+    {
+      G4String ErrorMessage = "The referenced solid '" + firstPtr->GetName() +
+                              +"in the Boolean shape '" + +boolean->GetName() +
+                              +"' was displaced too many times!";
+      G4Exception("GDMLWriteSolids::BooleanWrite()", "InvalidSetup",
+                  FatalException, ErrorMessage);
+    }
+
+    if(G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(firstPtr))
+    {
+      firstpos += disp->GetObjectTranslation();
+      firstrot += GetAngles(disp->GetObjectRotation());
+      firstPtr = disp->GetConstituentMovedSolid();
+      ++displaced;
+      continue;
+    }
+    break;
+  }
+  displaced = 0;
+  while(true)
+  {
+    if(displaced > maxTransforms)
+    {
+      G4String ErrorMessage = "The referenced solid '" + secondPtr->GetName() +
+                              +"in the Boolean shape '" + +boolean->GetName() +
+                              +"' was displaced too many times!";
+      G4Exception("GDMLWriteSolids::BooleanWrite()", "InvalidSetup",
+                  FatalException, ErrorMessage);
+    }
+
+    if(G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(secondPtr))
+    {
+      pos += disp->GetObjectTranslation();
+      rot += GetAngles(disp->GetObjectRotation());
+      secondPtr = disp->GetConstituentMovedSolid();
+      ++displaced;
+      continue;
+    }
+    break;
+  }
+
+  AddSolid(firstPtr);  // At first add the constituent solids!
+  AddSolid(secondPtr);
+
+  const G4String& name      = GenerateName(boolean->GetName(), boolean);
+  const G4String& firstref  = GenerateName(firstPtr->GetName(), firstPtr);
+  const G4String& secondref = GenerateName(secondPtr->GetName(), secondPtr);
+
+  xercesc::DOMElement* booleanElement = NewElement(tag);
+  booleanElement->setAttributeNode(NewAttribute("name", name));
+  xercesc::DOMElement* firstElement = NewElement("first");
+  firstElement->setAttributeNode(NewAttribute("ref", firstref));
+  booleanElement->appendChild(firstElement);
+  xercesc::DOMElement* secondElement = NewElement("second");
+  secondElement->setAttributeNode(NewAttribute("ref", secondref));
+  booleanElement->appendChild(secondElement);
+  solElement->appendChild(booleanElement);
+  // Add the boolean solid AFTER the constituent solids!
+
+  if((std::fabs(pos.x()) > kLinearPrecision) ||
+     (std::fabs(pos.y()) > kLinearPrecision) ||
+     (std::fabs(pos.z()) > kLinearPrecision))
+  {
+    PositionWrite(booleanElement, name + "_pos", pos);
+  }
+
+  if((std::fabs(rot.x()) > kAngularPrecision) ||
+     (std::fabs(rot.y()) > kAngularPrecision) ||
+     (std::fabs(rot.z()) > kAngularPrecision))
+  {
+    RotationWrite(booleanElement, name + "_rot", rot);
+  }
+
+  if((std::fabs(firstpos.x()) > kLinearPrecision) ||
+     (std::fabs(firstpos.y()) > kLinearPrecision) ||
+     (std::fabs(firstpos.z()) > kLinearPrecision))
+  {
+    FirstpositionWrite(booleanElement, name + "_fpos", firstpos);
+  }
+
+  if((std::fabs(firstrot.x()) > kAngularPrecision) ||
+     (std::fabs(firstrot.y()) > kAngularPrecision) ||
+     (std::fabs(firstrot.z()) > kAngularPrecision))
+  {
+    FirstrotationWrite(booleanElement, name + "_frot", firstrot);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::ScaledWrite(xercesc::DOMElement* solElement,
+                                    const G4ScaledSolid* const scaled)
+{
+  G4String tag("scaledSolid");
+
+  G4VSolid* solid         = const_cast<G4VSolid*>(scaled->GetUnscaledSolid());
+  G4Scale3D scale         = scaled->GetScaleTransform();
+  G4ThreeVector sclVector = G4ThreeVector(scale.xx(), scale.yy(), scale.zz());
+
+  AddSolid(solid);  // Add the constituent solid!
+
+  const G4String& name     = GenerateName(scaled->GetName(), scaled);
+  const G4String& solidref = GenerateName(solid->GetName(), solid);
+
+  xercesc::DOMElement* scaledElement = NewElement(tag);
+  scaledElement->setAttributeNode(NewAttribute("name", name));
+
+  xercesc::DOMElement* solidElement = NewElement("solidref");
+  solidElement->setAttributeNode(NewAttribute("ref", solidref));
+  scaledElement->appendChild(solidElement);
+
+  if((std::fabs(scale.xx()) > kLinearPrecision) &&
+     (std::fabs(scale.yy()) > kLinearPrecision) &&
+     (std::fabs(scale.zz()) > kLinearPrecision))
+  {
+    ScaleWrite(scaledElement, name + "_scl", sclVector);
+  }
+
+  solElement->appendChild(scaledElement);
+  // Add the scaled solid AFTER its constituent solid!
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::BoxWrite(xercesc::DOMElement* solElement,
+                                 const G4Box* const box)
+{
+  const G4String& name = GenerateName(box->GetName(), box);
+
+  xercesc::DOMElement* boxElement = NewElement("box");
+  boxElement->setAttributeNode(NewAttribute("name", name));
+  boxElement->setAttributeNode(
+    NewAttribute("x", 2.0 * box->GetXHalfLength() / mm));
+  boxElement->setAttributeNode(
+    NewAttribute("y", 2.0 * box->GetYHalfLength() / mm));
+  boxElement->setAttributeNode(
+    NewAttribute("z", 2.0 * box->GetZHalfLength() / mm));
+  boxElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(boxElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::ConeWrite(xercesc::DOMElement* solElement,
+                                  const G4Cons* const cone)
+{
+  const G4String& name = GenerateName(cone->GetName(), cone);
+
+  xercesc::DOMElement* coneElement = NewElement("cone");
+  coneElement->setAttributeNode(NewAttribute("name", name));
+  coneElement->setAttributeNode(
+    NewAttribute("rmin1", cone->GetInnerRadiusMinusZ() / mm));
+  coneElement->setAttributeNode(
+    NewAttribute("rmax1", cone->GetOuterRadiusMinusZ() / mm));
+  coneElement->setAttributeNode(
+    NewAttribute("rmin2", cone->GetInnerRadiusPlusZ() / mm));
+  coneElement->setAttributeNode(
+    NewAttribute("rmax2", cone->GetOuterRadiusPlusZ() / mm));
+  coneElement->setAttributeNode(
+    NewAttribute("z", 2.0 * cone->GetZHalfLength() / mm));
+  coneElement->setAttributeNode(
+    NewAttribute("startphi", cone->GetStartPhiAngle() / degree));
+  coneElement->setAttributeNode(
+    NewAttribute("deltaphi", cone->GetDeltaPhiAngle() / degree));
+  coneElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  coneElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(coneElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::ElconeWrite(xercesc::DOMElement* solElement,
+                                    const G4EllipticalCone* const elcone)
+{
+  const G4String& name = GenerateName(elcone->GetName(), elcone);
+
+  xercesc::DOMElement* elconeElement = NewElement("elcone");
+  elconeElement->setAttributeNode(NewAttribute("name", name));
+  elconeElement->setAttributeNode(
+    NewAttribute("dx", elcone->GetSemiAxisX() / mm));
+  elconeElement->setAttributeNode(
+    NewAttribute("dy", elcone->GetSemiAxisY() / mm));
+  elconeElement->setAttributeNode(NewAttribute("zmax", elcone->GetZMax() / mm));
+  elconeElement->setAttributeNode(
+    NewAttribute("zcut", elcone->GetZTopCut() / mm));
+  elconeElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(elconeElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::EllipsoidWrite(xercesc::DOMElement* solElement,
+                                       const G4Ellipsoid* const ellipsoid)
+{
+  const G4String& name = GenerateName(ellipsoid->GetName(), ellipsoid);
+
+  xercesc::DOMElement* ellipsoidElement = NewElement("ellipsoid");
+  ellipsoidElement->setAttributeNode(NewAttribute("name", name));
+  ellipsoidElement->setAttributeNode(
+    NewAttribute("ax", ellipsoid->GetSemiAxisMax(0) / mm));
+  ellipsoidElement->setAttributeNode(
+    NewAttribute("by", ellipsoid->GetSemiAxisMax(1) / mm));
+  ellipsoidElement->setAttributeNode(
+    NewAttribute("cz", ellipsoid->GetSemiAxisMax(2) / mm));
+  ellipsoidElement->setAttributeNode(
+    NewAttribute("zcut1", ellipsoid->GetZBottomCut() / mm));
+  ellipsoidElement->setAttributeNode(
+    NewAttribute("zcut2", ellipsoid->GetZTopCut() / mm));
+  ellipsoidElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(ellipsoidElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::EltubeWrite(xercesc::DOMElement* solElement,
+                                    const G4EllipticalTube* const eltube)
+{
+  const G4String& name = GenerateName(eltube->GetName(), eltube);
+
+  xercesc::DOMElement* eltubeElement = NewElement("eltube");
+  eltubeElement->setAttributeNode(NewAttribute("name", name));
+  eltubeElement->setAttributeNode(NewAttribute("dx", eltube->GetDx() / mm));
+  eltubeElement->setAttributeNode(NewAttribute("dy", eltube->GetDy() / mm));
+  eltubeElement->setAttributeNode(NewAttribute("dz", eltube->GetDz() / mm));
+  eltubeElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(eltubeElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::XtruWrite(xercesc::DOMElement* solElement,
+                                  const G4ExtrudedSolid* const xtru)
+{
+  const G4String& name = GenerateName(xtru->GetName(), xtru);
+
+  xercesc::DOMElement* xtruElement = NewElement("xtru");
+  xtruElement->setAttributeNode(NewAttribute("name", name));
+  xtruElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(xtruElement);
+
+  const G4int NumVertex = xtru->GetNofVertices();
+
+  for(G4int i = 0; i < NumVertex; ++i)
+  {
+    xercesc::DOMElement* twoDimVertexElement = NewElement("twoDimVertex");
+    xtruElement->appendChild(twoDimVertexElement);
+
+    const G4TwoVector& vertex = xtru->GetVertex(i);
+
+    twoDimVertexElement->setAttributeNode(NewAttribute("x", vertex.x() / mm));
+    twoDimVertexElement->setAttributeNode(NewAttribute("y", vertex.y() / mm));
+  }
+
+  const G4int NumSection = xtru->GetNofZSections();
+
+  for(G4int i = 0; i < NumSection; ++i)
+  {
+    xercesc::DOMElement* sectionElement = NewElement("section");
+    xtruElement->appendChild(sectionElement);
+
+    const G4ExtrudedSolid::ZSection section = xtru->GetZSection(i);
+
+    sectionElement->setAttributeNode(NewAttribute("zOrder", i));
+    sectionElement->setAttributeNode(
+      NewAttribute("zPosition", section.fZ / mm));
+    sectionElement->setAttributeNode(
+      NewAttribute("xOffset", section.fOffset.x() / mm));
+    sectionElement->setAttributeNode(
+      NewAttribute("yOffset", section.fOffset.y() / mm));
+    sectionElement->setAttributeNode(
+      NewAttribute("scalingFactor", section.fScale));
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::HypeWrite(xercesc::DOMElement* solElement,
+                                  const G4Hype* const hype)
+{
+  const G4String& name = GenerateName(hype->GetName(), hype);
+
+  xercesc::DOMElement* hypeElement = NewElement("hype");
+  hypeElement->setAttributeNode(NewAttribute("name", name));
+  hypeElement->setAttributeNode(
+    NewAttribute("rmin", hype->GetInnerRadius() / mm));
+  hypeElement->setAttributeNode(
+    NewAttribute("rmax", hype->GetOuterRadius() / mm));
+  hypeElement->setAttributeNode(
+    NewAttribute("inst", hype->GetInnerStereo() / degree));
+  hypeElement->setAttributeNode(
+    NewAttribute("outst", hype->GetOuterStereo() / degree));
+  hypeElement->setAttributeNode(
+    NewAttribute("z", 2.0 * hype->GetZHalfLength() / mm));
+  hypeElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  hypeElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(hypeElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::OrbWrite(xercesc::DOMElement* solElement,
+                                 const G4Orb* const orb)
+{
+  const G4String& name = GenerateName(orb->GetName(), orb);
+
+  xercesc::DOMElement* orbElement = NewElement("orb");
+  orbElement->setAttributeNode(NewAttribute("name", name));
+  orbElement->setAttributeNode(NewAttribute("r", orb->GetRadius() / mm));
+  orbElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(orbElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::ParaWrite(xercesc::DOMElement* solElement,
+                                  const G4Para* const para)
+{
+  const G4String& name = GenerateName(para->GetName(), para);
+
+  const G4ThreeVector simaxis = para->GetSymAxis();
+  const G4double alpha        = std::atan(para->GetTanAlpha());
+  const G4double phi          = simaxis.phi();
+  const G4double theta        = simaxis.theta();
+
+  xercesc::DOMElement* paraElement = NewElement("para");
+  paraElement->setAttributeNode(NewAttribute("name", name));
+  paraElement->setAttributeNode(
+    NewAttribute("x", 2.0 * para->GetXHalfLength() / mm));
+  paraElement->setAttributeNode(
+    NewAttribute("y", 2.0 * para->GetYHalfLength() / mm));
+  paraElement->setAttributeNode(
+    NewAttribute("z", 2.0 * para->GetZHalfLength() / mm));
+  paraElement->setAttributeNode(NewAttribute("alpha", alpha / degree));
+  paraElement->setAttributeNode(NewAttribute("theta", theta / degree));
+  paraElement->setAttributeNode(NewAttribute("phi", phi / degree));
+  paraElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  paraElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(paraElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::ParaboloidWrite(xercesc::DOMElement* solElement,
+                                        const G4Paraboloid* const paraboloid)
+{
+  const G4String& name = GenerateName(paraboloid->GetName(), paraboloid);
+
+  xercesc::DOMElement* paraboloidElement = NewElement("paraboloid");
+  paraboloidElement->setAttributeNode(NewAttribute("name", name));
+  paraboloidElement->setAttributeNode(
+    NewAttribute("rlo", paraboloid->GetRadiusMinusZ() / mm));
+  paraboloidElement->setAttributeNode(
+    NewAttribute("rhi", paraboloid->GetRadiusPlusZ() / mm));
+  paraboloidElement->setAttributeNode(
+    NewAttribute("dz", paraboloid->GetZHalfLength() / mm));
+  paraboloidElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(paraboloidElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::PolyconeWrite(xercesc::DOMElement* solElement,
+                                      const G4Polycone* const polycone)
+{
+  const G4String& name = GenerateName(polycone->GetName(), polycone);
+
+  xercesc::DOMElement* polyconeElement = NewElement("polycone");
+  polyconeElement->setAttributeNode(NewAttribute("name", name));
+  polyconeElement->setAttributeNode(NewAttribute(
+    "startphi", polycone->GetOriginalParameters()->Start_angle / degree));
+  polyconeElement->setAttributeNode(NewAttribute(
+    "deltaphi", polycone->GetOriginalParameters()->Opening_angle / degree));
+  polyconeElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  polyconeElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(polyconeElement);
+
+  const std::size_t num_zplanes
+        = polycone->GetOriginalParameters()->Num_z_planes;
+  const G4double* z_array    = polycone->GetOriginalParameters()->Z_values;
+  const G4double* rmin_array = polycone->GetOriginalParameters()->Rmin;
+  const G4double* rmax_array = polycone->GetOriginalParameters()->Rmax;
+
+  for(std::size_t i = 0; i < num_zplanes; ++i)
+  {
+    ZplaneWrite(polyconeElement, z_array[i], rmin_array[i], rmax_array[i]);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::GenericPolyconeWrite(
+  xercesc::DOMElement* solElement, const G4GenericPolycone* const polycone)
+{
+  const G4String& name = GenerateName(polycone->GetName(), polycone);
+  xercesc::DOMElement* polyconeElement = NewElement("genericPolycone");
+  const G4double startPhi              = polycone->GetStartPhi();
+  polyconeElement->setAttributeNode(NewAttribute("name", name));
+  polyconeElement->setAttributeNode(
+    NewAttribute("startphi", startPhi / degree));
+  polyconeElement->setAttributeNode(
+    NewAttribute("deltaphi", (polycone->GetEndPhi() - startPhi) / degree));
+  polyconeElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  polyconeElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(polyconeElement);
+
+  const std::size_t num_rzpoints = polycone->GetNumRZCorner();
+  for(std::size_t i = 0; i < num_rzpoints; ++i)
+  {
+    const G4double r_point = polycone->GetCorner(i).r;
+    const G4double z_point = polycone->GetCorner(i).z;
+    RZPointWrite(polyconeElement, r_point, z_point);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::PolyhedraWrite(xercesc::DOMElement* solElement,
+                                       const G4Polyhedra* const polyhedra)
+{
+  const G4String& name = GenerateName(polyhedra->GetName(), polyhedra);
+  if(polyhedra->IsGeneric() == false)
+  {
+    xercesc::DOMElement* polyhedraElement = NewElement("polyhedra");
+    polyhedraElement->setAttributeNode(NewAttribute("name", name));
+    polyhedraElement->setAttributeNode(NewAttribute(
+      "startphi", polyhedra->GetOriginalParameters()->Start_angle / degree));
+    polyhedraElement->setAttributeNode(NewAttribute(
+      "deltaphi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
+    polyhedraElement->setAttributeNode(
+      NewAttribute("numsides", polyhedra->GetOriginalParameters()->numSide));
+    polyhedraElement->setAttributeNode(NewAttribute("aunit", "deg"));
+    polyhedraElement->setAttributeNode(NewAttribute("lunit", "mm"));
+    solElement->appendChild(polyhedraElement);
+
+    const std::size_t num_zplanes
+          = polyhedra->GetOriginalParameters()->Num_z_planes;
+    const G4double* z_array  = polyhedra->GetOriginalParameters()->Z_values;
+    const G4double* rmin_array = polyhedra->GetOriginalParameters()->Rmin;
+    const G4double* rmax_array = polyhedra->GetOriginalParameters()->Rmax;
+
+    const G4double convertRad =
+      std::cos(0.5 * polyhedra->GetOriginalParameters()->Opening_angle /
+               polyhedra->GetOriginalParameters()->numSide);
+
+    for(std::size_t i = 0; i < num_zplanes; ++i)
+    {
+      ZplaneWrite(polyhedraElement, z_array[i], rmin_array[i] * convertRad,
+                  rmax_array[i] * convertRad);
+    }
+  }
+  else  // generic polyhedra
+  {
+    xercesc::DOMElement* polyhedraElement = NewElement("genericPolyhedra");
+    polyhedraElement->setAttributeNode(NewAttribute("name", name));
+    polyhedraElement->setAttributeNode(NewAttribute(
+      "startphi", polyhedra->GetOriginalParameters()->Start_angle / degree));
+    polyhedraElement->setAttributeNode(NewAttribute(
+      "deltaphi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
+    polyhedraElement->setAttributeNode(
+      NewAttribute("numsides", polyhedra->GetOriginalParameters()->numSide));
+    polyhedraElement->setAttributeNode(NewAttribute("aunit", "deg"));
+    polyhedraElement->setAttributeNode(NewAttribute("lunit", "mm"));
+    solElement->appendChild(polyhedraElement);
+
+    const std::size_t num_rzpoints = polyhedra->GetNumRZCorner();
+
+    for(std::size_t i = 0; i < num_rzpoints; ++i)
+    {
+      const G4double r_point = polyhedra->GetCorner(i).r;
+      const G4double z_point = polyhedra->GetCorner(i).z;
+      RZPointWrite(polyhedraElement, r_point, z_point);
+    }
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::SphereWrite(xercesc::DOMElement* solElement,
+                                    const G4Sphere* const sphere)
+{
+  const G4String& name = GenerateName(sphere->GetName(), sphere);
+
+  xercesc::DOMElement* sphereElement = NewElement("sphere");
+  sphereElement->setAttributeNode(NewAttribute("name", name));
+  sphereElement->setAttributeNode(
+    NewAttribute("rmin", sphere->GetInnerRadius() / mm));
+  sphereElement->setAttributeNode(
+    NewAttribute("rmax", sphere->GetOuterRadius() / mm));
+  sphereElement->setAttributeNode(
+    NewAttribute("startphi", sphere->GetStartPhiAngle() / degree));
+  sphereElement->setAttributeNode(
+    NewAttribute("deltaphi", sphere->GetDeltaPhiAngle() / degree));
+  sphereElement->setAttributeNode(
+    NewAttribute("starttheta", sphere->GetStartThetaAngle() / degree));
+  sphereElement->setAttributeNode(
+    NewAttribute("deltatheta", sphere->GetDeltaThetaAngle() / degree));
+  sphereElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  sphereElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(sphereElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TessellatedWrite(
+  xercesc::DOMElement* solElement, const G4TessellatedSolid* const tessellated)
+{
+  const G4String& solid_name = tessellated->GetName();
+  const G4String& name       = GenerateName(solid_name, tessellated);
+
+  xercesc::DOMElement* tessellatedElement = NewElement("tessellated");
+  tessellatedElement->setAttributeNode(NewAttribute("name", name));
+  tessellatedElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  tessellatedElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(tessellatedElement);
+
+  std::map<G4ThreeVector, G4String, G4ThreeVectorCompare> vertexMap;
+
+  const std::size_t NumFacets = tessellated->GetNumberOfFacets();
+  std::size_t NumVertex       = 0;
+
+  for(std::size_t i = 0; i < NumFacets; ++i)
+  {
+    const G4VFacet* facet          = tessellated->GetFacet(i);
+    const size_t NumVertexPerFacet = facet->GetNumberOfVertices();
+
+    G4String FacetTag;
+
+    if(NumVertexPerFacet == 3)
+    {
+      FacetTag = "triangular";
+    }
+    else if(NumVertexPerFacet == 4)
+    {
+      FacetTag = "quadrangular";
+    }
+    else
+    {
+      G4Exception("GDMLWriteSolids::TessellatedWrite()", "InvalidSetup",
+                  FatalException, "Facet should contain 3 or 4 vertices!");
+    }
+
+    xercesc::DOMElement* facetElement = NewElement(FacetTag);
+    tessellatedElement->appendChild(facetElement);
+
+    for(std::size_t j = 0; j < NumVertexPerFacet; ++j)
+    {
+      std::stringstream name_stream;
+      std::stringstream ref_stream;
+
+      name_stream << "vertex" << (j + 1);
+      ref_stream << solid_name << "_v" << NumVertex;
+
+      const G4String& fname = name_stream.str();  // facet's tag variable
+      G4String ref          = ref_stream.str();   // vertex tag to be associated
+
+      // Now search for the existance of the current vertex in the
+      // map of cached vertices. If existing, do NOT store it as
+      // position in the GDML file, so avoiding duplication; otherwise
+      // cache it in the local map and add it as position in the
+      // "define" section of the GDML file.
+
+      const G4ThreeVector& vertex = facet->GetVertex(j);
+
+      if(vertexMap.find(vertex) != vertexMap.cend())  // Vertex is cached
+      {
+        ref = vertexMap[vertex];  // Set the proper tag for it
+      }
+      else  // Vertex not found
+      {
+        vertexMap.insert(std::make_pair(vertex, ref));  // Cache vertex and ...
+        AddPosition(ref, vertex);  // ... add it to define section!
+        ++NumVertex;
+      }
+
+      // Now create association of the vertex with its facet
+      //
+      facetElement->setAttributeNode(NewAttribute(fname, ref));
+    }
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TetWrite(xercesc::DOMElement* solElement,
+                                 const G4Tet* const tet)
+{
+  const G4String& solid_name = tet->GetName();
+  const G4String& name       = GenerateName(solid_name, tet);
+
+  std::vector<G4ThreeVector> vertexList = tet->GetVertices();
+
+  xercesc::DOMElement* tetElement = NewElement("tet");
+  tetElement->setAttributeNode(NewAttribute("name", name));
+  tetElement->setAttributeNode(NewAttribute("vertex1", solid_name + "_v1"));
+  tetElement->setAttributeNode(NewAttribute("vertex2", solid_name + "_v2"));
+  tetElement->setAttributeNode(NewAttribute("vertex3", solid_name + "_v3"));
+  tetElement->setAttributeNode(NewAttribute("vertex4", solid_name + "_v4"));
+  tetElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(tetElement);
+
+  AddPosition(solid_name + "_v1", vertexList[0]);
+  AddPosition(solid_name + "_v2", vertexList[1]);
+  AddPosition(solid_name + "_v3", vertexList[2]);
+  AddPosition(solid_name + "_v4", vertexList[3]);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TorusWrite(xercesc::DOMElement* solElement,
+                                   const G4Torus* const torus)
+{
+  const G4String& name = GenerateName(torus->GetName(), torus);
+
+  xercesc::DOMElement* torusElement = NewElement("torus");
+  torusElement->setAttributeNode(NewAttribute("name", name));
+  torusElement->setAttributeNode(NewAttribute("rmin", torus->GetRmin() / mm));
+  torusElement->setAttributeNode(NewAttribute("rmax", torus->GetRmax() / mm));
+  torusElement->setAttributeNode(NewAttribute("rtor", torus->GetRtor() / mm));
+  torusElement->setAttributeNode(
+    NewAttribute("startphi", torus->GetSPhi() / degree));
+  torusElement->setAttributeNode(
+    NewAttribute("deltaphi", torus->GetDPhi() / degree));
+  torusElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  torusElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(torusElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::GenTrapWrite(xercesc::DOMElement* solElement,
+                                     const G4GenericTrap* const gtrap)
+{
+  const G4String& name = GenerateName(gtrap->GetName(), gtrap);
+
+  std::vector<G4TwoVector> vertices = gtrap->GetVertices();
+
+  xercesc::DOMElement* gtrapElement = NewElement("arb8");
+  gtrapElement->setAttributeNode(NewAttribute("name", name));
+  gtrapElement->setAttributeNode(
+    NewAttribute("dz", gtrap->GetZHalfLength() / mm));
+  gtrapElement->setAttributeNode(NewAttribute("v1x", vertices[0].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v1y", vertices[0].y()));
+  gtrapElement->setAttributeNode(NewAttribute("v2x", vertices[1].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v2y", vertices[1].y()));
+  gtrapElement->setAttributeNode(NewAttribute("v3x", vertices[2].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v3y", vertices[2].y()));
+  gtrapElement->setAttributeNode(NewAttribute("v4x", vertices[3].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v4y", vertices[3].y()));
+  gtrapElement->setAttributeNode(NewAttribute("v5x", vertices[4].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v5y", vertices[4].y()));
+  gtrapElement->setAttributeNode(NewAttribute("v6x", vertices[5].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v6y", vertices[5].y()));
+  gtrapElement->setAttributeNode(NewAttribute("v7x", vertices[6].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v7y", vertices[6].y()));
+  gtrapElement->setAttributeNode(NewAttribute("v8x", vertices[7].x()));
+  gtrapElement->setAttributeNode(NewAttribute("v8y", vertices[7].y()));
+  gtrapElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(gtrapElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TrapWrite(xercesc::DOMElement* solElement,
+                                  const G4Trap* const trap)
+{
+  const G4String& name = GenerateName(trap->GetName(), trap);
+
+  const G4ThreeVector& simaxis = trap->GetSymAxis();
+  const G4double phi           = simaxis.phi();
+  const G4double theta         = simaxis.theta();
+  const G4double alpha1        = std::atan(trap->GetTanAlpha1());
+  const G4double alpha2        = std::atan(trap->GetTanAlpha2());
+
+  xercesc::DOMElement* trapElement = NewElement("trap");
+  trapElement->setAttributeNode(NewAttribute("name", name));
+  trapElement->setAttributeNode(
+    NewAttribute("z", 2.0 * trap->GetZHalfLength() / mm));
+  trapElement->setAttributeNode(NewAttribute("theta", theta / degree));
+  trapElement->setAttributeNode(NewAttribute("phi", phi / degree));
+  trapElement->setAttributeNode(
+    NewAttribute("y1", 2.0 * trap->GetYHalfLength1() / mm));
+  trapElement->setAttributeNode(
+    NewAttribute("x1", 2.0 * trap->GetXHalfLength1() / mm));
+  trapElement->setAttributeNode(
+    NewAttribute("x2", 2.0 * trap->GetXHalfLength2() / mm));
+  trapElement->setAttributeNode(NewAttribute("alpha1", alpha1 / degree));
+  trapElement->setAttributeNode(
+    NewAttribute("y2", 2.0 * trap->GetYHalfLength2() / mm));
+  trapElement->setAttributeNode(
+    NewAttribute("x3", 2.0 * trap->GetXHalfLength3() / mm));
+  trapElement->setAttributeNode(
+    NewAttribute("x4", 2.0 * trap->GetXHalfLength4() / mm));
+  trapElement->setAttributeNode(NewAttribute("alpha2", alpha2 / degree));
+  trapElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  trapElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(trapElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TrdWrite(xercesc::DOMElement* solElement,
+                                 const G4Trd* const trd)
+{
+  const G4String& name = GenerateName(trd->GetName(), trd);
+
+  xercesc::DOMElement* trdElement = NewElement("trd");
+  trdElement->setAttributeNode(NewAttribute("name", name));
+  trdElement->setAttributeNode(
+    NewAttribute("x1", 2.0 * trd->GetXHalfLength1() / mm));
+  trdElement->setAttributeNode(
+    NewAttribute("x2", 2.0 * trd->GetXHalfLength2() / mm));
+  trdElement->setAttributeNode(
+    NewAttribute("y1", 2.0 * trd->GetYHalfLength1() / mm));
+  trdElement->setAttributeNode(
+    NewAttribute("y2", 2.0 * trd->GetYHalfLength2() / mm));
+  trdElement->setAttributeNode(
+    NewAttribute("z", 2.0 * trd->GetZHalfLength() / mm));
+  trdElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(trdElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TubeWrite(xercesc::DOMElement* solElement,
+                                  const G4Tubs* const tube)
+{
+  const G4String& name = GenerateName(tube->GetName(), tube);
+
+  xercesc::DOMElement* tubeElement = NewElement("tube");
+  tubeElement->setAttributeNode(NewAttribute("name", name));
+  tubeElement->setAttributeNode(
+    NewAttribute("rmin", tube->GetInnerRadius() / mm));
+  tubeElement->setAttributeNode(
+    NewAttribute("rmax", tube->GetOuterRadius() / mm));
+  tubeElement->setAttributeNode(
+    NewAttribute("z", 2.0 * tube->GetZHalfLength() / mm));
+  tubeElement->setAttributeNode(
+    NewAttribute("startphi", tube->GetStartPhiAngle() / degree));
+  tubeElement->setAttributeNode(
+    NewAttribute("deltaphi", tube->GetDeltaPhiAngle() / degree));
+  tubeElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  tubeElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(tubeElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::CutTubeWrite(xercesc::DOMElement* solElement,
+                                     const G4CutTubs* const cuttube)
+{
+  const G4String& name = GenerateName(cuttube->GetName(), cuttube);
+
+  xercesc::DOMElement* cuttubeElement = NewElement("cutTube");
+  cuttubeElement->setAttributeNode(NewAttribute("name", name));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("rmin", cuttube->GetInnerRadius() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("rmax", cuttube->GetOuterRadius() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("z", 2.0 * cuttube->GetZHalfLength() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("startphi", cuttube->GetStartPhiAngle() / degree));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("deltaphi", cuttube->GetDeltaPhiAngle() / degree));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("lowX", cuttube->GetLowNorm().getX() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("lowY", cuttube->GetLowNorm().getY() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("lowZ", cuttube->GetLowNorm().getZ() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("highX", cuttube->GetHighNorm().getX() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("highY", cuttube->GetHighNorm().getY() / mm));
+  cuttubeElement->setAttributeNode(
+    NewAttribute("highZ", cuttube->GetHighNorm().getZ() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  cuttubeElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(cuttubeElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TwistedboxWrite(xercesc::DOMElement* solElement,
+                                        const G4TwistedBox* const twistedbox)
+{
+  const G4String& name = GenerateName(twistedbox->GetName(), twistedbox);
+
+  xercesc::DOMElement* twistedboxElement = NewElement("twistedbox");
+  twistedboxElement->setAttributeNode(NewAttribute("name", name));
+  twistedboxElement->setAttributeNode(
+    NewAttribute("x", 2.0 * twistedbox->GetXHalfLength() / mm));
+  twistedboxElement->setAttributeNode(
+    NewAttribute("y", 2.0 * twistedbox->GetYHalfLength() / mm));
+  twistedboxElement->setAttributeNode(
+    NewAttribute("z", 2.0 * twistedbox->GetZHalfLength() / mm));
+  twistedboxElement->setAttributeNode(
+    NewAttribute("PhiTwist", twistedbox->GetPhiTwist() / degree));
+  twistedboxElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  twistedboxElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(twistedboxElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TwistedtrapWrite(xercesc::DOMElement* solElement,
+                                         const G4TwistedTrap* const twistedtrap)
+{
+  const G4String& name = GenerateName(twistedtrap->GetName(), twistedtrap);
+
+  xercesc::DOMElement* twistedtrapElement = NewElement("twistedtrap");
+  twistedtrapElement->setAttributeNode(NewAttribute("name", name));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("y1", 2.0 * twistedtrap->GetY1HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("x1", 2.0 * twistedtrap->GetX1HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("x2", 2.0 * twistedtrap->GetX2HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("y2", 2.0 * twistedtrap->GetY2HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("x3", 2.0 * twistedtrap->GetX3HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("x4", 2.0 * twistedtrap->GetX4HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("z", 2.0 * twistedtrap->GetZHalfLength() / mm));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("Alph", twistedtrap->GetTiltAngleAlpha() / degree));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("Theta", twistedtrap->GetPolarAngleTheta() / degree));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("Phi", twistedtrap->GetAzimuthalAnglePhi() / degree));
+  twistedtrapElement->setAttributeNode(
+    NewAttribute("PhiTwist", twistedtrap->GetPhiTwist() / degree));
+  twistedtrapElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  twistedtrapElement->setAttributeNode(NewAttribute("lunit", "mm"));
+
+  solElement->appendChild(twistedtrapElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TwistedtrdWrite(xercesc::DOMElement* solElement,
+                                        const G4TwistedTrd* const twistedtrd)
+{
+  const G4String& name = GenerateName(twistedtrd->GetName(), twistedtrd);
+
+  xercesc::DOMElement* twistedtrdElement = NewElement("twistedtrd");
+  twistedtrdElement->setAttributeNode(NewAttribute("name", name));
+  twistedtrdElement->setAttributeNode(
+    NewAttribute("x1", 2.0 * twistedtrd->GetX1HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(
+    NewAttribute("x2", 2.0 * twistedtrd->GetX2HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(
+    NewAttribute("y1", 2.0 * twistedtrd->GetY1HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(
+    NewAttribute("y2", 2.0 * twistedtrd->GetY2HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(
+    NewAttribute("z", 2.0 * twistedtrd->GetZHalfLength() / mm));
+  twistedtrdElement->setAttributeNode(
+    NewAttribute("PhiTwist", twistedtrd->GetPhiTwist() / degree));
+  twistedtrdElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  twistedtrdElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(twistedtrdElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::TwistedtubsWrite(xercesc::DOMElement* solElement,
+                                         const G4TwistedTubs* const twistedtubs)
+{
+  const G4String& name = GenerateName(twistedtubs->GetName(), twistedtubs);
+
+  xercesc::DOMElement* twistedtubsElement = NewElement("twistedtubs");
+  twistedtubsElement->setAttributeNode(NewAttribute("name", name));
+  twistedtubsElement->setAttributeNode(
+    NewAttribute("twistedangle", twistedtubs->GetPhiTwist() / degree));
+  twistedtubsElement->setAttributeNode(
+    NewAttribute("midinnerrad", twistedtubs->GetInnerRadius() / mm));
+  twistedtubsElement->setAttributeNode(
+    NewAttribute("midouterrad", twistedtubs->GetOuterRadius() / mm));
+  twistedtubsElement->setAttributeNode(
+    NewAttribute("negativeEndz", twistedtubs->GetEndZ(0) / mm));
+  twistedtubsElement->setAttributeNode(
+    NewAttribute("positiveEndz", twistedtubs->GetEndZ(1) / mm));
+  twistedtubsElement->setAttributeNode(
+    NewAttribute("phi", twistedtubs->GetDPhi() / degree));
+  twistedtubsElement->setAttributeNode(NewAttribute("aunit", "deg"));
+  twistedtubsElement->setAttributeNode(NewAttribute("lunit", "mm"));
+  solElement->appendChild(twistedtubsElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::ZplaneWrite(xercesc::DOMElement* element,
+                                    const G4double& z, const G4double& rmin,
+                                    const G4double& rmax)
+{
+  xercesc::DOMElement* zplaneElement = NewElement("zplane");
+  zplaneElement->setAttributeNode(NewAttribute("z", z / mm));
+  zplaneElement->setAttributeNode(NewAttribute("rmin", rmin / mm));
+  zplaneElement->setAttributeNode(NewAttribute("rmax", rmax / mm));
+  element->appendChild(zplaneElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::RZPointWrite(xercesc::DOMElement* element,
+                                     const G4double& r, const G4double& z)
+{
+  xercesc::DOMElement* rzpointElement = NewElement("rzpoint");
+  rzpointElement->setAttributeNode(NewAttribute("r", r / mm));
+  rzpointElement->setAttributeNode(NewAttribute("z", z / mm));
+  element->appendChild(rzpointElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::OpticalSurfaceWrite(xercesc::DOMElement* solElement,
+                                            const G4OpticalSurface* const surf)
+{
+  xercesc::DOMElement* optElement = NewElement("opticalsurface");
+  G4OpticalSurfaceModel smodel    = surf->GetModel();
+  G4double sval =
+    (smodel == glisur) ? surf->GetPolish() : surf->GetSigmaAlpha();
+  const G4String& name = GenerateName(surf->GetName(), surf);
+
+  optElement->setAttributeNode(NewAttribute("name", name));
+  optElement->setAttributeNode(NewAttribute("model", smodel));
+  optElement->setAttributeNode(NewAttribute("finish", surf->GetFinish()));
+  optElement->setAttributeNode(NewAttribute("type", surf->GetType()));
+  optElement->setAttributeNode(NewAttribute("value", sval));
+
+  // Write any property attached to the optical surface...
+  //
+  if(surf->GetMaterialPropertiesTable())
+  {
+    PropertyWrite(optElement, surf);
+  }
+
+  solElement->appendChild(optElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::PropertyWrite(xercesc::DOMElement* optElement,
+                                      const G4OpticalSurface* const surf)
+{
+  xercesc::DOMElement* propElement;
+  G4MaterialPropertiesTable* ptable = surf->GetMaterialPropertiesTable();
+  auto pvec = ptable->GetProperties();
+  auto cvec = ptable->GetConstProperties();
+
+  for(size_t i = 0; i < pvec.size(); ++i)
+  {
+    if(pvec[i] != nullptr) {
+      propElement = NewElement("property");
+      propElement->setAttributeNode(
+        NewAttribute("name", ptable->GetMaterialPropertyNames()[i]));
+      propElement->setAttributeNode(NewAttribute(
+        "ref", GenerateName(ptable->GetMaterialPropertyNames()[i],
+                            pvec[i])));
+      PropertyVectorWrite(ptable->GetMaterialPropertyNames()[i],
+                          pvec[i]);
+      optElement->appendChild(propElement);
+    }
+  }
+  for(size_t i = 0; i < cvec.size(); ++i)
+  {
+    if (cvec[i].second == true) {
+      propElement = NewElement("property");
+      propElement->setAttributeNode(NewAttribute(
+        "name", ptable->GetMaterialConstPropertyNames()[i]));
+      propElement->setAttributeNode(NewAttribute(
+        "ref", ptable->GetMaterialConstPropertyNames()[i]));
+      xercesc::DOMElement* constElement = NewElement("constant");
+      constElement->setAttributeNode(NewAttribute(
+        "name", ptable->GetMaterialConstPropertyNames()[i]));
+      constElement->setAttributeNode(NewAttribute("value", cvec[i].first));
+      defineElement->appendChild(constElement);
+      optElement->appendChild(propElement);
+    }
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::SolidsWrite(xercesc::DOMElement* gdmlElement)
+{
+#ifdef G4VERBOSE
+  G4cout << "G4GDML: Writing solids..." << G4endl;
+#endif
+  solidsElement = NewElement("solids");
+  gdmlElement->appendChild(solidsElement);
+
+  solidList.clear();
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteSolids::AddSolid(const G4VSolid* const solidPtr)
+{
+  for(std::size_t i = 0; i < solidList.size(); ++i)  // Check if solid is
+  {                                                  // already in the list!
+    if(solidList[i] == solidPtr)
+    {
+      return;
+    }
+  }
+
+  solidList.push_back(solidPtr);
+
+  if(const G4BooleanSolid* const booleanPtr =
+       dynamic_cast<const G4BooleanSolid*>(solidPtr))
+  {
+    BooleanWrite(solidsElement, booleanPtr);
+  }
+  else if(const G4ScaledSolid* const scaledPtr =
+            dynamic_cast<const G4ScaledSolid*>(solidPtr))
+  {
+    ScaledWrite(solidsElement, scaledPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4MultiUnion")
+  {
+    const G4MultiUnion* const munionPtr =
+      static_cast<const G4MultiUnion*>(solidPtr);
+    MultiUnionWrite(solidsElement, munionPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Box")
+  {
+    const G4Box* const boxPtr = static_cast<const G4Box*>(solidPtr);
+    BoxWrite(solidsElement, boxPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Cons")
+  {
+    const G4Cons* const conePtr = static_cast<const G4Cons*>(solidPtr);
+    ConeWrite(solidsElement, conePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4EllipticalCone")
+  {
+    const G4EllipticalCone* const elconePtr =
+      static_cast<const G4EllipticalCone*>(solidPtr);
+    ElconeWrite(solidsElement, elconePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Ellipsoid")
+  {
+    const G4Ellipsoid* const ellipsoidPtr =
+      static_cast<const G4Ellipsoid*>(solidPtr);
+    EllipsoidWrite(solidsElement, ellipsoidPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4EllipticalTube")
+  {
+    const G4EllipticalTube* const eltubePtr =
+      static_cast<const G4EllipticalTube*>(solidPtr);
+    EltubeWrite(solidsElement, eltubePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4ExtrudedSolid")
+  {
+    const G4ExtrudedSolid* const xtruPtr =
+      static_cast<const G4ExtrudedSolid*>(solidPtr);
+    XtruWrite(solidsElement, xtruPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Hype")
+  {
+    const G4Hype* const hypePtr = static_cast<const G4Hype*>(solidPtr);
+    HypeWrite(solidsElement, hypePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Orb")
+  {
+    const G4Orb* const orbPtr = static_cast<const G4Orb*>(solidPtr);
+    OrbWrite(solidsElement, orbPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Para")
+  {
+    const G4Para* const paraPtr = static_cast<const G4Para*>(solidPtr);
+    ParaWrite(solidsElement, paraPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Paraboloid")
+  {
+    const G4Paraboloid* const paraboloidPtr =
+      static_cast<const G4Paraboloid*>(solidPtr);
+    ParaboloidWrite(solidsElement, paraboloidPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Polycone")
+  {
+    const G4Polycone* const polyconePtr =
+      static_cast<const G4Polycone*>(solidPtr);
+    PolyconeWrite(solidsElement, polyconePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4GenericPolycone")
+  {
+    const G4GenericPolycone* const genpolyconePtr =
+      static_cast<const G4GenericPolycone*>(solidPtr);
+    GenericPolyconeWrite(solidsElement, genpolyconePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Polyhedra")
+  {
+    const G4Polyhedra* const polyhedraPtr =
+      static_cast<const G4Polyhedra*>(solidPtr);
+    PolyhedraWrite(solidsElement, polyhedraPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Sphere")
+  {
+    const G4Sphere* const spherePtr = static_cast<const G4Sphere*>(solidPtr);
+    SphereWrite(solidsElement, spherePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4TessellatedSolid")
+  {
+    const G4TessellatedSolid* const tessellatedPtr =
+      static_cast<const G4TessellatedSolid*>(solidPtr);
+    TessellatedWrite(solidsElement, tessellatedPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Tet")
+  {
+    const G4Tet* const tetPtr = static_cast<const G4Tet*>(solidPtr);
+    TetWrite(solidsElement, tetPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Torus")
+  {
+    const G4Torus* const torusPtr = static_cast<const G4Torus*>(solidPtr);
+    TorusWrite(solidsElement, torusPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4GenericTrap")
+  {
+    const G4GenericTrap* const gtrapPtr =
+      static_cast<const G4GenericTrap*>(solidPtr);
+    GenTrapWrite(solidsElement, gtrapPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Trap")
+  {
+    const G4Trap* const trapPtr = static_cast<const G4Trap*>(solidPtr);
+    TrapWrite(solidsElement, trapPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Trd")
+  {
+    const G4Trd* const trdPtr = static_cast<const G4Trd*>(solidPtr);
+    TrdWrite(solidsElement, trdPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4Tubs")
+  {
+    const G4Tubs* const tubePtr = static_cast<const G4Tubs*>(solidPtr);
+    TubeWrite(solidsElement, tubePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4CutTubs")
+  {
+    const G4CutTubs* const cuttubePtr = static_cast<const G4CutTubs*>(solidPtr);
+    CutTubeWrite(solidsElement, cuttubePtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4TwistedBox")
+  {
+    const G4TwistedBox* const twistedboxPtr =
+      static_cast<const G4TwistedBox*>(solidPtr);
+    TwistedboxWrite(solidsElement, twistedboxPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4TwistedTrap")
+  {
+    const G4TwistedTrap* const twistedtrapPtr =
+      static_cast<const G4TwistedTrap*>(solidPtr);
+    TwistedtrapWrite(solidsElement, twistedtrapPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4TwistedTrd")
+  {
+    const G4TwistedTrd* const twistedtrdPtr =
+      static_cast<const G4TwistedTrd*>(solidPtr);
+    TwistedtrdWrite(solidsElement, twistedtrdPtr);
+  }
+  else if(solidPtr->GetEntityType() == "G4TwistedTubs")
+  {
+    const G4TwistedTubs* const twistedtubsPtr =
+      static_cast<const G4TwistedTubs*>(solidPtr);
+    TwistedtubsWrite(solidsElement, twistedtubsPtr);
+  }
+  else
+  {
+    G4String error_msg = "Unknown solid: " + solidPtr->GetName() +
+                         "; Type: " + solidPtr->GetEntityType();
+    G4Exception("GDMLWriteSolids::AddSolid()", "WriteError", FatalException,
+                error_msg);
+  }
+}
+}

--- a/src/geo/src/gdml/GDMLWriteSolids.cc
+++ b/src/geo/src/gdml/GDMLWriteSolids.cc
@@ -1,60 +1,52 @@
 #include "RAT/GDMLWriteSolids.hh"
 
-#include "G4SystemOfUnits.hh"
 #include "G4BooleanSolid.hh"
-#include "G4ScaledSolid.hh"
 #include "G4Box.hh"
 #include "G4Cons.hh"
+#include "G4CutTubs.hh"
 #include "G4Ellipsoid.hh"
 #include "G4EllipticalCone.hh"
 #include "G4EllipticalTube.hh"
 #include "G4ExtrudedSolid.hh"
+#include "G4GenericPolycone.hh"
+#include "G4GenericTrap.hh"
 #include "G4Hype.hh"
+#include "G4IntersectionSolid.hh"
+#include "G4MaterialPropertiesTable.hh"
+#include "G4OpticalSurface.hh"
 #include "G4Orb.hh"
 #include "G4Para.hh"
 #include "G4Paraboloid.hh"
-#include "G4IntersectionSolid.hh"
 #include "G4Polycone.hh"
-#include "G4GenericPolycone.hh"
 #include "G4Polyhedra.hh"
 #include "G4ReflectedSolid.hh"
+#include "G4ScaledSolid.hh"
 #include "G4Sphere.hh"
 #include "G4SubtractionSolid.hh"
-#include "G4GenericTrap.hh"
+#include "G4SurfaceProperty.hh"
+#include "G4SystemOfUnits.hh"
 #include "G4TessellatedSolid.hh"
 #include "G4Tet.hh"
 #include "G4Torus.hh"
 #include "G4Trap.hh"
 #include "G4Trd.hh"
 #include "G4Tubs.hh"
-#include "G4CutTubs.hh"
 #include "G4TwistedBox.hh"
 #include "G4TwistedTrap.hh"
 #include "G4TwistedTrd.hh"
 #include "G4TwistedTubs.hh"
 #include "G4UnionSolid.hh"
-#include "G4OpticalSurface.hh"
-#include "G4SurfaceProperty.hh"
-#include "G4MaterialPropertiesTable.hh"
-
 #include "RAT/GLG4TorusStack.hh"
 namespace RAT {
 
 // --------------------------------------------------------------------
-GDMLWriteSolids::GDMLWriteSolids()
-  : G4GDMLWriteMaterials()
-{
-}
+GDMLWriteSolids::GDMLWriteSolids() : G4GDMLWriteMaterials() {}
 
 // --------------------------------------------------------------------
-GDMLWriteSolids::~GDMLWriteSolids()
-{
-}
+GDMLWriteSolids::~GDMLWriteSolids() {}
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::MultiUnionWrite(xercesc::DOMElement* solElement,
-                                        const G4MultiUnion* const munionSolid)
-{
+void GDMLWriteSolids::MultiUnionWrite(xercesc::DOMElement* solElement, const G4MultiUnion* const munionSolid) {
   G4int numSolids = munionSolid->GetNumberOfSolids();
   G4String tag("multiUnion");
 
@@ -65,9 +57,8 @@ void GDMLWriteSolids::MultiUnionWrite(xercesc::DOMElement* solElement,
   xercesc::DOMElement* multiUnionElement = NewElement(tag);
   multiUnionElement->setAttributeNode(NewAttribute("name", name));
 
-  for(G4int i = 0; i < numSolids; ++i)
-  {
-    solid     = munionSolid->GetSolid(i);
+  for (G4int i = 0; i < numSolids; ++i) {
+    solid = munionSolid->GetSolid(i);
     transform = munionSolid->GetTransformation(i);
 
     HepGeom::Rotate3D rot3d;
@@ -76,8 +67,7 @@ void GDMLWriteSolids::MultiUnionWrite(xercesc::DOMElement* solElement,
     transform.getDecomposition(scale, rot3d, transl);
 
     G4ThreeVector pos = transl.getTranslation();
-    G4RotationMatrix rotm(CLHEP::HepRep3x3(rot3d.xx(), rot3d.xy(), rot3d.xz(),
-                                           rot3d.yx(), rot3d.yy(), rot3d.yz(),
+    G4RotationMatrix rotm(CLHEP::HepRep3x3(rot3d.xx(), rot3d.xy(), rot3d.xz(), rot3d.yx(), rot3d.yy(), rot3d.yz(),
                                            rot3d.zx(), rot3d.zy(), rot3d.zz()));
     G4ThreeVector rot = GetAngles(rotm);
 
@@ -85,23 +75,19 @@ void GDMLWriteSolids::MultiUnionWrite(xercesc::DOMElement* solElement,
     const G4String& solidref = GenerateName(solid->GetName(), solid);
     std::ostringstream os;
     os << i + 1;
-    const G4String& nodeName          = "Node-" + G4String(os.str());
+    const G4String& nodeName = "Node-" + G4String(os.str());
     xercesc::DOMElement* solidElement = NewElement("solid");
     solidElement->setAttributeNode(NewAttribute("ref", solidref));
     xercesc::DOMElement* multiUnionNodeElement = NewElement("multiUnionNode");
-    multiUnionNodeElement->setAttributeNode(NewAttribute("name", name+"_"+nodeName));
+    multiUnionNodeElement->setAttributeNode(NewAttribute("name", name + "_" + nodeName));
     multiUnionNodeElement->appendChild(solidElement);  // Append solid to node
-    if((std::fabs(pos.x()) > kLinearPrecision) ||
-       (std::fabs(pos.y()) > kLinearPrecision) ||
-       (std::fabs(pos.z()) > kLinearPrecision))
-    {
-      PositionWrite(multiUnionNodeElement,name+"_"+nodeName+"_pos",pos);
+    if ((std::fabs(pos.x()) > kLinearPrecision) || (std::fabs(pos.y()) > kLinearPrecision) ||
+        (std::fabs(pos.z()) > kLinearPrecision)) {
+      PositionWrite(multiUnionNodeElement, name + "_" + nodeName + "_pos", pos);
     }
-    if((std::fabs(rot.x()) > kAngularPrecision) ||
-       (std::fabs(rot.y()) > kAngularPrecision) ||
-       (std::fabs(rot.z()) > kAngularPrecision))
-    {
-      RotationWrite(multiUnionNodeElement,name+"_"+nodeName+"_rot",rot);
+    if ((std::fabs(rot.x()) > kAngularPrecision) || (std::fabs(rot.y()) > kAngularPrecision) ||
+        (std::fabs(rot.z()) > kAngularPrecision)) {
+      RotationWrite(multiUnionNodeElement, name + "_" + nodeName + "_rot", rot);
     }
     multiUnionElement->appendChild(multiUnionNodeElement);  // Append node
   }
@@ -111,45 +97,33 @@ void GDMLWriteSolids::MultiUnionWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::BooleanWrite(xercesc::DOMElement* solElement,
-                                     const G4BooleanSolid* const boolean)
-{
+void GDMLWriteSolids::BooleanWrite(xercesc::DOMElement* solElement, const G4BooleanSolid* const boolean) {
   G4int displaced = 0;
 
   G4String tag("undefined");
-  if(dynamic_cast<const G4IntersectionSolid*>(boolean))
-  {
+  if (dynamic_cast<const G4IntersectionSolid*>(boolean)) {
     tag = "intersection";
-  }
-  else if(dynamic_cast<const G4SubtractionSolid*>(boolean))
-  {
+  } else if (dynamic_cast<const G4SubtractionSolid*>(boolean)) {
     tag = "subtraction";
-  }
-  else if(dynamic_cast<const G4UnionSolid*>(boolean))
-  {
+  } else if (dynamic_cast<const G4UnionSolid*>(boolean)) {
     tag = "union";
   }
 
-  G4VSolid* firstPtr  = const_cast<G4VSolid*>(boolean->GetConstituentSolid(0));
+  G4VSolid* firstPtr = const_cast<G4VSolid*>(boolean->GetConstituentSolid(0));
   G4VSolid* secondPtr = const_cast<G4VSolid*>(boolean->GetConstituentSolid(1));
 
   G4ThreeVector firstpos, firstrot, pos, rot;
 
   // Solve possible displacement of referenced solids!
   //
-  while(true)
-  {
-    if(displaced > 8)
-    {
-      G4String ErrorMessage = "The referenced solid '" + firstPtr->GetName() +
-                              +"in the Boolean shape '" + +boolean->GetName() +
-                              +"' was displaced too many times!";
-      G4Exception("GDMLWriteSolids::BooleanWrite()", "InvalidSetup",
-                  FatalException, ErrorMessage);
+  while (true) {
+    if (displaced > 8) {
+      G4String ErrorMessage = "The referenced solid '" + firstPtr->GetName() + +"in the Boolean shape '" +
+                              +boolean->GetName() + +"' was displaced too many times!";
+      G4Exception("GDMLWriteSolids::BooleanWrite()", "InvalidSetup", FatalException, ErrorMessage);
     }
 
-    if(G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(firstPtr))
-    {
+    if (G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(firstPtr)) {
       firstpos += disp->GetObjectTranslation();
       firstrot += GetAngles(disp->GetObjectRotation());
       firstPtr = disp->GetConstituentMovedSolid();
@@ -159,19 +133,14 @@ void GDMLWriteSolids::BooleanWrite(xercesc::DOMElement* solElement,
     break;
   }
   displaced = 0;
-  while(true)
-  {
-    if(displaced > maxTransforms)
-    {
-      G4String ErrorMessage = "The referenced solid '" + secondPtr->GetName() +
-                              +"in the Boolean shape '" + +boolean->GetName() +
-                              +"' was displaced too many times!";
-      G4Exception("GDMLWriteSolids::BooleanWrite()", "InvalidSetup",
-                  FatalException, ErrorMessage);
+  while (true) {
+    if (displaced > maxTransforms) {
+      G4String ErrorMessage = "The referenced solid '" + secondPtr->GetName() + +"in the Boolean shape '" +
+                              +boolean->GetName() + +"' was displaced too many times!";
+      G4Exception("GDMLWriteSolids::BooleanWrite()", "InvalidSetup", FatalException, ErrorMessage);
     }
 
-    if(G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(secondPtr))
-    {
+    if (G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(secondPtr)) {
       pos += disp->GetObjectTranslation();
       rot += GetAngles(disp->GetObjectRotation());
       secondPtr = disp->GetConstituentMovedSolid();
@@ -184,8 +153,8 @@ void GDMLWriteSolids::BooleanWrite(xercesc::DOMElement* solElement,
   AddSolid(firstPtr);  // At first add the constituent solids!
   AddSolid(secondPtr);
 
-  const G4String& name      = GenerateName(boolean->GetName(), boolean);
-  const G4String& firstref  = GenerateName(firstPtr->GetName(), firstPtr);
+  const G4String& name = GenerateName(boolean->GetName(), boolean);
+  const G4String& firstref = GenerateName(firstPtr->GetName(), firstPtr);
   const G4String& secondref = GenerateName(secondPtr->GetName(), secondPtr);
 
   xercesc::DOMElement* booleanElement = NewElement(tag);
@@ -199,48 +168,38 @@ void GDMLWriteSolids::BooleanWrite(xercesc::DOMElement* solElement,
   solElement->appendChild(booleanElement);
   // Add the boolean solid AFTER the constituent solids!
 
-  if((std::fabs(pos.x()) > kLinearPrecision) ||
-     (std::fabs(pos.y()) > kLinearPrecision) ||
-     (std::fabs(pos.z()) > kLinearPrecision))
-  {
+  if ((std::fabs(pos.x()) > kLinearPrecision) || (std::fabs(pos.y()) > kLinearPrecision) ||
+      (std::fabs(pos.z()) > kLinearPrecision)) {
     PositionWrite(booleanElement, name + "_pos", pos);
   }
 
-  if((std::fabs(rot.x()) > kAngularPrecision) ||
-     (std::fabs(rot.y()) > kAngularPrecision) ||
-     (std::fabs(rot.z()) > kAngularPrecision))
-  {
+  if ((std::fabs(rot.x()) > kAngularPrecision) || (std::fabs(rot.y()) > kAngularPrecision) ||
+      (std::fabs(rot.z()) > kAngularPrecision)) {
     RotationWrite(booleanElement, name + "_rot", rot);
   }
 
-  if((std::fabs(firstpos.x()) > kLinearPrecision) ||
-     (std::fabs(firstpos.y()) > kLinearPrecision) ||
-     (std::fabs(firstpos.z()) > kLinearPrecision))
-  {
+  if ((std::fabs(firstpos.x()) > kLinearPrecision) || (std::fabs(firstpos.y()) > kLinearPrecision) ||
+      (std::fabs(firstpos.z()) > kLinearPrecision)) {
     FirstpositionWrite(booleanElement, name + "_fpos", firstpos);
   }
 
-  if((std::fabs(firstrot.x()) > kAngularPrecision) ||
-     (std::fabs(firstrot.y()) > kAngularPrecision) ||
-     (std::fabs(firstrot.z()) > kAngularPrecision))
-  {
+  if ((std::fabs(firstrot.x()) > kAngularPrecision) || (std::fabs(firstrot.y()) > kAngularPrecision) ||
+      (std::fabs(firstrot.z()) > kAngularPrecision)) {
     FirstrotationWrite(booleanElement, name + "_frot", firstrot);
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::ScaledWrite(xercesc::DOMElement* solElement,
-                                    const G4ScaledSolid* const scaled)
-{
+void GDMLWriteSolids::ScaledWrite(xercesc::DOMElement* solElement, const G4ScaledSolid* const scaled) {
   G4String tag("scaledSolid");
 
-  G4VSolid* solid         = const_cast<G4VSolid*>(scaled->GetUnscaledSolid());
-  G4Scale3D scale         = scaled->GetScaleTransform();
+  G4VSolid* solid = const_cast<G4VSolid*>(scaled->GetUnscaledSolid());
+  G4Scale3D scale = scaled->GetScaleTransform();
   G4ThreeVector sclVector = G4ThreeVector(scale.xx(), scale.yy(), scale.zz());
 
   AddSolid(solid);  // Add the constituent solid!
 
-  const G4String& name     = GenerateName(scaled->GetName(), scaled);
+  const G4String& name = GenerateName(scaled->GetName(), scaled);
   const G4String& solidref = GenerateName(solid->GetName(), solid);
 
   xercesc::DOMElement* scaledElement = NewElement(tag);
@@ -250,10 +209,8 @@ void GDMLWriteSolids::ScaledWrite(xercesc::DOMElement* solElement,
   solidElement->setAttributeNode(NewAttribute("ref", solidref));
   scaledElement->appendChild(solidElement);
 
-  if((std::fabs(scale.xx()) > kLinearPrecision) &&
-     (std::fabs(scale.yy()) > kLinearPrecision) &&
-     (std::fabs(scale.zz()) > kLinearPrecision))
-  {
+  if ((std::fabs(scale.xx()) > kLinearPrecision) && (std::fabs(scale.yy()) > kLinearPrecision) &&
+      (std::fabs(scale.zz()) > kLinearPrecision)) {
     ScaleWrite(scaledElement, name + "_scl", sclVector);
   }
 
@@ -262,95 +219,67 @@ void GDMLWriteSolids::ScaledWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::BoxWrite(xercesc::DOMElement* solElement,
-                                 const G4Box* const box)
-{
+void GDMLWriteSolids::BoxWrite(xercesc::DOMElement* solElement, const G4Box* const box) {
   const G4String& name = GenerateName(box->GetName(), box);
 
   xercesc::DOMElement* boxElement = NewElement("box");
   boxElement->setAttributeNode(NewAttribute("name", name));
-  boxElement->setAttributeNode(
-    NewAttribute("x", 2.0 * box->GetXHalfLength() / mm));
-  boxElement->setAttributeNode(
-    NewAttribute("y", 2.0 * box->GetYHalfLength() / mm));
-  boxElement->setAttributeNode(
-    NewAttribute("z", 2.0 * box->GetZHalfLength() / mm));
+  boxElement->setAttributeNode(NewAttribute("x", 2.0 * box->GetXHalfLength() / mm));
+  boxElement->setAttributeNode(NewAttribute("y", 2.0 * box->GetYHalfLength() / mm));
+  boxElement->setAttributeNode(NewAttribute("z", 2.0 * box->GetZHalfLength() / mm));
   boxElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(boxElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::ConeWrite(xercesc::DOMElement* solElement,
-                                  const G4Cons* const cone)
-{
+void GDMLWriteSolids::ConeWrite(xercesc::DOMElement* solElement, const G4Cons* const cone) {
   const G4String& name = GenerateName(cone->GetName(), cone);
 
   xercesc::DOMElement* coneElement = NewElement("cone");
   coneElement->setAttributeNode(NewAttribute("name", name));
-  coneElement->setAttributeNode(
-    NewAttribute("rmin1", cone->GetInnerRadiusMinusZ() / mm));
-  coneElement->setAttributeNode(
-    NewAttribute("rmax1", cone->GetOuterRadiusMinusZ() / mm));
-  coneElement->setAttributeNode(
-    NewAttribute("rmin2", cone->GetInnerRadiusPlusZ() / mm));
-  coneElement->setAttributeNode(
-    NewAttribute("rmax2", cone->GetOuterRadiusPlusZ() / mm));
-  coneElement->setAttributeNode(
-    NewAttribute("z", 2.0 * cone->GetZHalfLength() / mm));
-  coneElement->setAttributeNode(
-    NewAttribute("startphi", cone->GetStartPhiAngle() / degree));
-  coneElement->setAttributeNode(
-    NewAttribute("deltaphi", cone->GetDeltaPhiAngle() / degree));
+  coneElement->setAttributeNode(NewAttribute("rmin1", cone->GetInnerRadiusMinusZ() / mm));
+  coneElement->setAttributeNode(NewAttribute("rmax1", cone->GetOuterRadiusMinusZ() / mm));
+  coneElement->setAttributeNode(NewAttribute("rmin2", cone->GetInnerRadiusPlusZ() / mm));
+  coneElement->setAttributeNode(NewAttribute("rmax2", cone->GetOuterRadiusPlusZ() / mm));
+  coneElement->setAttributeNode(NewAttribute("z", 2.0 * cone->GetZHalfLength() / mm));
+  coneElement->setAttributeNode(NewAttribute("startphi", cone->GetStartPhiAngle() / degree));
+  coneElement->setAttributeNode(NewAttribute("deltaphi", cone->GetDeltaPhiAngle() / degree));
   coneElement->setAttributeNode(NewAttribute("aunit", "deg"));
   coneElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(coneElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::ElconeWrite(xercesc::DOMElement* solElement,
-                                    const G4EllipticalCone* const elcone)
-{
+void GDMLWriteSolids::ElconeWrite(xercesc::DOMElement* solElement, const G4EllipticalCone* const elcone) {
   const G4String& name = GenerateName(elcone->GetName(), elcone);
 
   xercesc::DOMElement* elconeElement = NewElement("elcone");
   elconeElement->setAttributeNode(NewAttribute("name", name));
-  elconeElement->setAttributeNode(
-    NewAttribute("dx", elcone->GetSemiAxisX() / mm));
-  elconeElement->setAttributeNode(
-    NewAttribute("dy", elcone->GetSemiAxisY() / mm));
+  elconeElement->setAttributeNode(NewAttribute("dx", elcone->GetSemiAxisX() / mm));
+  elconeElement->setAttributeNode(NewAttribute("dy", elcone->GetSemiAxisY() / mm));
   elconeElement->setAttributeNode(NewAttribute("zmax", elcone->GetZMax() / mm));
-  elconeElement->setAttributeNode(
-    NewAttribute("zcut", elcone->GetZTopCut() / mm));
+  elconeElement->setAttributeNode(NewAttribute("zcut", elcone->GetZTopCut() / mm));
   elconeElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(elconeElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::EllipsoidWrite(xercesc::DOMElement* solElement,
-                                       const G4Ellipsoid* const ellipsoid)
-{
+void GDMLWriteSolids::EllipsoidWrite(xercesc::DOMElement* solElement, const G4Ellipsoid* const ellipsoid) {
   const G4String& name = GenerateName(ellipsoid->GetName(), ellipsoid);
 
   xercesc::DOMElement* ellipsoidElement = NewElement("ellipsoid");
   ellipsoidElement->setAttributeNode(NewAttribute("name", name));
-  ellipsoidElement->setAttributeNode(
-    NewAttribute("ax", ellipsoid->GetSemiAxisMax(0) / mm));
-  ellipsoidElement->setAttributeNode(
-    NewAttribute("by", ellipsoid->GetSemiAxisMax(1) / mm));
-  ellipsoidElement->setAttributeNode(
-    NewAttribute("cz", ellipsoid->GetSemiAxisMax(2) / mm));
-  ellipsoidElement->setAttributeNode(
-    NewAttribute("zcut1", ellipsoid->GetZBottomCut() / mm));
-  ellipsoidElement->setAttributeNode(
-    NewAttribute("zcut2", ellipsoid->GetZTopCut() / mm));
+  ellipsoidElement->setAttributeNode(NewAttribute("ax", ellipsoid->GetSemiAxisMax(0) / mm));
+  ellipsoidElement->setAttributeNode(NewAttribute("by", ellipsoid->GetSemiAxisMax(1) / mm));
+  ellipsoidElement->setAttributeNode(NewAttribute("cz", ellipsoid->GetSemiAxisMax(2) / mm));
+  ellipsoidElement->setAttributeNode(NewAttribute("zcut1", ellipsoid->GetZBottomCut() / mm));
+  ellipsoidElement->setAttributeNode(NewAttribute("zcut2", ellipsoid->GetZTopCut() / mm));
   ellipsoidElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(ellipsoidElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::EltubeWrite(xercesc::DOMElement* solElement,
-                                    const G4EllipticalTube* const eltube)
-{
+void GDMLWriteSolids::EltubeWrite(xercesc::DOMElement* solElement, const G4EllipticalTube* const eltube) {
   const G4String& name = GenerateName(eltube->GetName(), eltube);
 
   xercesc::DOMElement* eltubeElement = NewElement("eltube");
@@ -363,9 +292,7 @@ void GDMLWriteSolids::EltubeWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::XtruWrite(xercesc::DOMElement* solElement,
-                                  const G4ExtrudedSolid* const xtru)
-{
+void GDMLWriteSolids::XtruWrite(xercesc::DOMElement* solElement, const G4ExtrudedSolid* const xtru) {
   const G4String& name = GenerateName(xtru->GetName(), xtru);
 
   xercesc::DOMElement* xtruElement = NewElement("xtru");
@@ -375,8 +302,7 @@ void GDMLWriteSolids::XtruWrite(xercesc::DOMElement* solElement,
 
   const G4int NumVertex = xtru->GetNofVertices();
 
-  for(G4int i = 0; i < NumVertex; ++i)
-  {
+  for (G4int i = 0; i < NumVertex; ++i) {
     xercesc::DOMElement* twoDimVertexElement = NewElement("twoDimVertex");
     xtruElement->appendChild(twoDimVertexElement);
 
@@ -388,52 +314,38 @@ void GDMLWriteSolids::XtruWrite(xercesc::DOMElement* solElement,
 
   const G4int NumSection = xtru->GetNofZSections();
 
-  for(G4int i = 0; i < NumSection; ++i)
-  {
+  for (G4int i = 0; i < NumSection; ++i) {
     xercesc::DOMElement* sectionElement = NewElement("section");
     xtruElement->appendChild(sectionElement);
 
     const G4ExtrudedSolid::ZSection section = xtru->GetZSection(i);
 
     sectionElement->setAttributeNode(NewAttribute("zOrder", i));
-    sectionElement->setAttributeNode(
-      NewAttribute("zPosition", section.fZ / mm));
-    sectionElement->setAttributeNode(
-      NewAttribute("xOffset", section.fOffset.x() / mm));
-    sectionElement->setAttributeNode(
-      NewAttribute("yOffset", section.fOffset.y() / mm));
-    sectionElement->setAttributeNode(
-      NewAttribute("scalingFactor", section.fScale));
+    sectionElement->setAttributeNode(NewAttribute("zPosition", section.fZ / mm));
+    sectionElement->setAttributeNode(NewAttribute("xOffset", section.fOffset.x() / mm));
+    sectionElement->setAttributeNode(NewAttribute("yOffset", section.fOffset.y() / mm));
+    sectionElement->setAttributeNode(NewAttribute("scalingFactor", section.fScale));
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::HypeWrite(xercesc::DOMElement* solElement,
-                                  const G4Hype* const hype)
-{
+void GDMLWriteSolids::HypeWrite(xercesc::DOMElement* solElement, const G4Hype* const hype) {
   const G4String& name = GenerateName(hype->GetName(), hype);
 
   xercesc::DOMElement* hypeElement = NewElement("hype");
   hypeElement->setAttributeNode(NewAttribute("name", name));
-  hypeElement->setAttributeNode(
-    NewAttribute("rmin", hype->GetInnerRadius() / mm));
-  hypeElement->setAttributeNode(
-    NewAttribute("rmax", hype->GetOuterRadius() / mm));
-  hypeElement->setAttributeNode(
-    NewAttribute("inst", hype->GetInnerStereo() / degree));
-  hypeElement->setAttributeNode(
-    NewAttribute("outst", hype->GetOuterStereo() / degree));
-  hypeElement->setAttributeNode(
-    NewAttribute("z", 2.0 * hype->GetZHalfLength() / mm));
+  hypeElement->setAttributeNode(NewAttribute("rmin", hype->GetInnerRadius() / mm));
+  hypeElement->setAttributeNode(NewAttribute("rmax", hype->GetOuterRadius() / mm));
+  hypeElement->setAttributeNode(NewAttribute("inst", hype->GetInnerStereo() / degree));
+  hypeElement->setAttributeNode(NewAttribute("outst", hype->GetOuterStereo() / degree));
+  hypeElement->setAttributeNode(NewAttribute("z", 2.0 * hype->GetZHalfLength() / mm));
   hypeElement->setAttributeNode(NewAttribute("aunit", "deg"));
   hypeElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(hypeElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::OrbWrite(xercesc::DOMElement* solElement,
-                                 const G4Orb* const orb)
-{
+void GDMLWriteSolids::OrbWrite(xercesc::DOMElement* solElement, const G4Orb* const orb) {
   const G4String& name = GenerateName(orb->GetName(), orb);
 
   xercesc::DOMElement* orbElement = NewElement("orb");
@@ -444,24 +356,19 @@ void GDMLWriteSolids::OrbWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::ParaWrite(xercesc::DOMElement* solElement,
-                                  const G4Para* const para)
-{
+void GDMLWriteSolids::ParaWrite(xercesc::DOMElement* solElement, const G4Para* const para) {
   const G4String& name = GenerateName(para->GetName(), para);
 
   const G4ThreeVector simaxis = para->GetSymAxis();
-  const G4double alpha        = std::atan(para->GetTanAlpha());
-  const G4double phi          = simaxis.phi();
-  const G4double theta        = simaxis.theta();
+  const G4double alpha = std::atan(para->GetTanAlpha());
+  const G4double phi = simaxis.phi();
+  const G4double theta = simaxis.theta();
 
   xercesc::DOMElement* paraElement = NewElement("para");
   paraElement->setAttributeNode(NewAttribute("name", name));
-  paraElement->setAttributeNode(
-    NewAttribute("x", 2.0 * para->GetXHalfLength() / mm));
-  paraElement->setAttributeNode(
-    NewAttribute("y", 2.0 * para->GetYHalfLength() / mm));
-  paraElement->setAttributeNode(
-    NewAttribute("z", 2.0 * para->GetZHalfLength() / mm));
+  paraElement->setAttributeNode(NewAttribute("x", 2.0 * para->GetXHalfLength() / mm));
+  paraElement->setAttributeNode(NewAttribute("y", 2.0 * para->GetYHalfLength() / mm));
+  paraElement->setAttributeNode(NewAttribute("z", 2.0 * para->GetZHalfLength() / mm));
   paraElement->setAttributeNode(NewAttribute("alpha", alpha / degree));
   paraElement->setAttributeNode(NewAttribute("theta", theta / degree));
   paraElement->setAttributeNode(NewAttribute("phi", phi / degree));
@@ -471,70 +378,55 @@ void GDMLWriteSolids::ParaWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::ParaboloidWrite(xercesc::DOMElement* solElement,
-                                        const G4Paraboloid* const paraboloid)
-{
+void GDMLWriteSolids::ParaboloidWrite(xercesc::DOMElement* solElement, const G4Paraboloid* const paraboloid) {
   const G4String& name = GenerateName(paraboloid->GetName(), paraboloid);
 
   xercesc::DOMElement* paraboloidElement = NewElement("paraboloid");
   paraboloidElement->setAttributeNode(NewAttribute("name", name));
-  paraboloidElement->setAttributeNode(
-    NewAttribute("rlo", paraboloid->GetRadiusMinusZ() / mm));
-  paraboloidElement->setAttributeNode(
-    NewAttribute("rhi", paraboloid->GetRadiusPlusZ() / mm));
-  paraboloidElement->setAttributeNode(
-    NewAttribute("dz", paraboloid->GetZHalfLength() / mm));
+  paraboloidElement->setAttributeNode(NewAttribute("rlo", paraboloid->GetRadiusMinusZ() / mm));
+  paraboloidElement->setAttributeNode(NewAttribute("rhi", paraboloid->GetRadiusPlusZ() / mm));
+  paraboloidElement->setAttributeNode(NewAttribute("dz", paraboloid->GetZHalfLength() / mm));
   paraboloidElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(paraboloidElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::PolyconeWrite(xercesc::DOMElement* solElement,
-                                      const G4Polycone* const polycone)
-{
+void GDMLWriteSolids::PolyconeWrite(xercesc::DOMElement* solElement, const G4Polycone* const polycone) {
   const G4String& name = GenerateName(polycone->GetName(), polycone);
 
   xercesc::DOMElement* polyconeElement = NewElement("polycone");
   polyconeElement->setAttributeNode(NewAttribute("name", name));
-  polyconeElement->setAttributeNode(NewAttribute(
-    "startphi", polycone->GetOriginalParameters()->Start_angle / degree));
-  polyconeElement->setAttributeNode(NewAttribute(
-    "deltaphi", polycone->GetOriginalParameters()->Opening_angle / degree));
+  polyconeElement->setAttributeNode(NewAttribute("startphi", polycone->GetOriginalParameters()->Start_angle / degree));
+  polyconeElement->setAttributeNode(
+      NewAttribute("deltaphi", polycone->GetOriginalParameters()->Opening_angle / degree));
   polyconeElement->setAttributeNode(NewAttribute("aunit", "deg"));
   polyconeElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(polyconeElement);
 
-  const std::size_t num_zplanes
-        = polycone->GetOriginalParameters()->Num_z_planes;
-  const G4double* z_array    = polycone->GetOriginalParameters()->Z_values;
+  const std::size_t num_zplanes = polycone->GetOriginalParameters()->Num_z_planes;
+  const G4double* z_array = polycone->GetOriginalParameters()->Z_values;
   const G4double* rmin_array = polycone->GetOriginalParameters()->Rmin;
   const G4double* rmax_array = polycone->GetOriginalParameters()->Rmax;
 
-  for(std::size_t i = 0; i < num_zplanes; ++i)
-  {
+  for (std::size_t i = 0; i < num_zplanes; ++i) {
     ZplaneWrite(polyconeElement, z_array[i], rmin_array[i], rmax_array[i]);
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::GenericPolyconeWrite(
-  xercesc::DOMElement* solElement, const G4GenericPolycone* const polycone)
-{
+void GDMLWriteSolids::GenericPolyconeWrite(xercesc::DOMElement* solElement, const G4GenericPolycone* const polycone) {
   const G4String& name = GenerateName(polycone->GetName(), polycone);
   xercesc::DOMElement* polyconeElement = NewElement("genericPolycone");
-  const G4double startPhi              = polycone->GetStartPhi();
+  const G4double startPhi = polycone->GetStartPhi();
   polyconeElement->setAttributeNode(NewAttribute("name", name));
-  polyconeElement->setAttributeNode(
-    NewAttribute("startphi", startPhi / degree));
-  polyconeElement->setAttributeNode(
-    NewAttribute("deltaphi", (polycone->GetEndPhi() - startPhi) / degree));
+  polyconeElement->setAttributeNode(NewAttribute("startphi", startPhi / degree));
+  polyconeElement->setAttributeNode(NewAttribute("deltaphi", (polycone->GetEndPhi() - startPhi) / degree));
   polyconeElement->setAttributeNode(NewAttribute("aunit", "deg"));
   polyconeElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(polyconeElement);
 
   const std::size_t num_rzpoints = polycone->GetNumRZCorner();
-  for(std::size_t i = 0; i < num_rzpoints; ++i)
-  {
+  for (std::size_t i = 0; i < num_rzpoints; ++i) {
     const G4double r_point = polycone->GetCorner(i).r;
     const G4double z_point = polycone->GetCorner(i).z;
     RZPointWrite(polyconeElement, r_point, z_point);
@@ -542,58 +434,47 @@ void GDMLWriteSolids::GenericPolyconeWrite(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::PolyhedraWrite(xercesc::DOMElement* solElement,
-                                       const G4Polyhedra* const polyhedra)
-{
+void GDMLWriteSolids::PolyhedraWrite(xercesc::DOMElement* solElement, const G4Polyhedra* const polyhedra) {
   const G4String& name = GenerateName(polyhedra->GetName(), polyhedra);
-  if(polyhedra->IsGeneric() == false)
-  {
+  if (polyhedra->IsGeneric() == false) {
     xercesc::DOMElement* polyhedraElement = NewElement("polyhedra");
     polyhedraElement->setAttributeNode(NewAttribute("name", name));
-    polyhedraElement->setAttributeNode(NewAttribute(
-      "startphi", polyhedra->GetOriginalParameters()->Start_angle / degree));
-    polyhedraElement->setAttributeNode(NewAttribute(
-      "deltaphi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
     polyhedraElement->setAttributeNode(
-      NewAttribute("numsides", polyhedra->GetOriginalParameters()->numSide));
+        NewAttribute("startphi", polyhedra->GetOriginalParameters()->Start_angle / degree));
+    polyhedraElement->setAttributeNode(
+        NewAttribute("deltaphi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
+    polyhedraElement->setAttributeNode(NewAttribute("numsides", polyhedra->GetOriginalParameters()->numSide));
     polyhedraElement->setAttributeNode(NewAttribute("aunit", "deg"));
     polyhedraElement->setAttributeNode(NewAttribute("lunit", "mm"));
     solElement->appendChild(polyhedraElement);
 
-    const std::size_t num_zplanes
-          = polyhedra->GetOriginalParameters()->Num_z_planes;
-    const G4double* z_array  = polyhedra->GetOriginalParameters()->Z_values;
+    const std::size_t num_zplanes = polyhedra->GetOriginalParameters()->Num_z_planes;
+    const G4double* z_array = polyhedra->GetOriginalParameters()->Z_values;
     const G4double* rmin_array = polyhedra->GetOriginalParameters()->Rmin;
     const G4double* rmax_array = polyhedra->GetOriginalParameters()->Rmax;
 
     const G4double convertRad =
-      std::cos(0.5 * polyhedra->GetOriginalParameters()->Opening_angle /
-               polyhedra->GetOriginalParameters()->numSide);
+        std::cos(0.5 * polyhedra->GetOriginalParameters()->Opening_angle / polyhedra->GetOriginalParameters()->numSide);
 
-    for(std::size_t i = 0; i < num_zplanes; ++i)
-    {
-      ZplaneWrite(polyhedraElement, z_array[i], rmin_array[i] * convertRad,
-                  rmax_array[i] * convertRad);
+    for (std::size_t i = 0; i < num_zplanes; ++i) {
+      ZplaneWrite(polyhedraElement, z_array[i], rmin_array[i] * convertRad, rmax_array[i] * convertRad);
     }
-  }
-  else  // generic polyhedra
+  } else  // generic polyhedra
   {
     xercesc::DOMElement* polyhedraElement = NewElement("genericPolyhedra");
     polyhedraElement->setAttributeNode(NewAttribute("name", name));
-    polyhedraElement->setAttributeNode(NewAttribute(
-      "startphi", polyhedra->GetOriginalParameters()->Start_angle / degree));
-    polyhedraElement->setAttributeNode(NewAttribute(
-      "deltaphi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
     polyhedraElement->setAttributeNode(
-      NewAttribute("numsides", polyhedra->GetOriginalParameters()->numSide));
+        NewAttribute("startphi", polyhedra->GetOriginalParameters()->Start_angle / degree));
+    polyhedraElement->setAttributeNode(
+        NewAttribute("deltaphi", polyhedra->GetOriginalParameters()->Opening_angle / degree));
+    polyhedraElement->setAttributeNode(NewAttribute("numsides", polyhedra->GetOriginalParameters()->numSide));
     polyhedraElement->setAttributeNode(NewAttribute("aunit", "deg"));
     polyhedraElement->setAttributeNode(NewAttribute("lunit", "mm"));
     solElement->appendChild(polyhedraElement);
 
     const std::size_t num_rzpoints = polyhedra->GetNumRZCorner();
 
-    for(std::size_t i = 0; i < num_rzpoints; ++i)
-    {
+    for (std::size_t i = 0; i < num_rzpoints; ++i) {
       const G4double r_point = polyhedra->GetCorner(i).r;
       const G4double z_point = polyhedra->GetCorner(i).z;
       RZPointWrite(polyhedraElement, r_point, z_point);
@@ -602,36 +483,26 @@ void GDMLWriteSolids::PolyhedraWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::SphereWrite(xercesc::DOMElement* solElement,
-                                    const G4Sphere* const sphere)
-{
+void GDMLWriteSolids::SphereWrite(xercesc::DOMElement* solElement, const G4Sphere* const sphere) {
   const G4String& name = GenerateName(sphere->GetName(), sphere);
 
   xercesc::DOMElement* sphereElement = NewElement("sphere");
   sphereElement->setAttributeNode(NewAttribute("name", name));
-  sphereElement->setAttributeNode(
-    NewAttribute("rmin", sphere->GetInnerRadius() / mm));
-  sphereElement->setAttributeNode(
-    NewAttribute("rmax", sphere->GetOuterRadius() / mm));
-  sphereElement->setAttributeNode(
-    NewAttribute("startphi", sphere->GetStartPhiAngle() / degree));
-  sphereElement->setAttributeNode(
-    NewAttribute("deltaphi", sphere->GetDeltaPhiAngle() / degree));
-  sphereElement->setAttributeNode(
-    NewAttribute("starttheta", sphere->GetStartThetaAngle() / degree));
-  sphereElement->setAttributeNode(
-    NewAttribute("deltatheta", sphere->GetDeltaThetaAngle() / degree));
+  sphereElement->setAttributeNode(NewAttribute("rmin", sphere->GetInnerRadius() / mm));
+  sphereElement->setAttributeNode(NewAttribute("rmax", sphere->GetOuterRadius() / mm));
+  sphereElement->setAttributeNode(NewAttribute("startphi", sphere->GetStartPhiAngle() / degree));
+  sphereElement->setAttributeNode(NewAttribute("deltaphi", sphere->GetDeltaPhiAngle() / degree));
+  sphereElement->setAttributeNode(NewAttribute("starttheta", sphere->GetStartThetaAngle() / degree));
+  sphereElement->setAttributeNode(NewAttribute("deltatheta", sphere->GetDeltaThetaAngle() / degree));
   sphereElement->setAttributeNode(NewAttribute("aunit", "deg"));
   sphereElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(sphereElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TessellatedWrite(
-  xercesc::DOMElement* solElement, const G4TessellatedSolid* const tessellated)
-{
+void GDMLWriteSolids::TessellatedWrite(xercesc::DOMElement* solElement, const G4TessellatedSolid* const tessellated) {
   const G4String& solid_name = tessellated->GetName();
-  const G4String& name       = GenerateName(solid_name, tessellated);
+  const G4String& name = GenerateName(solid_name, tessellated);
 
   xercesc::DOMElement* tessellatedElement = NewElement("tessellated");
   tessellatedElement->setAttributeNode(NewAttribute("name", name));
@@ -642,34 +513,27 @@ void GDMLWriteSolids::TessellatedWrite(
   std::map<G4ThreeVector, G4String, G4ThreeVectorCompare> vertexMap;
 
   const std::size_t NumFacets = tessellated->GetNumberOfFacets();
-  std::size_t NumVertex       = 0;
+  std::size_t NumVertex = 0;
 
-  for(std::size_t i = 0; i < NumFacets; ++i)
-  {
-    const G4VFacet* facet          = tessellated->GetFacet(i);
+  for (std::size_t i = 0; i < NumFacets; ++i) {
+    const G4VFacet* facet = tessellated->GetFacet(i);
     const size_t NumVertexPerFacet = facet->GetNumberOfVertices();
 
     G4String FacetTag;
 
-    if(NumVertexPerFacet == 3)
-    {
+    if (NumVertexPerFacet == 3) {
       FacetTag = "triangular";
-    }
-    else if(NumVertexPerFacet == 4)
-    {
+    } else if (NumVertexPerFacet == 4) {
       FacetTag = "quadrangular";
-    }
-    else
-    {
-      G4Exception("GDMLWriteSolids::TessellatedWrite()", "InvalidSetup",
-                  FatalException, "Facet should contain 3 or 4 vertices!");
+    } else {
+      G4Exception("GDMLWriteSolids::TessellatedWrite()", "InvalidSetup", FatalException,
+                  "Facet should contain 3 or 4 vertices!");
     }
 
     xercesc::DOMElement* facetElement = NewElement(FacetTag);
     tessellatedElement->appendChild(facetElement);
 
-    for(std::size_t j = 0; j < NumVertexPerFacet; ++j)
-    {
+    for (std::size_t j = 0; j < NumVertexPerFacet; ++j) {
       std::stringstream name_stream;
       std::stringstream ref_stream;
 
@@ -677,7 +541,7 @@ void GDMLWriteSolids::TessellatedWrite(
       ref_stream << solid_name << "_v" << NumVertex;
 
       const G4String& fname = name_stream.str();  // facet's tag variable
-      G4String ref          = ref_stream.str();   // vertex tag to be associated
+      G4String ref = ref_stream.str();            // vertex tag to be associated
 
       // Now search for the existance of the current vertex in the
       // map of cached vertices. If existing, do NOT store it as
@@ -687,14 +551,13 @@ void GDMLWriteSolids::TessellatedWrite(
 
       const G4ThreeVector& vertex = facet->GetVertex(j);
 
-      if(vertexMap.find(vertex) != vertexMap.cend())  // Vertex is cached
+      if (vertexMap.find(vertex) != vertexMap.cend())  // Vertex is cached
       {
         ref = vertexMap[vertex];  // Set the proper tag for it
-      }
-      else  // Vertex not found
+      } else                      // Vertex not found
       {
         vertexMap.insert(std::make_pair(vertex, ref));  // Cache vertex and ...
-        AddPosition(ref, vertex);  // ... add it to define section!
+        AddPosition(ref, vertex);                       // ... add it to define section!
         ++NumVertex;
       }
 
@@ -706,11 +569,9 @@ void GDMLWriteSolids::TessellatedWrite(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TetWrite(xercesc::DOMElement* solElement,
-                                 const G4Tet* const tet)
-{
+void GDMLWriteSolids::TetWrite(xercesc::DOMElement* solElement, const G4Tet* const tet) {
   const G4String& solid_name = tet->GetName();
-  const G4String& name       = GenerateName(solid_name, tet);
+  const G4String& name = GenerateName(solid_name, tet);
 
   std::vector<G4ThreeVector> vertexList = tet->GetVertices();
 
@@ -730,9 +591,7 @@ void GDMLWriteSolids::TetWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TorusWrite(xercesc::DOMElement* solElement,
-                                   const G4Torus* const torus)
-{
+void GDMLWriteSolids::TorusWrite(xercesc::DOMElement* solElement, const G4Torus* const torus) {
   const G4String& name = GenerateName(torus->GetName(), torus);
 
   xercesc::DOMElement* torusElement = NewElement("torus");
@@ -740,27 +599,22 @@ void GDMLWriteSolids::TorusWrite(xercesc::DOMElement* solElement,
   torusElement->setAttributeNode(NewAttribute("rmin", torus->GetRmin() / mm));
   torusElement->setAttributeNode(NewAttribute("rmax", torus->GetRmax() / mm));
   torusElement->setAttributeNode(NewAttribute("rtor", torus->GetRtor() / mm));
-  torusElement->setAttributeNode(
-    NewAttribute("startphi", torus->GetSPhi() / degree));
-  torusElement->setAttributeNode(
-    NewAttribute("deltaphi", torus->GetDPhi() / degree));
+  torusElement->setAttributeNode(NewAttribute("startphi", torus->GetSPhi() / degree));
+  torusElement->setAttributeNode(NewAttribute("deltaphi", torus->GetDPhi() / degree));
   torusElement->setAttributeNode(NewAttribute("aunit", "deg"));
   torusElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(torusElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::GenTrapWrite(xercesc::DOMElement* solElement,
-                                     const G4GenericTrap* const gtrap)
-{
+void GDMLWriteSolids::GenTrapWrite(xercesc::DOMElement* solElement, const G4GenericTrap* const gtrap) {
   const G4String& name = GenerateName(gtrap->GetName(), gtrap);
 
   std::vector<G4TwoVector> vertices = gtrap->GetVertices();
 
   xercesc::DOMElement* gtrapElement = NewElement("arb8");
   gtrapElement->setAttributeNode(NewAttribute("name", name));
-  gtrapElement->setAttributeNode(
-    NewAttribute("dz", gtrap->GetZHalfLength() / mm));
+  gtrapElement->setAttributeNode(NewAttribute("dz", gtrap->GetZHalfLength() / mm));
   gtrapElement->setAttributeNode(NewAttribute("v1x", vertices[0].x()));
   gtrapElement->setAttributeNode(NewAttribute("v1y", vertices[0].y()));
   gtrapElement->setAttributeNode(NewAttribute("v2x", vertices[1].x()));
@@ -782,36 +636,27 @@ void GDMLWriteSolids::GenTrapWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TrapWrite(xercesc::DOMElement* solElement,
-                                  const G4Trap* const trap)
-{
+void GDMLWriteSolids::TrapWrite(xercesc::DOMElement* solElement, const G4Trap* const trap) {
   const G4String& name = GenerateName(trap->GetName(), trap);
 
   const G4ThreeVector& simaxis = trap->GetSymAxis();
-  const G4double phi           = simaxis.phi();
-  const G4double theta         = simaxis.theta();
-  const G4double alpha1        = std::atan(trap->GetTanAlpha1());
-  const G4double alpha2        = std::atan(trap->GetTanAlpha2());
+  const G4double phi = simaxis.phi();
+  const G4double theta = simaxis.theta();
+  const G4double alpha1 = std::atan(trap->GetTanAlpha1());
+  const G4double alpha2 = std::atan(trap->GetTanAlpha2());
 
   xercesc::DOMElement* trapElement = NewElement("trap");
   trapElement->setAttributeNode(NewAttribute("name", name));
-  trapElement->setAttributeNode(
-    NewAttribute("z", 2.0 * trap->GetZHalfLength() / mm));
+  trapElement->setAttributeNode(NewAttribute("z", 2.0 * trap->GetZHalfLength() / mm));
   trapElement->setAttributeNode(NewAttribute("theta", theta / degree));
   trapElement->setAttributeNode(NewAttribute("phi", phi / degree));
-  trapElement->setAttributeNode(
-    NewAttribute("y1", 2.0 * trap->GetYHalfLength1() / mm));
-  trapElement->setAttributeNode(
-    NewAttribute("x1", 2.0 * trap->GetXHalfLength1() / mm));
-  trapElement->setAttributeNode(
-    NewAttribute("x2", 2.0 * trap->GetXHalfLength2() / mm));
+  trapElement->setAttributeNode(NewAttribute("y1", 2.0 * trap->GetYHalfLength1() / mm));
+  trapElement->setAttributeNode(NewAttribute("x1", 2.0 * trap->GetXHalfLength1() / mm));
+  trapElement->setAttributeNode(NewAttribute("x2", 2.0 * trap->GetXHalfLength2() / mm));
   trapElement->setAttributeNode(NewAttribute("alpha1", alpha1 / degree));
-  trapElement->setAttributeNode(
-    NewAttribute("y2", 2.0 * trap->GetYHalfLength2() / mm));
-  trapElement->setAttributeNode(
-    NewAttribute("x3", 2.0 * trap->GetXHalfLength3() / mm));
-  trapElement->setAttributeNode(
-    NewAttribute("x4", 2.0 * trap->GetXHalfLength4() / mm));
+  trapElement->setAttributeNode(NewAttribute("y2", 2.0 * trap->GetYHalfLength2() / mm));
+  trapElement->setAttributeNode(NewAttribute("x3", 2.0 * trap->GetXHalfLength3() / mm));
+  trapElement->setAttributeNode(NewAttribute("x4", 2.0 * trap->GetXHalfLength4() / mm));
   trapElement->setAttributeNode(NewAttribute("alpha2", alpha2 / degree));
   trapElement->setAttributeNode(NewAttribute("aunit", "deg"));
   trapElement->setAttributeNode(NewAttribute("lunit", "mm"));
@@ -819,136 +664,90 @@ void GDMLWriteSolids::TrapWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TrdWrite(xercesc::DOMElement* solElement,
-                                 const G4Trd* const trd)
-{
+void GDMLWriteSolids::TrdWrite(xercesc::DOMElement* solElement, const G4Trd* const trd) {
   const G4String& name = GenerateName(trd->GetName(), trd);
 
   xercesc::DOMElement* trdElement = NewElement("trd");
   trdElement->setAttributeNode(NewAttribute("name", name));
-  trdElement->setAttributeNode(
-    NewAttribute("x1", 2.0 * trd->GetXHalfLength1() / mm));
-  trdElement->setAttributeNode(
-    NewAttribute("x2", 2.0 * trd->GetXHalfLength2() / mm));
-  trdElement->setAttributeNode(
-    NewAttribute("y1", 2.0 * trd->GetYHalfLength1() / mm));
-  trdElement->setAttributeNode(
-    NewAttribute("y2", 2.0 * trd->GetYHalfLength2() / mm));
-  trdElement->setAttributeNode(
-    NewAttribute("z", 2.0 * trd->GetZHalfLength() / mm));
+  trdElement->setAttributeNode(NewAttribute("x1", 2.0 * trd->GetXHalfLength1() / mm));
+  trdElement->setAttributeNode(NewAttribute("x2", 2.0 * trd->GetXHalfLength2() / mm));
+  trdElement->setAttributeNode(NewAttribute("y1", 2.0 * trd->GetYHalfLength1() / mm));
+  trdElement->setAttributeNode(NewAttribute("y2", 2.0 * trd->GetYHalfLength2() / mm));
+  trdElement->setAttributeNode(NewAttribute("z", 2.0 * trd->GetZHalfLength() / mm));
   trdElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(trdElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TubeWrite(xercesc::DOMElement* solElement,
-                                  const G4Tubs* const tube)
-{
+void GDMLWriteSolids::TubeWrite(xercesc::DOMElement* solElement, const G4Tubs* const tube) {
   const G4String& name = GenerateName(tube->GetName(), tube);
 
   xercesc::DOMElement* tubeElement = NewElement("tube");
   tubeElement->setAttributeNode(NewAttribute("name", name));
-  tubeElement->setAttributeNode(
-    NewAttribute("rmin", tube->GetInnerRadius() / mm));
-  tubeElement->setAttributeNode(
-    NewAttribute("rmax", tube->GetOuterRadius() / mm));
-  tubeElement->setAttributeNode(
-    NewAttribute("z", 2.0 * tube->GetZHalfLength() / mm));
-  tubeElement->setAttributeNode(
-    NewAttribute("startphi", tube->GetStartPhiAngle() / degree));
-  tubeElement->setAttributeNode(
-    NewAttribute("deltaphi", tube->GetDeltaPhiAngle() / degree));
+  tubeElement->setAttributeNode(NewAttribute("rmin", tube->GetInnerRadius() / mm));
+  tubeElement->setAttributeNode(NewAttribute("rmax", tube->GetOuterRadius() / mm));
+  tubeElement->setAttributeNode(NewAttribute("z", 2.0 * tube->GetZHalfLength() / mm));
+  tubeElement->setAttributeNode(NewAttribute("startphi", tube->GetStartPhiAngle() / degree));
+  tubeElement->setAttributeNode(NewAttribute("deltaphi", tube->GetDeltaPhiAngle() / degree));
   tubeElement->setAttributeNode(NewAttribute("aunit", "deg"));
   tubeElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(tubeElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::CutTubeWrite(xercesc::DOMElement* solElement,
-                                     const G4CutTubs* const cuttube)
-{
+void GDMLWriteSolids::CutTubeWrite(xercesc::DOMElement* solElement, const G4CutTubs* const cuttube) {
   const G4String& name = GenerateName(cuttube->GetName(), cuttube);
 
   xercesc::DOMElement* cuttubeElement = NewElement("cutTube");
   cuttubeElement->setAttributeNode(NewAttribute("name", name));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("rmin", cuttube->GetInnerRadius() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("rmax", cuttube->GetOuterRadius() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("z", 2.0 * cuttube->GetZHalfLength() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("startphi", cuttube->GetStartPhiAngle() / degree));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("deltaphi", cuttube->GetDeltaPhiAngle() / degree));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("lowX", cuttube->GetLowNorm().getX() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("lowY", cuttube->GetLowNorm().getY() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("lowZ", cuttube->GetLowNorm().getZ() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("highX", cuttube->GetHighNorm().getX() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("highY", cuttube->GetHighNorm().getY() / mm));
-  cuttubeElement->setAttributeNode(
-    NewAttribute("highZ", cuttube->GetHighNorm().getZ() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("rmin", cuttube->GetInnerRadius() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("rmax", cuttube->GetOuterRadius() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("z", 2.0 * cuttube->GetZHalfLength() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("startphi", cuttube->GetStartPhiAngle() / degree));
+  cuttubeElement->setAttributeNode(NewAttribute("deltaphi", cuttube->GetDeltaPhiAngle() / degree));
+  cuttubeElement->setAttributeNode(NewAttribute("lowX", cuttube->GetLowNorm().getX() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("lowY", cuttube->GetLowNorm().getY() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("lowZ", cuttube->GetLowNorm().getZ() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("highX", cuttube->GetHighNorm().getX() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("highY", cuttube->GetHighNorm().getY() / mm));
+  cuttubeElement->setAttributeNode(NewAttribute("highZ", cuttube->GetHighNorm().getZ() / mm));
   cuttubeElement->setAttributeNode(NewAttribute("aunit", "deg"));
   cuttubeElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(cuttubeElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TwistedboxWrite(xercesc::DOMElement* solElement,
-                                        const G4TwistedBox* const twistedbox)
-{
+void GDMLWriteSolids::TwistedboxWrite(xercesc::DOMElement* solElement, const G4TwistedBox* const twistedbox) {
   const G4String& name = GenerateName(twistedbox->GetName(), twistedbox);
 
   xercesc::DOMElement* twistedboxElement = NewElement("twistedbox");
   twistedboxElement->setAttributeNode(NewAttribute("name", name));
-  twistedboxElement->setAttributeNode(
-    NewAttribute("x", 2.0 * twistedbox->GetXHalfLength() / mm));
-  twistedboxElement->setAttributeNode(
-    NewAttribute("y", 2.0 * twistedbox->GetYHalfLength() / mm));
-  twistedboxElement->setAttributeNode(
-    NewAttribute("z", 2.0 * twistedbox->GetZHalfLength() / mm));
-  twistedboxElement->setAttributeNode(
-    NewAttribute("PhiTwist", twistedbox->GetPhiTwist() / degree));
+  twistedboxElement->setAttributeNode(NewAttribute("x", 2.0 * twistedbox->GetXHalfLength() / mm));
+  twistedboxElement->setAttributeNode(NewAttribute("y", 2.0 * twistedbox->GetYHalfLength() / mm));
+  twistedboxElement->setAttributeNode(NewAttribute("z", 2.0 * twistedbox->GetZHalfLength() / mm));
+  twistedboxElement->setAttributeNode(NewAttribute("PhiTwist", twistedbox->GetPhiTwist() / degree));
   twistedboxElement->setAttributeNode(NewAttribute("aunit", "deg"));
   twistedboxElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(twistedboxElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TwistedtrapWrite(xercesc::DOMElement* solElement,
-                                         const G4TwistedTrap* const twistedtrap)
-{
+void GDMLWriteSolids::TwistedtrapWrite(xercesc::DOMElement* solElement, const G4TwistedTrap* const twistedtrap) {
   const G4String& name = GenerateName(twistedtrap->GetName(), twistedtrap);
 
   xercesc::DOMElement* twistedtrapElement = NewElement("twistedtrap");
   twistedtrapElement->setAttributeNode(NewAttribute("name", name));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("y1", 2.0 * twistedtrap->GetY1HalfLength() / mm));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("x1", 2.0 * twistedtrap->GetX1HalfLength() / mm));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("x2", 2.0 * twistedtrap->GetX2HalfLength() / mm));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("y2", 2.0 * twistedtrap->GetY2HalfLength() / mm));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("x3", 2.0 * twistedtrap->GetX3HalfLength() / mm));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("x4", 2.0 * twistedtrap->GetX4HalfLength() / mm));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("z", 2.0 * twistedtrap->GetZHalfLength() / mm));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("Alph", twistedtrap->GetTiltAngleAlpha() / degree));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("Theta", twistedtrap->GetPolarAngleTheta() / degree));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("Phi", twistedtrap->GetAzimuthalAnglePhi() / degree));
-  twistedtrapElement->setAttributeNode(
-    NewAttribute("PhiTwist", twistedtrap->GetPhiTwist() / degree));
+  twistedtrapElement->setAttributeNode(NewAttribute("y1", 2.0 * twistedtrap->GetY1HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(NewAttribute("x1", 2.0 * twistedtrap->GetX1HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(NewAttribute("x2", 2.0 * twistedtrap->GetX2HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(NewAttribute("y2", 2.0 * twistedtrap->GetY2HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(NewAttribute("x3", 2.0 * twistedtrap->GetX3HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(NewAttribute("x4", 2.0 * twistedtrap->GetX4HalfLength() / mm));
+  twistedtrapElement->setAttributeNode(NewAttribute("z", 2.0 * twistedtrap->GetZHalfLength() / mm));
+  twistedtrapElement->setAttributeNode(NewAttribute("Alph", twistedtrap->GetTiltAngleAlpha() / degree));
+  twistedtrapElement->setAttributeNode(NewAttribute("Theta", twistedtrap->GetPolarAngleTheta() / degree));
+  twistedtrapElement->setAttributeNode(NewAttribute("Phi", twistedtrap->GetAzimuthalAnglePhi() / degree));
+  twistedtrapElement->setAttributeNode(NewAttribute("PhiTwist", twistedtrap->GetPhiTwist() / degree));
   twistedtrapElement->setAttributeNode(NewAttribute("aunit", "deg"));
   twistedtrapElement->setAttributeNode(NewAttribute("lunit", "mm"));
 
@@ -956,70 +755,52 @@ void GDMLWriteSolids::TwistedtrapWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TwistedtrdWrite(xercesc::DOMElement* solElement,
-                                        const G4TwistedTrd* const twistedtrd)
-{
+void GDMLWriteSolids::TwistedtrdWrite(xercesc::DOMElement* solElement, const G4TwistedTrd* const twistedtrd) {
   const G4String& name = GenerateName(twistedtrd->GetName(), twistedtrd);
 
   xercesc::DOMElement* twistedtrdElement = NewElement("twistedtrd");
   twistedtrdElement->setAttributeNode(NewAttribute("name", name));
-  twistedtrdElement->setAttributeNode(
-    NewAttribute("x1", 2.0 * twistedtrd->GetX1HalfLength() / mm));
-  twistedtrdElement->setAttributeNode(
-    NewAttribute("x2", 2.0 * twistedtrd->GetX2HalfLength() / mm));
-  twistedtrdElement->setAttributeNode(
-    NewAttribute("y1", 2.0 * twistedtrd->GetY1HalfLength() / mm));
-  twistedtrdElement->setAttributeNode(
-    NewAttribute("y2", 2.0 * twistedtrd->GetY2HalfLength() / mm));
-  twistedtrdElement->setAttributeNode(
-    NewAttribute("z", 2.0 * twistedtrd->GetZHalfLength() / mm));
-  twistedtrdElement->setAttributeNode(
-    NewAttribute("PhiTwist", twistedtrd->GetPhiTwist() / degree));
+  twistedtrdElement->setAttributeNode(NewAttribute("x1", 2.0 * twistedtrd->GetX1HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(NewAttribute("x2", 2.0 * twistedtrd->GetX2HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(NewAttribute("y1", 2.0 * twistedtrd->GetY1HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(NewAttribute("y2", 2.0 * twistedtrd->GetY2HalfLength() / mm));
+  twistedtrdElement->setAttributeNode(NewAttribute("z", 2.0 * twistedtrd->GetZHalfLength() / mm));
+  twistedtrdElement->setAttributeNode(NewAttribute("PhiTwist", twistedtrd->GetPhiTwist() / degree));
   twistedtrdElement->setAttributeNode(NewAttribute("aunit", "deg"));
   twistedtrdElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(twistedtrdElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::TwistedtubsWrite(xercesc::DOMElement* solElement,
-                                         const G4TwistedTubs* const twistedtubs)
-{
+void GDMLWriteSolids::TwistedtubsWrite(xercesc::DOMElement* solElement, const G4TwistedTubs* const twistedtubs) {
   const G4String& name = GenerateName(twistedtubs->GetName(), twistedtubs);
 
   xercesc::DOMElement* twistedtubsElement = NewElement("twistedtubs");
   twistedtubsElement->setAttributeNode(NewAttribute("name", name));
-  twistedtubsElement->setAttributeNode(
-    NewAttribute("twistedangle", twistedtubs->GetPhiTwist() / degree));
-  twistedtubsElement->setAttributeNode(
-    NewAttribute("midinnerrad", twistedtubs->GetInnerRadius() / mm));
-  twistedtubsElement->setAttributeNode(
-    NewAttribute("midouterrad", twistedtubs->GetOuterRadius() / mm));
-  twistedtubsElement->setAttributeNode(
-    NewAttribute("negativeEndz", twistedtubs->GetEndZ(0) / mm));
-  twistedtubsElement->setAttributeNode(
-    NewAttribute("positiveEndz", twistedtubs->GetEndZ(1) / mm));
-  twistedtubsElement->setAttributeNode(
-    NewAttribute("phi", twistedtubs->GetDPhi() / degree));
+  twistedtubsElement->setAttributeNode(NewAttribute("twistedangle", twistedtubs->GetPhiTwist() / degree));
+  twistedtubsElement->setAttributeNode(NewAttribute("midinnerrad", twistedtubs->GetInnerRadius() / mm));
+  twistedtubsElement->setAttributeNode(NewAttribute("midouterrad", twistedtubs->GetOuterRadius() / mm));
+  twistedtubsElement->setAttributeNode(NewAttribute("negativeEndz", twistedtubs->GetEndZ(0) / mm));
+  twistedtubsElement->setAttributeNode(NewAttribute("positiveEndz", twistedtubs->GetEndZ(1) / mm));
+  twistedtubsElement->setAttributeNode(NewAttribute("phi", twistedtubs->GetDPhi() / degree));
   twistedtubsElement->setAttributeNode(NewAttribute("aunit", "deg"));
   twistedtubsElement->setAttributeNode(NewAttribute("lunit", "mm"));
   solElement->appendChild(twistedtubsElement);
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::GLG4TorusStackWrite(xercesc::DOMElement* solElement,
-                                       const GLG4TorusStack* const torusStack)
-{
+void GDMLWriteSolids::GLG4TorusStackWrite(xercesc::DOMElement* solElement, const GLG4TorusStack* const torusStack) {
   const G4String& name = GenerateName(torusStack->GetName(), torusStack);
   xercesc::DOMElement* torusStackElement = NewElement("torusstack");
   torusStackElement->setAttributeNode(NewAttribute("name", name));
   torusStackElement->setAttributeNode(NewAttribute("lunit", "mm"));
   int n_segments = torusStack->GetN();
-  for(int i = 0; i < n_segments+1; i++){
+  for (int i = 0; i < n_segments + 1; i++) {
     xercesc::DOMElement* edgeElement = NewElement("edge");
     edgeElement->setAttributeNode(NewAttribute("z", torusStack->GetZEdge(i) / mm));
     edgeElement->setAttributeNode(NewAttribute("rho", torusStack->GetRhoEdge(i) / mm));
     torusStackElement->appendChild(edgeElement);
-    if (i < n_segments){
+    if (i < n_segments) {
       xercesc::DOMElement* originElement = NewElement("origin");
       originElement->setAttributeNode(NewAttribute("z", torusStack->GetZo(i) / mm));
       originElement->setAttributeNode(NewAttribute("rho", torusStack->GetA(i) / mm));
@@ -1036,10 +817,8 @@ void GDMLWriteSolids::GLG4TorusStackWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::ZplaneWrite(xercesc::DOMElement* element,
-                                    const G4double& z, const G4double& rmin,
-                                    const G4double& rmax)
-{
+void GDMLWriteSolids::ZplaneWrite(xercesc::DOMElement* element, const G4double& z, const G4double& rmin,
+                                  const G4double& rmax) {
   xercesc::DOMElement* zplaneElement = NewElement("zplane");
   zplaneElement->setAttributeNode(NewAttribute("z", z / mm));
   zplaneElement->setAttributeNode(NewAttribute("rmin", rmin / mm));
@@ -1048,9 +827,7 @@ void GDMLWriteSolids::ZplaneWrite(xercesc::DOMElement* element,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::RZPointWrite(xercesc::DOMElement* element,
-                                     const G4double& r, const G4double& z)
-{
+void GDMLWriteSolids::RZPointWrite(xercesc::DOMElement* element, const G4double& r, const G4double& z) {
   xercesc::DOMElement* rzpointElement = NewElement("rzpoint");
   rzpointElement->setAttributeNode(NewAttribute("r", r / mm));
   rzpointElement->setAttributeNode(NewAttribute("z", z / mm));
@@ -1058,13 +835,10 @@ void GDMLWriteSolids::RZPointWrite(xercesc::DOMElement* element,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::OpticalSurfaceWrite(xercesc::DOMElement* solElement,
-                                            const G4OpticalSurface* const surf)
-{
+void GDMLWriteSolids::OpticalSurfaceWrite(xercesc::DOMElement* solElement, const G4OpticalSurface* const surf) {
   xercesc::DOMElement* optElement = NewElement("opticalsurface");
-  G4OpticalSurfaceModel smodel    = surf->GetModel();
-  G4double sval =
-    (smodel == glisur) ? surf->GetPolish() : surf->GetSigmaAlpha();
+  G4OpticalSurfaceModel smodel = surf->GetModel();
+  G4double sval = (smodel == glisur) ? surf->GetPolish() : surf->GetSigmaAlpha();
   const G4String& name = GenerateName(surf->GetName(), surf);
 
   optElement->setAttributeNode(NewAttribute("name", name));
@@ -1075,8 +849,7 @@ void GDMLWriteSolids::OpticalSurfaceWrite(xercesc::DOMElement* solElement,
 
   // Write any property attached to the optical surface...
   //
-  if(surf->GetMaterialPropertiesTable())
-  {
+  if (surf->GetMaterialPropertiesTable()) {
     PropertyWrite(optElement, surf);
   }
 
@@ -1084,39 +857,28 @@ void GDMLWriteSolids::OpticalSurfaceWrite(xercesc::DOMElement* solElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::PropertyWrite(xercesc::DOMElement* optElement,
-                                      const G4OpticalSurface* const surf)
-{
+void GDMLWriteSolids::PropertyWrite(xercesc::DOMElement* optElement, const G4OpticalSurface* const surf) {
   xercesc::DOMElement* propElement;
   G4MaterialPropertiesTable* ptable = surf->GetMaterialPropertiesTable();
   auto pvec = ptable->GetProperties();
   auto cvec = ptable->GetConstProperties();
 
-  for(size_t i = 0; i < pvec.size(); ++i)
-  {
-    if(pvec[i] != nullptr) {
+  for (size_t i = 0; i < pvec.size(); ++i) {
+    if (pvec[i] != nullptr) {
       propElement = NewElement("property");
-      propElement->setAttributeNode(
-        NewAttribute("name", ptable->GetMaterialPropertyNames()[i]));
-      propElement->setAttributeNode(NewAttribute(
-        "ref", GenerateName(ptable->GetMaterialPropertyNames()[i],
-                            pvec[i])));
-      PropertyVectorWrite(ptable->GetMaterialPropertyNames()[i],
-                          pvec[i]);
+      propElement->setAttributeNode(NewAttribute("name", ptable->GetMaterialPropertyNames()[i]));
+      propElement->setAttributeNode(NewAttribute("ref", GenerateName(ptable->GetMaterialPropertyNames()[i], pvec[i])));
+      PropertyVectorWrite(ptable->GetMaterialPropertyNames()[i], pvec[i]);
       optElement->appendChild(propElement);
     }
   }
-  for(size_t i = 0; i < cvec.size(); ++i)
-  {
+  for (size_t i = 0; i < cvec.size(); ++i) {
     if (cvec[i].second == true) {
       propElement = NewElement("property");
-      propElement->setAttributeNode(NewAttribute(
-        "name", ptable->GetMaterialConstPropertyNames()[i]));
-      propElement->setAttributeNode(NewAttribute(
-        "ref", ptable->GetMaterialConstPropertyNames()[i]));
+      propElement->setAttributeNode(NewAttribute("name", ptable->GetMaterialConstPropertyNames()[i]));
+      propElement->setAttributeNode(NewAttribute("ref", ptable->GetMaterialConstPropertyNames()[i]));
       xercesc::DOMElement* constElement = NewElement("constant");
-      constElement->setAttributeNode(NewAttribute(
-        "name", ptable->GetMaterialConstPropertyNames()[i]));
+      constElement->setAttributeNode(NewAttribute("name", ptable->GetMaterialConstPropertyNames()[i]));
       constElement->setAttributeNode(NewAttribute("value", cvec[i].first));
       defineElement->appendChild(constElement);
       optElement->appendChild(propElement);
@@ -1125,8 +887,7 @@ void GDMLWriteSolids::PropertyWrite(xercesc::DOMElement* optElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::SolidsWrite(xercesc::DOMElement* gdmlElement)
-{
+void GDMLWriteSolids::SolidsWrite(xercesc::DOMElement* gdmlElement) {
 #ifdef G4VERBOSE
   G4cout << "G4GDML: Writing solids..." << G4endl;
 #endif
@@ -1137,190 +898,107 @@ void GDMLWriteSolids::SolidsWrite(xercesc::DOMElement* gdmlElement)
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteSolids::AddSolid(const G4VSolid* const solidPtr)
-{
-  for(std::size_t i = 0; i < solidList.size(); ++i)  // Check if solid is
-  {                                                  // already in the list!
-    if(solidList[i] == solidPtr)
-    {
+void GDMLWriteSolids::AddSolid(const G4VSolid* const solidPtr) {
+  for (std::size_t i = 0; i < solidList.size(); ++i)  // Check if solid is
+  {                                                   // already in the list!
+    if (solidList[i] == solidPtr) {
       return;
     }
   }
 
   solidList.push_back(solidPtr);
 
-  if(const G4BooleanSolid* const booleanPtr =
-       dynamic_cast<const G4BooleanSolid*>(solidPtr))
-  {
+  if (const G4BooleanSolid* const booleanPtr = dynamic_cast<const G4BooleanSolid*>(solidPtr)) {
     BooleanWrite(solidsElement, booleanPtr);
-  }
-  else if(const G4ScaledSolid* const scaledPtr =
-            dynamic_cast<const G4ScaledSolid*>(solidPtr))
-  {
+  } else if (const G4ScaledSolid* const scaledPtr = dynamic_cast<const G4ScaledSolid*>(solidPtr)) {
     ScaledWrite(solidsElement, scaledPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4MultiUnion")
-  {
-    const G4MultiUnion* const munionPtr =
-      static_cast<const G4MultiUnion*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4MultiUnion") {
+    const G4MultiUnion* const munionPtr = static_cast<const G4MultiUnion*>(solidPtr);
     MultiUnionWrite(solidsElement, munionPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Box")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Box") {
     const G4Box* const boxPtr = static_cast<const G4Box*>(solidPtr);
     BoxWrite(solidsElement, boxPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Cons")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Cons") {
     const G4Cons* const conePtr = static_cast<const G4Cons*>(solidPtr);
     ConeWrite(solidsElement, conePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4EllipticalCone")
-  {
-    const G4EllipticalCone* const elconePtr =
-      static_cast<const G4EllipticalCone*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4EllipticalCone") {
+    const G4EllipticalCone* const elconePtr = static_cast<const G4EllipticalCone*>(solidPtr);
     ElconeWrite(solidsElement, elconePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Ellipsoid")
-  {
-    const G4Ellipsoid* const ellipsoidPtr =
-      static_cast<const G4Ellipsoid*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4Ellipsoid") {
+    const G4Ellipsoid* const ellipsoidPtr = static_cast<const G4Ellipsoid*>(solidPtr);
     EllipsoidWrite(solidsElement, ellipsoidPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4EllipticalTube")
-  {
-    const G4EllipticalTube* const eltubePtr =
-      static_cast<const G4EllipticalTube*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4EllipticalTube") {
+    const G4EllipticalTube* const eltubePtr = static_cast<const G4EllipticalTube*>(solidPtr);
     EltubeWrite(solidsElement, eltubePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4ExtrudedSolid")
-  {
-    const G4ExtrudedSolid* const xtruPtr =
-      static_cast<const G4ExtrudedSolid*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4ExtrudedSolid") {
+    const G4ExtrudedSolid* const xtruPtr = static_cast<const G4ExtrudedSolid*>(solidPtr);
     XtruWrite(solidsElement, xtruPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Hype")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Hype") {
     const G4Hype* const hypePtr = static_cast<const G4Hype*>(solidPtr);
     HypeWrite(solidsElement, hypePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Orb")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Orb") {
     const G4Orb* const orbPtr = static_cast<const G4Orb*>(solidPtr);
     OrbWrite(solidsElement, orbPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Para")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Para") {
     const G4Para* const paraPtr = static_cast<const G4Para*>(solidPtr);
     ParaWrite(solidsElement, paraPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Paraboloid")
-  {
-    const G4Paraboloid* const paraboloidPtr =
-      static_cast<const G4Paraboloid*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4Paraboloid") {
+    const G4Paraboloid* const paraboloidPtr = static_cast<const G4Paraboloid*>(solidPtr);
     ParaboloidWrite(solidsElement, paraboloidPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Polycone")
-  {
-    const G4Polycone* const polyconePtr =
-      static_cast<const G4Polycone*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4Polycone") {
+    const G4Polycone* const polyconePtr = static_cast<const G4Polycone*>(solidPtr);
     PolyconeWrite(solidsElement, polyconePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4GenericPolycone")
-  {
-    const G4GenericPolycone* const genpolyconePtr =
-      static_cast<const G4GenericPolycone*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4GenericPolycone") {
+    const G4GenericPolycone* const genpolyconePtr = static_cast<const G4GenericPolycone*>(solidPtr);
     GenericPolyconeWrite(solidsElement, genpolyconePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Polyhedra")
-  {
-    const G4Polyhedra* const polyhedraPtr =
-      static_cast<const G4Polyhedra*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4Polyhedra") {
+    const G4Polyhedra* const polyhedraPtr = static_cast<const G4Polyhedra*>(solidPtr);
     PolyhedraWrite(solidsElement, polyhedraPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Sphere")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Sphere") {
     const G4Sphere* const spherePtr = static_cast<const G4Sphere*>(solidPtr);
     SphereWrite(solidsElement, spherePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4TessellatedSolid")
-  {
-    const G4TessellatedSolid* const tessellatedPtr =
-      static_cast<const G4TessellatedSolid*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4TessellatedSolid") {
+    const G4TessellatedSolid* const tessellatedPtr = static_cast<const G4TessellatedSolid*>(solidPtr);
     TessellatedWrite(solidsElement, tessellatedPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Tet")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Tet") {
     const G4Tet* const tetPtr = static_cast<const G4Tet*>(solidPtr);
     TetWrite(solidsElement, tetPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Torus")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Torus") {
     const G4Torus* const torusPtr = static_cast<const G4Torus*>(solidPtr);
     TorusWrite(solidsElement, torusPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4GenericTrap")
-  {
-    const G4GenericTrap* const gtrapPtr =
-      static_cast<const G4GenericTrap*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4GenericTrap") {
+    const G4GenericTrap* const gtrapPtr = static_cast<const G4GenericTrap*>(solidPtr);
     GenTrapWrite(solidsElement, gtrapPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Trap")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Trap") {
     const G4Trap* const trapPtr = static_cast<const G4Trap*>(solidPtr);
     TrapWrite(solidsElement, trapPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Trd")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Trd") {
     const G4Trd* const trdPtr = static_cast<const G4Trd*>(solidPtr);
     TrdWrite(solidsElement, trdPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4Tubs")
-  {
+  } else if (solidPtr->GetEntityType() == "G4Tubs") {
     const G4Tubs* const tubePtr = static_cast<const G4Tubs*>(solidPtr);
     TubeWrite(solidsElement, tubePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4CutTubs")
-  {
+  } else if (solidPtr->GetEntityType() == "G4CutTubs") {
     const G4CutTubs* const cuttubePtr = static_cast<const G4CutTubs*>(solidPtr);
     CutTubeWrite(solidsElement, cuttubePtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4TwistedBox")
-  {
-    const G4TwistedBox* const twistedboxPtr =
-      static_cast<const G4TwistedBox*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4TwistedBox") {
+    const G4TwistedBox* const twistedboxPtr = static_cast<const G4TwistedBox*>(solidPtr);
     TwistedboxWrite(solidsElement, twistedboxPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4TwistedTrap")
-  {
-    const G4TwistedTrap* const twistedtrapPtr =
-      static_cast<const G4TwistedTrap*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4TwistedTrap") {
+    const G4TwistedTrap* const twistedtrapPtr = static_cast<const G4TwistedTrap*>(solidPtr);
     TwistedtrapWrite(solidsElement, twistedtrapPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4TwistedTrd")
-  {
-    const G4TwistedTrd* const twistedtrdPtr =
-      static_cast<const G4TwistedTrd*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4TwistedTrd") {
+    const G4TwistedTrd* const twistedtrdPtr = static_cast<const G4TwistedTrd*>(solidPtr);
     TwistedtrdWrite(solidsElement, twistedtrdPtr);
-  }
-  else if(solidPtr->GetEntityType() == "G4TwistedTubs")
-  {
-    const G4TwistedTubs* const twistedtubsPtr =
-      static_cast<const G4TwistedTubs*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "G4TwistedTubs") {
+    const G4TwistedTubs* const twistedtubsPtr = static_cast<const G4TwistedTubs*>(solidPtr);
     TwistedtubsWrite(solidsElement, twistedtubsPtr);
-  }
-  else if(solidPtr->GetEntityType() == "GLG4TorusStack")
-  {
-    const GLG4TorusStack* const torusStack =
-      static_cast<const GLG4TorusStack*>(solidPtr);
+  } else if (solidPtr->GetEntityType() == "GLG4TorusStack") {
+    const GLG4TorusStack* const torusStack = static_cast<const GLG4TorusStack*>(solidPtr);
     GLG4TorusStackWrite(solidsElement, torusStack);
-  }
-  else
-  {
-    G4String error_msg = "Unknown solid: " + solidPtr->GetName() +
-                         "; Type: " + solidPtr->GetEntityType();
-    G4Exception("GDMLWriteSolids::AddSolid()", "WriteError", FatalException,
-                error_msg);
+  } else {
+    G4String error_msg = "Unknown solid: " + solidPtr->GetName() + "; Type: " + solidPtr->GetEntityType();
+    G4Exception("GDMLWriteSolids::AddSolid()", "WriteError", FatalException, error_msg);
   }
 }
-}
+}  // namespace RAT

--- a/src/geo/src/gdml/GDMLWriteSolids.cc
+++ b/src/geo/src/gdml/GDMLWriteSolids.cc
@@ -852,6 +852,42 @@ void GDMLWriteSolids::OpticalSurfaceWrite(xercesc::DOMElement* solElement, const
   if (surf->GetMaterialPropertiesTable()) {
     PropertyWrite(optElement, surf);
   }
+  const G4Physics2DVector* const dichroic_vector = const_cast<G4OpticalSurface*>(surf)->GetDichroicVector();
+  xercesc::DOMElement* propElement;
+  if (dichroic_vector) {
+    propElement = NewElement("dichroic_data");
+    size_t length_x = dichroic_vector->GetLengthX();
+    size_t length_y = dichroic_vector->GetLengthY();
+    propElement->setAttributeNode(NewAttribute("x_length", length_x));
+    propElement->setAttributeNode(NewAttribute("y_length", length_y));
+    xercesc::DOMElement* x_element = NewElement("x");
+    xercesc::DOMElement* y_element = NewElement("y");
+    std::ostringstream xvalues;
+    std::ostringstream yvalues;
+    for (size_t i = 0; i < length_x; i++) {
+      if (i != 0) xvalues << " ";
+      xvalues << dichroic_vector->GetX(i);
+    }
+    x_element->setAttributeNode(NewAttribute("values", xvalues.str()));
+    for (size_t i = 0; i < length_y; i++) {
+      if (i != 0) yvalues << " ";
+      yvalues << dichroic_vector->GetY(i);
+    }
+    y_element->setAttributeNode(NewAttribute("values", yvalues.str()));
+    propElement->appendChild(x_element);
+    propElement->appendChild(y_element);
+    xercesc::DOMElement* data = NewElement("data");
+    std::ostringstream data_values;
+    for (size_t i = 0; i < length_x; i++) {
+      for (size_t j = 0; j < length_y; j++) {
+        if (i != 0 || j != 0) data_values << " ";
+        data_values << dichroic_vector->GetValue(i, j);
+      }
+    }
+    data->setAttributeNode(NewAttribute("values", data_values.str()));
+    propElement->appendChild(data);
+    optElement->appendChild(propElement);
+  }
 
   solElement->appendChild(optElement);
 }

--- a/src/geo/src/gdml/GDMLWriteStructure.cc
+++ b/src/geo/src/gdml/GDMLWriteStructure.cc
@@ -1,0 +1,894 @@
+#include "RAT/GDMLWriteStructure.hh"
+#include "G4GDMLEvaluator.hh"
+
+#include "G4Material.hh"
+#include "G4ReflectedSolid.hh"
+#include "G4DisplacedSolid.hh"
+#include "G4LogicalVolumeStore.hh"
+#include "G4PhysicalVolumeStore.hh"
+#include "G4ReflectionFactory.hh"
+#include "G4PVDivision.hh"
+#include "G4PVReplica.hh"
+#include "G4Region.hh"
+#include "G4OpticalSurface.hh"
+#include "G4LogicalSkinSurface.hh"
+#include "G4LogicalBorderSurface.hh"
+
+#include "G4ProductionCuts.hh"
+#include "G4ProductionCutsTable.hh"
+#include "G4Gamma.hh"
+#include "G4Electron.hh"
+#include "G4Positron.hh"
+#include "G4Proton.hh"
+
+#include "G4VSensitiveDetector.hh"
+#include "G4AssemblyStore.hh"
+#include "G4AssemblyVolume.hh"
+
+namespace RAT {
+
+G4int GDMLWriteStructure::levelNo = 0;  // Counter for level being exported
+
+// --------------------------------------------------------------------
+GDMLWriteStructure::GDMLWriteStructure()
+  : GDMLWriteParamvol()
+  , maxLevel(INT_MAX)
+{
+  reflFactory = G4ReflectionFactory::Instance();
+}
+
+// --------------------------------------------------------------------
+GDMLWriteStructure::~GDMLWriteStructure()
+{
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::DivisionvolWrite(
+  xercesc::DOMElement* volumeElement, const G4PVDivision* const divisionvol)
+{
+  EAxis axis       = kUndefined;
+  G4int number     = 0;
+  G4double width   = 0.0;
+  G4double offset  = 0.0;
+  G4bool consuming = false;
+
+  divisionvol->GetReplicationData(axis, number, width, offset, consuming);
+  axis = divisionvol->GetDivisionAxis();
+
+  G4String unitString("mm");
+  G4String axisString("kUndefined");
+  if(axis == kXAxis)
+  {
+    axisString = "kXAxis";
+  }
+  else if(axis == kYAxis)
+  {
+    axisString = "kYAxis";
+  }
+  else if(axis == kZAxis)
+  {
+    axisString = "kZAxis";
+  }
+  else if(axis == kRho)
+  {
+    axisString = "kRho";
+  }
+  else if(axis == kPhi)
+  {
+    axisString = "kPhi";
+    unitString = "rad";
+  }
+
+  const G4String name = GenerateName(divisionvol->GetName(), divisionvol);
+  const G4String volumeref =
+    GenerateName(divisionvol->GetLogicalVolume()->GetName(),
+                 divisionvol->GetLogicalVolume());
+
+  xercesc::DOMElement* divisionvolElement = NewElement("divisionvol");
+  divisionvolElement->setAttributeNode(NewAttribute("axis", axisString));
+  divisionvolElement->setAttributeNode(NewAttribute("number", number));
+  divisionvolElement->setAttributeNode(NewAttribute("width", width));
+  divisionvolElement->setAttributeNode(NewAttribute("offset", offset));
+  divisionvolElement->setAttributeNode(NewAttribute("unit", unitString));
+  xercesc::DOMElement* volumerefElement = NewElement("volumeref");
+  volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
+  divisionvolElement->appendChild(volumerefElement);
+  volumeElement->appendChild(divisionvolElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::PhysvolWrite(xercesc::DOMElement* volumeElement,
+                                        const G4VPhysicalVolume* const physvol,
+                                        const G4Transform3D& T,
+                                        const G4String& ModuleName)
+{
+  HepGeom::Scale3D scale;
+  HepGeom::Rotate3D rotate;
+  HepGeom::Translate3D translate;
+
+  T.getDecomposition(scale, rotate, translate);
+
+  const G4ThreeVector scl(scale(0, 0), scale(1, 1), scale(2, 2));
+  const G4ThreeVector rot = GetAngles(rotate.getRotation());
+  const G4ThreeVector pos = T.getTranslation();
+
+  const G4String name    = GenerateName(physvol->GetName(), physvol);
+  const G4int copynumber = physvol->GetCopyNo();
+
+  xercesc::DOMElement* physvolElement = NewElement("physvol");
+  physvolElement->setAttributeNode(NewAttribute("name", name));
+  if(copynumber)
+  {
+    physvolElement->setAttributeNode(NewAttribute("copynumber", copynumber));
+  }
+
+  volumeElement->appendChild(physvolElement);
+
+  G4LogicalVolume* lv;
+  // Is it reflected?
+  if(reflFactory->IsReflected(physvol->GetLogicalVolume()))
+  {
+    lv = reflFactory->GetConstituentLV(physvol->GetLogicalVolume());
+  }
+  else
+  {
+    lv = physvol->GetLogicalVolume();
+  }
+
+  const G4String volumeref = GenerateName(lv->GetName(), lv);
+
+  if(ModuleName.empty())
+  {
+    xercesc::DOMElement* volumerefElement = NewElement("volumeref");
+    volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
+    physvolElement->appendChild(volumerefElement);
+  }
+  else
+  {
+    xercesc::DOMElement* fileElement = NewElement("file");
+    fileElement->setAttributeNode(NewAttribute("name", ModuleName));
+    fileElement->setAttributeNode(NewAttribute("volname", volumeref));
+    physvolElement->appendChild(fileElement);
+  }
+
+  if(std::fabs(pos.x()) > kLinearPrecision ||
+     std::fabs(pos.y()) > kLinearPrecision ||
+     std::fabs(pos.z()) > kLinearPrecision)
+  {
+    PositionWrite(physvolElement, name + "_pos", pos);
+  }
+  if(std::fabs(rot.x()) > kAngularPrecision ||
+     std::fabs(rot.y()) > kAngularPrecision ||
+     std::fabs(rot.z()) > kAngularPrecision)
+  {
+    RotationWrite(physvolElement, name + "_rot", rot);
+  }
+  if(std::fabs(scl.x() - 1.0) > kRelativePrecision ||
+     std::fabs(scl.y() - 1.0) > kRelativePrecision ||
+     std::fabs(scl.z() - 1.0) > kRelativePrecision)
+  {
+    ScaleWrite(physvolElement, name + "_scl", scl);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::ReplicavolWrite(
+  xercesc::DOMElement* volumeElement, const G4VPhysicalVolume* const replicavol)
+{
+  EAxis axis       = kUndefined;
+  G4int number     = 0;
+  G4double width   = 0.0;
+  G4double offset  = 0.0;
+  G4bool consuming = false;
+  G4String unitString("mm");
+
+  replicavol->GetReplicationData(axis, number, width, offset, consuming);
+
+  const G4String volumeref = GenerateName(
+    replicavol->GetLogicalVolume()->GetName(), replicavol->GetLogicalVolume());
+
+  xercesc::DOMElement* replicavolElement = NewElement("replicavol");
+  replicavolElement->setAttributeNode(NewAttribute("number", number));
+  xercesc::DOMElement* volumerefElement = NewElement("volumeref");
+  volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
+  replicavolElement->appendChild(volumerefElement);
+  xercesc::DOMElement* replicateElement = NewElement("replicate_along_axis");
+  replicavolElement->appendChild(replicateElement);
+
+  xercesc::DOMElement* dirElement = NewElement("direction");
+  if(axis == kXAxis)
+  {
+    dirElement->setAttributeNode(NewAttribute("x", "1"));
+  }
+  else if(axis == kYAxis)
+  {
+    dirElement->setAttributeNode(NewAttribute("y", "1"));
+  }
+  else if(axis == kZAxis)
+  {
+    dirElement->setAttributeNode(NewAttribute("z", "1"));
+  }
+  else if(axis == kRho)
+  {
+    dirElement->setAttributeNode(NewAttribute("rho", "1"));
+  }
+  else if(axis == kPhi)
+  {
+    dirElement->setAttributeNode(NewAttribute("phi", "1"));
+    unitString = "rad";
+  }
+  replicateElement->appendChild(dirElement);
+
+  xercesc::DOMElement* widthElement = NewElement("width");
+  widthElement->setAttributeNode(NewAttribute("value", width));
+  widthElement->setAttributeNode(NewAttribute("unit", unitString));
+  replicateElement->appendChild(widthElement);
+
+  xercesc::DOMElement* offsetElement = NewElement("offset");
+  offsetElement->setAttributeNode(NewAttribute("value", offset));
+  offsetElement->setAttributeNode(NewAttribute("unit", unitString));
+  replicateElement->appendChild(offsetElement);
+
+  volumeElement->appendChild(replicavolElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::AssemblyWrite(xercesc::DOMElement* volumeElement,
+                                         const G4int assemblyID)
+{
+  G4AssemblyStore* assemblies  = G4AssemblyStore::GetInstance();
+  G4AssemblyVolume* myassembly = assemblies->GetAssembly(assemblyID);
+
+  xercesc::DOMElement* assemblyElement = NewElement("assembly");
+  G4String name = "Assembly_" + std::to_string(assemblyID);
+
+  assemblyElement->setAttributeNode(NewAttribute("name", name));
+
+  auto vit = myassembly->GetTripletsIterator();
+
+  G4int depth = 0;
+  const G4String ModuleName;
+
+  for(std::size_t i5 = 0; i5 < myassembly->TotalTriplets(); ++i5)
+  {
+    G4LogicalVolume* lvol = (*vit).GetVolume();
+    if (lvol == nullptr)
+    {
+      G4String message = "Nested assemblies not yet supported for exporting. Sorry!";
+      G4Exception("GDMLWriteStructure::AssemblyWrite()", "InvalidSetup",
+                  FatalException, message);
+      return;
+    }
+    TraverseVolumeTree(lvol, depth + 1);
+
+    const G4ThreeVector rot = GetAngles((*vit).GetRotation()->inverse());
+    const G4ThreeVector pos = (*vit).GetTranslation();
+
+    const G4String pname =
+      GenerateName((*vit).GetVolume()->GetName() + "_pv", &(*vit));
+
+    xercesc::DOMElement* physvolElement = NewElement("physvol");
+    physvolElement->setAttributeNode(NewAttribute("name", pname));
+
+    assemblyElement->appendChild(physvolElement);
+
+    const G4String volumeref =
+      GenerateName((*vit).GetVolume()->GetName(), (*vit).GetVolume());
+
+    xercesc::DOMElement* volumerefElement = NewElement("volumeref");
+    volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
+    physvolElement->appendChild(volumerefElement);
+
+    if(std::fabs(pos.x()) > kLinearPrecision ||
+       std::fabs(pos.y()) > kLinearPrecision ||
+       std::fabs(pos.z()) > kLinearPrecision)
+    {
+      PositionWrite(physvolElement,name+"_position_" + std::to_string(i5), pos);
+    }
+
+    if(std::fabs(rot.x()) > kAngularPrecision ||
+       std::fabs(rot.y()) > kAngularPrecision ||
+       std::fabs(rot.z()) > kAngularPrecision)
+    {
+      RotationWrite(physvolElement,name+"_rotation_" + std::to_string(i5), rot);
+    }
+    ++vit;
+  }
+
+  volumeElement->appendChild(assemblyElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::BorderSurfaceCache(
+  const G4LogicalBorderSurface* const bsurf)
+{
+  if(bsurf == nullptr)
+  {
+    return;
+  }
+
+  const G4SurfaceProperty* psurf = bsurf->GetSurfaceProperty();
+
+  // Generate the new element for border-surface
+  //
+  const G4String& bsname             = GenerateName(bsurf->GetName(), bsurf);
+  const G4String& psname             = GenerateName(psurf->GetName(), psurf);
+  xercesc::DOMElement* borderElement = NewElement("bordersurface");
+  borderElement->setAttributeNode(NewAttribute("name", bsname));
+  borderElement->setAttributeNode(NewAttribute("surfaceproperty", psname));
+
+  const G4String volumeref1 =
+    GenerateName(bsurf->GetVolume1()->GetName(), bsurf->GetVolume1());
+  const G4String volumeref2 =
+    GenerateName(bsurf->GetVolume2()->GetName(), bsurf->GetVolume2());
+  xercesc::DOMElement* volumerefElement1 = NewElement("physvolref");
+  xercesc::DOMElement* volumerefElement2 = NewElement("physvolref");
+  volumerefElement1->setAttributeNode(NewAttribute("ref", volumeref1));
+  volumerefElement2->setAttributeNode(NewAttribute("ref", volumeref2));
+  borderElement->appendChild(volumerefElement1);
+  borderElement->appendChild(volumerefElement2);
+
+  if(FindOpticalSurface(psurf))
+  {
+    const G4OpticalSurface* opsurf =
+      dynamic_cast<const G4OpticalSurface*>(psurf);
+    if(opsurf == nullptr)
+    {
+      G4Exception("GDMLWriteStructure::BorderSurfaceCache()", "InvalidSetup",
+                  FatalException, "No optical surface found!");
+      return;
+    }
+    OpticalSurfaceWrite(solidsElement, opsurf);
+  }
+
+  borderElementVec.push_back(borderElement);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::SkinSurfaceCache(
+  const G4LogicalSkinSurface* const ssurf)
+{
+  if(ssurf == nullptr)
+  {
+    return;
+  }
+
+  const G4SurfaceProperty* psurf = ssurf->GetSurfaceProperty();
+
+  // Generate the new element for border-surface
+  //
+  const G4String& ssname           = GenerateName(ssurf->GetName(), ssurf);
+  const G4String& psname           = GenerateName(psurf->GetName(), psurf);
+  xercesc::DOMElement* skinElement = NewElement("skinsurface");
+  skinElement->setAttributeNode(NewAttribute("name", ssname));
+  skinElement->setAttributeNode(NewAttribute("surfaceproperty", psname));
+
+  const G4String volumeref = GenerateName(ssurf->GetLogicalVolume()->GetName(),
+                                          ssurf->GetLogicalVolume());
+  xercesc::DOMElement* volumerefElement = NewElement("volumeref");
+  volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
+  skinElement->appendChild(volumerefElement);
+
+  if(FindOpticalSurface(psurf))
+  {
+    const G4OpticalSurface* opsurf =
+      dynamic_cast<const G4OpticalSurface*>(psurf);
+    if(opsurf == nullptr)
+    {
+      G4Exception("GDMLWriteStructure::SkinSurfaceCache()", "InvalidSetup",
+                  FatalException, "No optical surface found!");
+      return;
+    }
+    OpticalSurfaceWrite(solidsElement, opsurf);
+  }
+
+  skinElementVec.push_back(skinElement);
+}
+
+// --------------------------------------------------------------------
+G4bool GDMLWriteStructure::FindOpticalSurface(const G4SurfaceProperty* psurf)
+{
+  const G4OpticalSurface* osurf = dynamic_cast<const G4OpticalSurface*>(psurf);
+  auto pos = std::find(opt_vec.cbegin(), opt_vec.cend(), osurf);
+  if(pos != opt_vec.cend())
+  {
+    return false;
+  }  // item already created!
+
+  opt_vec.push_back(osurf);  // cache it for future reference
+  return true;
+}
+
+// --------------------------------------------------------------------
+const G4LogicalSkinSurface* GDMLWriteStructure::GetSkinSurface(
+  const G4LogicalVolume* const lvol)
+{
+  G4LogicalSkinSurface* surf = 0;
+  G4int nsurf = G4LogicalSkinSurface::GetNumberOfSkinSurfaces();
+  if(nsurf)
+  {
+    const G4LogicalSkinSurfaceTable* stable =
+      G4LogicalSkinSurface::GetSurfaceTable();
+    for(auto pos = stable->cbegin(); pos != stable->cend(); ++pos)
+    {
+      if(lvol == (*pos)->GetLogicalVolume())
+      {
+        surf = *pos;
+        break;
+      }
+    }
+  }
+  return surf;
+}
+
+// --------------------------------------------------------------------
+const G4LogicalBorderSurface* GDMLWriteStructure::GetBorderSurface(
+  const G4VPhysicalVolume* const pvol)
+{
+  G4LogicalBorderSurface* surf = nullptr;
+  G4int nsurf = G4LogicalBorderSurface::GetNumberOfBorderSurfaces();
+  if(nsurf)
+  {
+    const G4LogicalBorderSurfaceTable* btable =
+      G4LogicalBorderSurface::GetSurfaceTable();
+    for(auto pos = btable->cbegin(); pos != btable->cend(); ++pos)
+    {
+      if(pvol == pos->first.first)  // just the first in the couple
+      {                             // could be enough?
+        surf = pos->second;         // break;
+        BorderSurfaceCache(surf);
+      }
+    }
+  }
+  return surf;
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::SurfacesWrite()
+{
+#ifdef G4VERBOSE
+  G4cout << "G4GDML: Writing surfaces..." << G4endl;
+#endif
+  for(auto pos = skinElementVec.cbegin();
+           pos != skinElementVec.cend(); ++pos)
+  {
+    structureElement->appendChild(*pos);
+  }
+  for(auto pos = borderElementVec.cbegin();
+           pos != borderElementVec.cend(); ++pos)
+  {
+    structureElement->appendChild(*pos);
+  }
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::StructureWrite(xercesc::DOMElement* gdmlElement)
+{
+#ifdef G4VERBOSE
+  G4cout << "G4GDML: Writing structure..." << G4endl;
+#endif
+
+  // filling the list of phys volumes that are parts of assemblies
+
+  G4AssemblyStore* assemblies = G4AssemblyStore::GetInstance();
+
+  for(auto it = assemblies->cbegin(); it != assemblies->cend(); ++it)
+  {
+    auto vit = (*it)->GetVolumesIterator();
+
+    for(std::size_t i5 = 0; i5 < (*it)->TotalImprintedVolumes(); ++i5)
+    {
+      G4String pvname = (*vit)->GetName();
+      std::size_t pos = pvname.find("_impr_") + 6;
+      G4String impID  = pvname.substr(pos);
+
+      pos   = impID.find("_");
+      impID = impID.substr(0, pos);
+
+      assemblyVolMap[*vit] = (*it)->GetAssemblyID();
+      imprintsMap[*vit]    = std::atoi(impID.c_str());
+      ++vit;
+    }
+  }
+
+  structureElement = NewElement("structure");
+  gdmlElement->appendChild(structureElement);
+}
+
+// --------------------------------------------------------------------
+G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
+  const G4LogicalVolume* const volumePtr, const G4int depth)
+{
+  if(VolumeMap().find(volumePtr) != VolumeMap().cend())
+  {
+    return VolumeMap()[volumePtr];  // Volume is already processed
+  }
+
+  G4VSolid* solidPtr = volumePtr->GetSolid();
+  G4Transform3D R, invR;
+  G4int trans = 0;
+
+  std::map<const G4LogicalVolume*, G4GDMLAuxListType>::iterator auxiter;
+
+  ++levelNo;
+
+  while(true)  // Solve possible displacement/reflection
+  {            // of the referenced solid!
+    if(trans > maxTransforms)
+    {
+      G4String ErrorMessage = "Referenced solid in volume '" +
+                              volumePtr->GetName() +
+                              "' was displaced/reflected too many times!";
+      G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup",
+                  FatalException, ErrorMessage);
+    }
+
+    if(G4ReflectedSolid* refl = dynamic_cast<G4ReflectedSolid*>(solidPtr))
+    {
+      R        = R * refl->GetTransform3D();
+      solidPtr = refl->GetConstituentMovedSolid();
+      ++trans;
+      continue;
+    }
+
+    if(G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(solidPtr))
+    {
+      R        = R * G4Transform3D(disp->GetObjectRotation(),
+                            disp->GetObjectTranslation());
+      solidPtr = disp->GetConstituentMovedSolid();
+      ++trans;
+      continue;
+    }
+
+    break;
+  }
+
+  // check if it is a reflected volume
+  G4LogicalVolume* tmplv = const_cast<G4LogicalVolume*>(volumePtr);
+
+  if(reflFactory->IsReflected(tmplv))
+  {
+    tmplv = reflFactory->GetConstituentLV(tmplv);
+    if(VolumeMap().find(tmplv) != VolumeMap().cend())
+    {
+      return R;  // Volume is already processed
+    }
+  }
+
+  // Only compute the inverse when necessary!
+  //
+  if(trans > 0)
+  {
+    invR = R.inverse();
+  }
+
+  const G4String name = GenerateName(tmplv->GetName(), tmplv);
+
+  G4String materialref = "NULL";
+
+  if(volumePtr->GetMaterial())
+  {
+    materialref = GenerateName(volumePtr->GetMaterial()->GetName(),
+                               volumePtr->GetMaterial());
+  }
+
+  const G4String solidref = GenerateName(solidPtr->GetName(), solidPtr);
+
+  xercesc::DOMElement* volumeElement = NewElement("volume");
+  volumeElement->setAttributeNode(NewAttribute("name", name));
+  xercesc::DOMElement* materialrefElement = NewElement("materialref");
+  materialrefElement->setAttributeNode(NewAttribute("ref", materialref));
+  volumeElement->appendChild(materialrefElement);
+  xercesc::DOMElement* solidrefElement = NewElement("solidref");
+  solidrefElement->setAttributeNode(NewAttribute("ref", solidref));
+  volumeElement->appendChild(solidrefElement);
+
+  G4int daughterCount = volumePtr->GetNoDaughters();
+
+  if(levelNo == maxLevel)  // Stop exporting if reached levels limit
+  {
+    daughterCount = 0;
+  }
+
+  std::map<G4int, std::vector<G4int> > assemblyIDToAddedImprints;
+
+  for(G4int i = 0; i < daughterCount; ++i)  // Traverse all the children!
+  {
+    const G4VPhysicalVolume* const physvol = volumePtr->GetDaughter(i);
+    const G4String ModuleName              = Modularize(physvol, depth);
+
+    G4Transform3D daughterR;
+
+    if(ModuleName.empty())  // Check if subtree requested to be
+    {                       // a separate module!
+      daughterR = TraverseVolumeTree(physvol->GetLogicalVolume(), depth + 1);
+    }
+    else
+    {
+      GDMLWriteStructure writer;
+      daughterR = writer.Write(ModuleName, physvol->GetLogicalVolume(),
+                               SchemaLocation, depth + 1);
+    }
+
+    if(const G4PVDivision* const divisionvol =
+         dynamic_cast<const G4PVDivision*>(physvol))  // Is it division?
+    {
+      if(!G4Transform3D::Identity.isNear(invR * daughterR, kRelativePrecision))
+      {
+        G4String ErrorMessage = "Division volume in '" + name +
+                                "' can not be related to reflected solid!";
+        G4Exception("GDMLWriteStructure::TraverseVolumeTree()",
+                    "InvalidSetup", FatalException, ErrorMessage);
+      }
+      DivisionvolWrite(volumeElement, divisionvol);
+    }
+    else
+    {
+      if(physvol->IsParameterised())  // Is it a paramvol?
+      {
+        if(!G4Transform3D::Identity.isNear(invR * daughterR,
+                                           kRelativePrecision))
+        {
+          G4String ErrorMessage = "Parameterised volume in '" + name +
+                                  "' can not be related to reflected solid!";
+          G4Exception("GDMLWriteStructure::TraverseVolumeTree()",
+                      "InvalidSetup", FatalException, ErrorMessage);
+        }
+        ParamvolWrite(volumeElement, physvol);
+      }
+      else
+      {
+        if(physvol->IsReplicated())  // Is it a replicavol?
+        {
+          if(!G4Transform3D::Identity.isNear(invR * daughterR,
+                                             kRelativePrecision))
+          {
+            G4String ErrorMessage = "Replica volume in '" + name +
+                                    "' can not be related to reflected solid!";
+            G4Exception("GDMLWriteStructure::TraverseVolumeTree()",
+                        "InvalidSetup", FatalException, ErrorMessage);
+          }
+          ReplicavolWrite(volumeElement, physvol);
+        }
+        else  // Is it a physvol or an assembly?
+        {
+          if(assemblyVolMap.find(physvol) != assemblyVolMap.cend())
+          {
+            G4int assemblyID = assemblyVolMap[physvol];
+
+            G4String assemblyref = "Assembly_" + std::to_string(assemblyID);
+
+            // here I need to retrieve the imprint ID
+
+            G4int imprintID = imprintsMap[physvol];
+
+            // there are 2 steps:
+            //
+            // 1) add assembly to the structure if that has not yet been done
+            // (but after the constituents volumes have been added)
+            //
+
+            if(std::find(addedAssemblies.cbegin(), addedAssemblies.cend(),
+                         assemblyID) == addedAssemblies.cend())
+            {
+              AssemblyWrite(structureElement, assemblyID);
+              addedAssemblies.push_back(assemblyID);
+              assemblyIDToAddedImprints[assemblyID] = std::vector<G4int>();
+            }
+
+            // 2) add the assembly (as physical volume) to the mother volume
+            // (but only once), using it's original position and rotation.
+            //
+
+            // here I need a check if assembly has been already added to the
+            // mother volume
+            std::vector<G4int>& addedImprints = assemblyIDToAddedImprints[assemblyID];
+            if(std::find(addedImprints.cbegin(), addedImprints.cend(),
+                         imprintID) == addedImprints.cend())
+            {
+              G4String imprintname = "Imprint_" + std::to_string(imprintID) + "_";
+              imprintname          = GenerateName(imprintname, physvol);
+
+              // I need to get those two from the  container of imprints from
+              // the assembly I have the imprint ID, I need to get pos and rot
+              //
+              G4Transform3D& transf = G4AssemblyStore::GetInstance()
+                                        ->GetAssembly(assemblyID)
+                                        ->GetImprintTransformation(imprintID);
+
+              HepGeom::Scale3D scale;
+              HepGeom::Rotate3D rotate;
+              HepGeom::Translate3D translate;
+
+              transf.getDecomposition(scale, rotate, translate);
+
+              const G4ThreeVector scl(scale(0, 0), scale(1, 1), scale(2, 2));
+              const G4ThreeVector rot = GetAngles(rotate.getRotation().inverse());
+              const G4ThreeVector pos = transf.getTranslation();
+
+              // here I need a normal physvol referencing to my assemblyref
+
+              xercesc::DOMElement* physvolElement = NewElement("physvol");
+              physvolElement->setAttributeNode(NewAttribute("name", imprintname));
+
+              xercesc::DOMElement* volumerefElement = NewElement("volumeref");
+              volumerefElement->setAttributeNode(NewAttribute("ref", assemblyref));
+              physvolElement->appendChild(volumerefElement);
+
+              if(std::fabs(pos.x()) > kLinearPrecision ||
+                 std::fabs(pos.y()) > kLinearPrecision ||
+                 std::fabs(pos.z()) > kLinearPrecision)
+              {
+                PositionWrite(physvolElement, imprintname + "_pos", pos);
+              }
+              if(std::fabs(rot.x()) > kAngularPrecision ||
+                 std::fabs(rot.y()) > kAngularPrecision ||
+                 std::fabs(rot.z()) > kAngularPrecision)
+              {
+                RotationWrite(physvolElement, imprintname + "_rot", rot);
+              }
+              if(std::fabs(scl.x() - 1.0) > kRelativePrecision ||
+                 std::fabs(scl.y() - 1.0) > kRelativePrecision ||
+                 std::fabs(scl.z() - 1.0) > kRelativePrecision)
+              {
+                ScaleWrite(physvolElement, name + "_scl", scl);
+              }
+
+              volumeElement->appendChild(physvolElement);
+              //
+              addedImprints.push_back(imprintID);
+            }
+          }
+          else  // not part of assembly, so a normal physical volume
+          {
+            G4RotationMatrix rot;
+            if(physvol->GetFrameRotation() != nullptr)
+            {
+              rot = *(physvol->GetFrameRotation());
+            }
+            G4Transform3D P(rot, physvol->GetObjectTranslation());
+
+            PhysvolWrite(volumeElement, physvol, invR * P * daughterR,
+                         ModuleName);
+          }
+        }
+      }
+    }
+    // BorderSurfaceCache(GetBorderSurface(physvol));
+    GetBorderSurface(physvol);
+  }
+
+  if(cexport)
+  {
+    ExportEnergyCuts(volumePtr);
+  }
+  // Add optional energy cuts
+
+  if(sdexport)
+  {
+    ExportSD(volumePtr);
+  }
+  // Add optional SDs
+
+  // Here write the auxiliary info
+  //
+  auxiter = auxmap.find(volumePtr);
+  if(auxiter != auxmap.cend())
+  {
+    AddAuxInfo(&(auxiter->second), volumeElement);
+  }
+
+  structureElement->appendChild(volumeElement);
+  // Append the volume AFTER traversing the children so that
+  // the order of volumes will be correct!
+
+  VolumeMap()[tmplv] = R;
+
+  AddExtension(volumeElement, volumePtr);
+  // Add any possible user defined extension attached to a volume
+
+  AddMaterial(volumePtr->GetMaterial());
+  // Add the involved materials and solids!
+
+  AddSolid(solidPtr);
+
+  SkinSurfaceCache(GetSkinSurface(volumePtr));
+
+  return R;
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
+                                              const G4LogicalVolume* const lvol)
+{
+  auto pos = auxmap.find(lvol);
+
+  if(pos == auxmap.cend())
+  {
+    auxmap[lvol] = G4GDMLAuxListType();
+  }
+
+  auxmap[lvol].push_back(myaux);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::SetEnergyCutsExport(G4bool fcuts)
+{
+  cexport = fcuts;
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::ExportEnergyCuts(const G4LogicalVolume* const lvol)
+{
+  G4GDMLEvaluator eval;
+  G4ProductionCuts* pcuts     = lvol->GetRegion()->GetProductionCuts();
+  G4ProductionCutsTable* ctab = G4ProductionCutsTable::GetProductionCutsTable();
+  G4Gamma* gamma              = G4Gamma::Gamma();
+  G4Electron* eminus          = G4Electron::Electron();
+  G4Positron* eplus           = G4Positron::Positron();
+  G4Proton* proton            = G4Proton::Proton();
+
+  G4double gamma_cut = ctab->ConvertRangeToEnergy(
+    gamma, lvol->GetMaterial(), pcuts->GetProductionCut("gamma"));
+  G4double eminus_cut = ctab->ConvertRangeToEnergy(
+    eminus, lvol->GetMaterial(), pcuts->GetProductionCut("e-"));
+  G4double eplus_cut = ctab->ConvertRangeToEnergy(
+    eplus, lvol->GetMaterial(), pcuts->GetProductionCut("e+"));
+  G4double proton_cut = ctab->ConvertRangeToEnergy(
+    proton, lvol->GetMaterial(), pcuts->GetProductionCut("proton"));
+
+  G4GDMLAuxStructType gammainfo  = { "gammaECut",
+                                    eval.ConvertToString(gamma_cut), "MeV", 0 };
+  G4GDMLAuxStructType eminusinfo = { "electronECut",
+                                     eval.ConvertToString(eminus_cut), "MeV",
+                                     0 };
+  G4GDMLAuxStructType eplusinfo  = { "positronECut",
+                                    eval.ConvertToString(eplus_cut), "MeV", 0 };
+  G4GDMLAuxStructType protinfo   = { "protonECut",
+                                   eval.ConvertToString(proton_cut), "MeV", 0 };
+
+  AddVolumeAuxiliary(gammainfo, lvol);
+  AddVolumeAuxiliary(eminusinfo, lvol);
+  AddVolumeAuxiliary(eplusinfo, lvol);
+  AddVolumeAuxiliary(protinfo, lvol);
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::SetSDExport(G4bool fsd)
+{
+  sdexport = fsd;
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::ExportSD(const G4LogicalVolume* const lvol)
+{
+  G4VSensitiveDetector* sd = lvol->GetSensitiveDetector();
+
+  if(sd != nullptr)
+  {
+    G4String SDname = sd->GetName();
+
+    G4GDMLAuxStructType SDinfo = { "SensDet", SDname, "", 0 };
+    AddVolumeAuxiliary(SDinfo, lvol);
+  }
+}
+
+// --------------------------------------------------------------------
+G4int GDMLWriteStructure::GetMaxExportLevel() const
+{
+  return maxLevel;
+}
+
+// --------------------------------------------------------------------
+void GDMLWriteStructure::SetMaxExportLevel(G4int level)
+{
+  if(level <= 0)
+  {
+    G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup",
+                FatalException, "Levels to export must be greater than zero!");
+    return;
+  }
+  maxLevel = level;
+  levelNo  = 0;
+}
+}

--- a/src/geo/src/gdml/GDMLWriteStructure.cc
+++ b/src/geo/src/gdml/GDMLWriteStructure.cc
@@ -1,55 +1,46 @@
 #include "RAT/GDMLWriteStructure.hh"
-#include "G4GDMLEvaluator.hh"
 
-#include "G4Material.hh"
-#include "G4ReflectedSolid.hh"
-#include "G4DisplacedSolid.hh"
-#include "G4LogicalVolumeStore.hh"
-#include "G4PhysicalVolumeStore.hh"
-#include "G4ReflectionFactory.hh"
-#include "G4PVDivision.hh"
-#include "G4PVReplica.hh"
-#include "G4Region.hh"
-#include "G4OpticalSurface.hh"
-#include "G4LogicalSkinSurface.hh"
-#include "G4LogicalBorderSurface.hh"
-
-#include "G4ProductionCuts.hh"
-#include "G4ProductionCutsTable.hh"
-#include "G4Gamma.hh"
-#include "G4Electron.hh"
-#include "G4Positron.hh"
-#include "G4Proton.hh"
-
-#include "G4VSensitiveDetector.hh"
 #include "G4AssemblyStore.hh"
 #include "G4AssemblyVolume.hh"
+#include "G4DisplacedSolid.hh"
+#include "G4Electron.hh"
+#include "G4GDMLEvaluator.hh"
+#include "G4Gamma.hh"
+#include "G4LogicalBorderSurface.hh"
+#include "G4LogicalSkinSurface.hh"
+#include "G4LogicalVolumeStore.hh"
+#include "G4Material.hh"
+#include "G4OpticalSurface.hh"
+#include "G4PVDivision.hh"
+#include "G4PVReplica.hh"
+#include "G4PhysicalVolumeStore.hh"
+#include "G4Positron.hh"
+#include "G4ProductionCuts.hh"
+#include "G4ProductionCutsTable.hh"
+#include "G4Proton.hh"
+#include "G4ReflectedSolid.hh"
+#include "G4ReflectionFactory.hh"
+#include "G4Region.hh"
+#include "G4VSensitiveDetector.hh"
 
 namespace RAT {
 
 G4int GDMLWriteStructure::levelNo = 0;  // Counter for level being exported
 
 // --------------------------------------------------------------------
-GDMLWriteStructure::GDMLWriteStructure()
-  : GDMLWriteParamvol()
-  , maxLevel(INT_MAX)
-{
+GDMLWriteStructure::GDMLWriteStructure() : GDMLWriteParamvol(), maxLevel(INT_MAX) {
   reflFactory = G4ReflectionFactory::Instance();
 }
 
 // --------------------------------------------------------------------
-GDMLWriteStructure::~GDMLWriteStructure()
-{
-}
+GDMLWriteStructure::~GDMLWriteStructure() {}
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::DivisionvolWrite(
-  xercesc::DOMElement* volumeElement, const G4PVDivision* const divisionvol)
-{
-  EAxis axis       = kUndefined;
-  G4int number     = 0;
-  G4double width   = 0.0;
-  G4double offset  = 0.0;
+void GDMLWriteStructure::DivisionvolWrite(xercesc::DOMElement* volumeElement, const G4PVDivision* const divisionvol) {
+  EAxis axis = kUndefined;
+  G4int number = 0;
+  G4double width = 0.0;
+  G4double offset = 0.0;
   G4bool consuming = false;
 
   divisionvol->GetReplicationData(axis, number, width, offset, consuming);
@@ -57,32 +48,21 @@ void GDMLWriteStructure::DivisionvolWrite(
 
   G4String unitString("mm");
   G4String axisString("kUndefined");
-  if(axis == kXAxis)
-  {
+  if (axis == kXAxis) {
     axisString = "kXAxis";
-  }
-  else if(axis == kYAxis)
-  {
+  } else if (axis == kYAxis) {
     axisString = "kYAxis";
-  }
-  else if(axis == kZAxis)
-  {
+  } else if (axis == kZAxis) {
     axisString = "kZAxis";
-  }
-  else if(axis == kRho)
-  {
+  } else if (axis == kRho) {
     axisString = "kRho";
-  }
-  else if(axis == kPhi)
-  {
+  } else if (axis == kPhi) {
     axisString = "kPhi";
     unitString = "rad";
   }
 
   const G4String name = GenerateName(divisionvol->GetName(), divisionvol);
-  const G4String volumeref =
-    GenerateName(divisionvol->GetLogicalVolume()->GetName(),
-                 divisionvol->GetLogicalVolume());
+  const G4String volumeref = GenerateName(divisionvol->GetLogicalVolume()->GetName(), divisionvol->GetLogicalVolume());
 
   xercesc::DOMElement* divisionvolElement = NewElement("divisionvol");
   divisionvolElement->setAttributeNode(NewAttribute("axis", axisString));
@@ -97,11 +77,8 @@ void GDMLWriteStructure::DivisionvolWrite(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::PhysvolWrite(xercesc::DOMElement* volumeElement,
-                                        const G4VPhysicalVolume* const physvol,
-                                        const G4Transform3D& T,
-                                        const G4String& ModuleName)
-{
+void GDMLWriteStructure::PhysvolWrite(xercesc::DOMElement* volumeElement, const G4VPhysicalVolume* const physvol,
+                                      const G4Transform3D& T, const G4String& ModuleName) {
   HepGeom::Scale3D scale;
   HepGeom::Rotate3D rotate;
   HepGeom::Translate3D translate;
@@ -112,13 +89,12 @@ void GDMLWriteStructure::PhysvolWrite(xercesc::DOMElement* volumeElement,
   const G4ThreeVector rot = GetAngles(rotate.getRotation());
   const G4ThreeVector pos = T.getTranslation();
 
-  const G4String name    = GenerateName(physvol->GetName(), physvol);
+  const G4String name = GenerateName(physvol->GetName(), physvol);
   const G4int copynumber = physvol->GetCopyNo();
 
   xercesc::DOMElement* physvolElement = NewElement("physvol");
   physvolElement->setAttributeNode(NewAttribute("name", name));
-  if(copynumber)
-  {
+  if (copynumber) {
     physvolElement->setAttributeNode(NewAttribute("copynumber", copynumber));
   }
 
@@ -126,66 +102,52 @@ void GDMLWriteStructure::PhysvolWrite(xercesc::DOMElement* volumeElement,
 
   G4LogicalVolume* lv;
   // Is it reflected?
-  if(reflFactory->IsReflected(physvol->GetLogicalVolume()))
-  {
+  if (reflFactory->IsReflected(physvol->GetLogicalVolume())) {
     lv = reflFactory->GetConstituentLV(physvol->GetLogicalVolume());
-  }
-  else
-  {
+  } else {
     lv = physvol->GetLogicalVolume();
   }
 
   const G4String volumeref = GenerateName(lv->GetName(), lv);
 
-  if(ModuleName.empty())
-  {
+  if (ModuleName.empty()) {
     xercesc::DOMElement* volumerefElement = NewElement("volumeref");
     volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
     physvolElement->appendChild(volumerefElement);
-  }
-  else
-  {
+  } else {
     xercesc::DOMElement* fileElement = NewElement("file");
     fileElement->setAttributeNode(NewAttribute("name", ModuleName));
     fileElement->setAttributeNode(NewAttribute("volname", volumeref));
     physvolElement->appendChild(fileElement);
   }
 
-  if(std::fabs(pos.x()) > kLinearPrecision ||
-     std::fabs(pos.y()) > kLinearPrecision ||
-     std::fabs(pos.z()) > kLinearPrecision)
-  {
+  if (std::fabs(pos.x()) > kLinearPrecision || std::fabs(pos.y()) > kLinearPrecision ||
+      std::fabs(pos.z()) > kLinearPrecision) {
     PositionWrite(physvolElement, name + "_pos", pos);
   }
-  if(std::fabs(rot.x()) > kAngularPrecision ||
-     std::fabs(rot.y()) > kAngularPrecision ||
-     std::fabs(rot.z()) > kAngularPrecision)
-  {
+  if (std::fabs(rot.x()) > kAngularPrecision || std::fabs(rot.y()) > kAngularPrecision ||
+      std::fabs(rot.z()) > kAngularPrecision) {
     RotationWrite(physvolElement, name + "_rot", rot);
   }
-  if(std::fabs(scl.x() - 1.0) > kRelativePrecision ||
-     std::fabs(scl.y() - 1.0) > kRelativePrecision ||
-     std::fabs(scl.z() - 1.0) > kRelativePrecision)
-  {
+  if (std::fabs(scl.x() - 1.0) > kRelativePrecision || std::fabs(scl.y() - 1.0) > kRelativePrecision ||
+      std::fabs(scl.z() - 1.0) > kRelativePrecision) {
     ScaleWrite(physvolElement, name + "_scl", scl);
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::ReplicavolWrite(
-  xercesc::DOMElement* volumeElement, const G4VPhysicalVolume* const replicavol)
-{
-  EAxis axis       = kUndefined;
-  G4int number     = 0;
-  G4double width   = 0.0;
-  G4double offset  = 0.0;
+void GDMLWriteStructure::ReplicavolWrite(xercesc::DOMElement* volumeElement,
+                                         const G4VPhysicalVolume* const replicavol) {
+  EAxis axis = kUndefined;
+  G4int number = 0;
+  G4double width = 0.0;
+  G4double offset = 0.0;
   G4bool consuming = false;
   G4String unitString("mm");
 
   replicavol->GetReplicationData(axis, number, width, offset, consuming);
 
-  const G4String volumeref = GenerateName(
-    replicavol->GetLogicalVolume()->GetName(), replicavol->GetLogicalVolume());
+  const G4String volumeref = GenerateName(replicavol->GetLogicalVolume()->GetName(), replicavol->GetLogicalVolume());
 
   xercesc::DOMElement* replicavolElement = NewElement("replicavol");
   replicavolElement->setAttributeNode(NewAttribute("number", number));
@@ -196,24 +158,15 @@ void GDMLWriteStructure::ReplicavolWrite(
   replicavolElement->appendChild(replicateElement);
 
   xercesc::DOMElement* dirElement = NewElement("direction");
-  if(axis == kXAxis)
-  {
+  if (axis == kXAxis) {
     dirElement->setAttributeNode(NewAttribute("x", "1"));
-  }
-  else if(axis == kYAxis)
-  {
+  } else if (axis == kYAxis) {
     dirElement->setAttributeNode(NewAttribute("y", "1"));
-  }
-  else if(axis == kZAxis)
-  {
+  } else if (axis == kZAxis) {
     dirElement->setAttributeNode(NewAttribute("z", "1"));
-  }
-  else if(axis == kRho)
-  {
+  } else if (axis == kRho) {
     dirElement->setAttributeNode(NewAttribute("rho", "1"));
-  }
-  else if(axis == kPhi)
-  {
+  } else if (axis == kPhi) {
     dirElement->setAttributeNode(NewAttribute("phi", "1"));
     unitString = "rad";
   }
@@ -233,10 +186,8 @@ void GDMLWriteStructure::ReplicavolWrite(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::AssemblyWrite(xercesc::DOMElement* volumeElement,
-                                         const G4int assemblyID)
-{
-  G4AssemblyStore* assemblies  = G4AssemblyStore::GetInstance();
+void GDMLWriteStructure::AssemblyWrite(xercesc::DOMElement* volumeElement, const G4int assemblyID) {
+  G4AssemblyStore* assemblies = G4AssemblyStore::GetInstance();
   G4AssemblyVolume* myassembly = assemblies->GetAssembly(assemblyID);
 
   xercesc::DOMElement* assemblyElement = NewElement("assembly");
@@ -249,14 +200,11 @@ void GDMLWriteStructure::AssemblyWrite(xercesc::DOMElement* volumeElement,
   G4int depth = 0;
   const G4String ModuleName;
 
-  for(std::size_t i5 = 0; i5 < myassembly->TotalTriplets(); ++i5)
-  {
+  for (std::size_t i5 = 0; i5 < myassembly->TotalTriplets(); ++i5) {
     G4LogicalVolume* lvol = (*vit).GetVolume();
-    if (lvol == nullptr)
-    {
+    if (lvol == nullptr) {
       G4String message = "Nested assemblies not yet supported for exporting. Sorry!";
-      G4Exception("GDMLWriteStructure::AssemblyWrite()", "InvalidSetup",
-                  FatalException, message);
+      G4Exception("GDMLWriteStructure::AssemblyWrite()", "InvalidSetup", FatalException, message);
       return;
     }
     TraverseVolumeTree(lvol, depth + 1);
@@ -264,33 +212,27 @@ void GDMLWriteStructure::AssemblyWrite(xercesc::DOMElement* volumeElement,
     const G4ThreeVector rot = GetAngles((*vit).GetRotation()->inverse());
     const G4ThreeVector pos = (*vit).GetTranslation();
 
-    const G4String pname =
-      GenerateName((*vit).GetVolume()->GetName() + "_pv", &(*vit));
+    const G4String pname = GenerateName((*vit).GetVolume()->GetName() + "_pv", &(*vit));
 
     xercesc::DOMElement* physvolElement = NewElement("physvol");
     physvolElement->setAttributeNode(NewAttribute("name", pname));
 
     assemblyElement->appendChild(physvolElement);
 
-    const G4String volumeref =
-      GenerateName((*vit).GetVolume()->GetName(), (*vit).GetVolume());
+    const G4String volumeref = GenerateName((*vit).GetVolume()->GetName(), (*vit).GetVolume());
 
     xercesc::DOMElement* volumerefElement = NewElement("volumeref");
     volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
     physvolElement->appendChild(volumerefElement);
 
-    if(std::fabs(pos.x()) > kLinearPrecision ||
-       std::fabs(pos.y()) > kLinearPrecision ||
-       std::fabs(pos.z()) > kLinearPrecision)
-    {
-      PositionWrite(physvolElement,name+"_position_" + std::to_string(i5), pos);
+    if (std::fabs(pos.x()) > kLinearPrecision || std::fabs(pos.y()) > kLinearPrecision ||
+        std::fabs(pos.z()) > kLinearPrecision) {
+      PositionWrite(physvolElement, name + "_position_" + std::to_string(i5), pos);
     }
 
-    if(std::fabs(rot.x()) > kAngularPrecision ||
-       std::fabs(rot.y()) > kAngularPrecision ||
-       std::fabs(rot.z()) > kAngularPrecision)
-    {
-      RotationWrite(physvolElement,name+"_rotation_" + std::to_string(i5), rot);
+    if (std::fabs(rot.x()) > kAngularPrecision || std::fabs(rot.y()) > kAngularPrecision ||
+        std::fabs(rot.z()) > kAngularPrecision) {
+      RotationWrite(physvolElement, name + "_rotation_" + std::to_string(i5), rot);
     }
     ++vit;
   }
@@ -299,11 +241,8 @@ void GDMLWriteStructure::AssemblyWrite(xercesc::DOMElement* volumeElement,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::BorderSurfaceCache(
-  const G4LogicalBorderSurface* const bsurf)
-{
-  if(bsurf == nullptr)
-  {
+void GDMLWriteStructure::BorderSurfaceCache(const G4LogicalBorderSurface* const bsurf) {
+  if (bsurf == nullptr) {
     return;
   }
 
@@ -311,16 +250,14 @@ void GDMLWriteStructure::BorderSurfaceCache(
 
   // Generate the new element for border-surface
   //
-  const G4String& bsname             = GenerateName(bsurf->GetName(), bsurf);
-  const G4String& psname             = GenerateName(psurf->GetName(), psurf);
+  const G4String& bsname = GenerateName(bsurf->GetName(), bsurf);
+  const G4String& psname = GenerateName(psurf->GetName(), psurf);
   xercesc::DOMElement* borderElement = NewElement("bordersurface");
   borderElement->setAttributeNode(NewAttribute("name", bsname));
   borderElement->setAttributeNode(NewAttribute("surfaceproperty", psname));
 
-  const G4String volumeref1 =
-    GenerateName(bsurf->GetVolume1()->GetName(), bsurf->GetVolume1());
-  const G4String volumeref2 =
-    GenerateName(bsurf->GetVolume2()->GetName(), bsurf->GetVolume2());
+  const G4String volumeref1 = GenerateName(bsurf->GetVolume1()->GetName(), bsurf->GetVolume1());
+  const G4String volumeref2 = GenerateName(bsurf->GetVolume2()->GetName(), bsurf->GetVolume2());
   xercesc::DOMElement* volumerefElement1 = NewElement("physvolref");
   xercesc::DOMElement* volumerefElement2 = NewElement("physvolref");
   volumerefElement1->setAttributeNode(NewAttribute("ref", volumeref1));
@@ -328,14 +265,11 @@ void GDMLWriteStructure::BorderSurfaceCache(
   borderElement->appendChild(volumerefElement1);
   borderElement->appendChild(volumerefElement2);
 
-  if(FindOpticalSurface(psurf))
-  {
-    const G4OpticalSurface* opsurf =
-      dynamic_cast<const G4OpticalSurface*>(psurf);
-    if(opsurf == nullptr)
-    {
-      G4Exception("GDMLWriteStructure::BorderSurfaceCache()", "InvalidSetup",
-                  FatalException, "No optical surface found!");
+  if (FindOpticalSurface(psurf)) {
+    const G4OpticalSurface* opsurf = dynamic_cast<const G4OpticalSurface*>(psurf);
+    if (opsurf == nullptr) {
+      G4Exception("GDMLWriteStructure::BorderSurfaceCache()", "InvalidSetup", FatalException,
+                  "No optical surface found!");
       return;
     }
     OpticalSurfaceWrite(solidsElement, opsurf);
@@ -345,11 +279,8 @@ void GDMLWriteStructure::BorderSurfaceCache(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::SkinSurfaceCache(
-  const G4LogicalSkinSurface* const ssurf)
-{
-  if(ssurf == nullptr)
-  {
+void GDMLWriteStructure::SkinSurfaceCache(const G4LogicalSkinSurface* const ssurf) {
+  if (ssurf == nullptr) {
     return;
   }
 
@@ -357,26 +288,22 @@ void GDMLWriteStructure::SkinSurfaceCache(
 
   // Generate the new element for border-surface
   //
-  const G4String& ssname           = GenerateName(ssurf->GetName(), ssurf);
-  const G4String& psname           = GenerateName(psurf->GetName(), psurf);
+  const G4String& ssname = GenerateName(ssurf->GetName(), ssurf);
+  const G4String& psname = GenerateName(psurf->GetName(), psurf);
   xercesc::DOMElement* skinElement = NewElement("skinsurface");
   skinElement->setAttributeNode(NewAttribute("name", ssname));
   skinElement->setAttributeNode(NewAttribute("surfaceproperty", psname));
 
-  const G4String volumeref = GenerateName(ssurf->GetLogicalVolume()->GetName(),
-                                          ssurf->GetLogicalVolume());
+  const G4String volumeref = GenerateName(ssurf->GetLogicalVolume()->GetName(), ssurf->GetLogicalVolume());
   xercesc::DOMElement* volumerefElement = NewElement("volumeref");
   volumerefElement->setAttributeNode(NewAttribute("ref", volumeref));
   skinElement->appendChild(volumerefElement);
 
-  if(FindOpticalSurface(psurf))
-  {
-    const G4OpticalSurface* opsurf =
-      dynamic_cast<const G4OpticalSurface*>(psurf);
-    if(opsurf == nullptr)
-    {
-      G4Exception("GDMLWriteStructure::SkinSurfaceCache()", "InvalidSetup",
-                  FatalException, "No optical surface found!");
+  if (FindOpticalSurface(psurf)) {
+    const G4OpticalSurface* opsurf = dynamic_cast<const G4OpticalSurface*>(psurf);
+    if (opsurf == nullptr) {
+      G4Exception("GDMLWriteStructure::SkinSurfaceCache()", "InvalidSetup", FatalException,
+                  "No optical surface found!");
       return;
     }
     OpticalSurfaceWrite(solidsElement, opsurf);
@@ -386,12 +313,10 @@ void GDMLWriteStructure::SkinSurfaceCache(
 }
 
 // --------------------------------------------------------------------
-G4bool GDMLWriteStructure::FindOpticalSurface(const G4SurfaceProperty* psurf)
-{
+G4bool GDMLWriteStructure::FindOpticalSurface(const G4SurfaceProperty* psurf) {
   const G4OpticalSurface* osurf = dynamic_cast<const G4OpticalSurface*>(psurf);
   auto pos = std::find(opt_vec.cbegin(), opt_vec.cend(), osurf);
-  if(pos != opt_vec.cend())
-  {
+  if (pos != opt_vec.cend()) {
     return false;
   }  // item already created!
 
@@ -400,19 +325,13 @@ G4bool GDMLWriteStructure::FindOpticalSurface(const G4SurfaceProperty* psurf)
 }
 
 // --------------------------------------------------------------------
-const G4LogicalSkinSurface* GDMLWriteStructure::GetSkinSurface(
-  const G4LogicalVolume* const lvol)
-{
+const G4LogicalSkinSurface* GDMLWriteStructure::GetSkinSurface(const G4LogicalVolume* const lvol) {
   G4LogicalSkinSurface* surf = 0;
   G4int nsurf = G4LogicalSkinSurface::GetNumberOfSkinSurfaces();
-  if(nsurf)
-  {
-    const G4LogicalSkinSurfaceTable* stable =
-      G4LogicalSkinSurface::GetSurfaceTable();
-    for(auto pos = stable->cbegin(); pos != stable->cend(); ++pos)
-    {
-      if(lvol == (*pos)->GetLogicalVolume())
-      {
+  if (nsurf) {
+    const G4LogicalSkinSurfaceTable* stable = G4LogicalSkinSurface::GetSurfaceTable();
+    for (auto pos = stable->cbegin(); pos != stable->cend(); ++pos) {
+      if (lvol == (*pos)->GetLogicalVolume()) {
         surf = *pos;
         break;
       }
@@ -422,20 +341,15 @@ const G4LogicalSkinSurface* GDMLWriteStructure::GetSkinSurface(
 }
 
 // --------------------------------------------------------------------
-const G4LogicalBorderSurface* GDMLWriteStructure::GetBorderSurface(
-  const G4VPhysicalVolume* const pvol)
-{
+const G4LogicalBorderSurface* GDMLWriteStructure::GetBorderSurface(const G4VPhysicalVolume* const pvol) {
   G4LogicalBorderSurface* surf = nullptr;
   G4int nsurf = G4LogicalBorderSurface::GetNumberOfBorderSurfaces();
-  if(nsurf)
-  {
-    const G4LogicalBorderSurfaceTable* btable =
-      G4LogicalBorderSurface::GetSurfaceTable();
-    for(auto pos = btable->cbegin(); pos != btable->cend(); ++pos)
-    {
-      if(pvol == pos->first.first)  // just the first in the couple
-      {                             // could be enough?
-        surf = pos->second;         // break;
+  if (nsurf) {
+    const G4LogicalBorderSurfaceTable* btable = G4LogicalBorderSurface::GetSurfaceTable();
+    for (auto pos = btable->cbegin(); pos != btable->cend(); ++pos) {
+      if (pvol == pos->first.first)  // just the first in the couple
+      {                              // could be enough?
+        surf = pos->second;          // break;
         BorderSurfaceCache(surf);
       }
     }
@@ -444,26 +358,20 @@ const G4LogicalBorderSurface* GDMLWriteStructure::GetBorderSurface(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::SurfacesWrite()
-{
+void GDMLWriteStructure::SurfacesWrite() {
 #ifdef G4VERBOSE
   G4cout << "G4GDML: Writing surfaces..." << G4endl;
 #endif
-  for(auto pos = skinElementVec.cbegin();
-           pos != skinElementVec.cend(); ++pos)
-  {
+  for (auto pos = skinElementVec.cbegin(); pos != skinElementVec.cend(); ++pos) {
     structureElement->appendChild(*pos);
   }
-  for(auto pos = borderElementVec.cbegin();
-           pos != borderElementVec.cend(); ++pos)
-  {
+  for (auto pos = borderElementVec.cbegin(); pos != borderElementVec.cend(); ++pos) {
     structureElement->appendChild(*pos);
   }
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::StructureWrite(xercesc::DOMElement* gdmlElement)
-{
+void GDMLWriteStructure::StructureWrite(xercesc::DOMElement* gdmlElement) {
 #ifdef G4VERBOSE
   G4cout << "G4GDML: Writing structure..." << G4endl;
 #endif
@@ -472,21 +380,19 @@ void GDMLWriteStructure::StructureWrite(xercesc::DOMElement* gdmlElement)
 
   G4AssemblyStore* assemblies = G4AssemblyStore::GetInstance();
 
-  for(auto it = assemblies->cbegin(); it != assemblies->cend(); ++it)
-  {
+  for (auto it = assemblies->cbegin(); it != assemblies->cend(); ++it) {
     auto vit = (*it)->GetVolumesIterator();
 
-    for(std::size_t i5 = 0; i5 < (*it)->TotalImprintedVolumes(); ++i5)
-    {
+    for (std::size_t i5 = 0; i5 < (*it)->TotalImprintedVolumes(); ++i5) {
       G4String pvname = (*vit)->GetName();
       std::size_t pos = pvname.find("_impr_") + 6;
-      G4String impID  = pvname.substr(pos);
+      G4String impID = pvname.substr(pos);
 
-      pos   = impID.find("_");
+      pos = impID.find("_");
       impID = impID.substr(0, pos);
 
       assemblyVolMap[*vit] = (*it)->GetAssemblyID();
-      imprintsMap[*vit]    = std::atoi(impID.c_str());
+      imprintsMap[*vit] = std::atoi(impID.c_str());
       ++vit;
     }
   }
@@ -496,11 +402,8 @@ void GDMLWriteStructure::StructureWrite(xercesc::DOMElement* gdmlElement)
 }
 
 // --------------------------------------------------------------------
-G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
-  const G4LogicalVolume* const volumePtr, const G4int depth)
-{
-  if(VolumeMap().find(volumePtr) != VolumeMap().cend())
-  {
+G4Transform3D GDMLWriteStructure::TraverseVolumeTree(const G4LogicalVolume* const volumePtr, const G4int depth) {
+  if (VolumeMap().find(volumePtr) != VolumeMap().cend()) {
     return VolumeMap()[volumePtr];  // Volume is already processed
   }
 
@@ -512,29 +415,23 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
 
   ++levelNo;
 
-  while(true)  // Solve possible displacement/reflection
-  {            // of the referenced solid!
-    if(trans > maxTransforms)
-    {
-      G4String ErrorMessage = "Referenced solid in volume '" +
-                              volumePtr->GetName() +
-                              "' was displaced/reflected too many times!";
-      G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup",
-                  FatalException, ErrorMessage);
+  while (true)  // Solve possible displacement/reflection
+  {             // of the referenced solid!
+    if (trans > maxTransforms) {
+      G4String ErrorMessage =
+          "Referenced solid in volume '" + volumePtr->GetName() + "' was displaced/reflected too many times!";
+      G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup", FatalException, ErrorMessage);
     }
 
-    if(G4ReflectedSolid* refl = dynamic_cast<G4ReflectedSolid*>(solidPtr))
-    {
-      R        = R * refl->GetTransform3D();
+    if (G4ReflectedSolid* refl = dynamic_cast<G4ReflectedSolid*>(solidPtr)) {
+      R = R * refl->GetTransform3D();
       solidPtr = refl->GetConstituentMovedSolid();
       ++trans;
       continue;
     }
 
-    if(G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(solidPtr))
-    {
-      R        = R * G4Transform3D(disp->GetObjectRotation(),
-                            disp->GetObjectTranslation());
+    if (G4DisplacedSolid* disp = dynamic_cast<G4DisplacedSolid*>(solidPtr)) {
+      R = R * G4Transform3D(disp->GetObjectRotation(), disp->GetObjectTranslation());
       solidPtr = disp->GetConstituentMovedSolid();
       ++trans;
       continue;
@@ -546,19 +443,16 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
   // check if it is a reflected volume
   G4LogicalVolume* tmplv = const_cast<G4LogicalVolume*>(volumePtr);
 
-  if(reflFactory->IsReflected(tmplv))
-  {
+  if (reflFactory->IsReflected(tmplv)) {
     tmplv = reflFactory->GetConstituentLV(tmplv);
-    if(VolumeMap().find(tmplv) != VolumeMap().cend())
-    {
+    if (VolumeMap().find(tmplv) != VolumeMap().cend()) {
       return R;  // Volume is already processed
     }
   }
 
   // Only compute the inverse when necessary!
   //
-  if(trans > 0)
-  {
+  if (trans > 0) {
     invR = R.inverse();
   }
 
@@ -566,10 +460,8 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
 
   G4String materialref = "NULL";
 
-  if(volumePtr->GetMaterial())
-  {
-    materialref = GenerateName(volumePtr->GetMaterial()->GetName(),
-                               volumePtr->GetMaterial());
+  if (volumePtr->GetMaterial()) {
+    materialref = GenerateName(volumePtr->GetMaterial()->GetName(), volumePtr->GetMaterial());
   }
 
   const G4String solidref = GenerateName(solidPtr->GetName(), solidPtr);
@@ -585,75 +477,54 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
 
   G4int daughterCount = volumePtr->GetNoDaughters();
 
-  if(levelNo == maxLevel)  // Stop exporting if reached levels limit
+  if (levelNo == maxLevel)  // Stop exporting if reached levels limit
   {
     daughterCount = 0;
   }
 
   std::map<G4int, std::vector<G4int> > assemblyIDToAddedImprints;
 
-  for(G4int i = 0; i < daughterCount; ++i)  // Traverse all the children!
+  for (G4int i = 0; i < daughterCount; ++i)  // Traverse all the children!
   {
     const G4VPhysicalVolume* const physvol = volumePtr->GetDaughter(i);
-    const G4String ModuleName              = Modularize(physvol, depth);
+    const G4String ModuleName = Modularize(physvol, depth);
 
     G4Transform3D daughterR;
 
-    if(ModuleName.empty())  // Check if subtree requested to be
-    {                       // a separate module!
+    if (ModuleName.empty())  // Check if subtree requested to be
+    {                        // a separate module!
       daughterR = TraverseVolumeTree(physvol->GetLogicalVolume(), depth + 1);
-    }
-    else
-    {
+    } else {
       GDMLWriteStructure writer;
-      daughterR = writer.Write(ModuleName, physvol->GetLogicalVolume(),
-                               SchemaLocation, depth + 1);
+      daughterR = writer.Write(ModuleName, physvol->GetLogicalVolume(), SchemaLocation, depth + 1);
     }
 
-    if(const G4PVDivision* const divisionvol =
-         dynamic_cast<const G4PVDivision*>(physvol))  // Is it division?
+    if (const G4PVDivision* const divisionvol = dynamic_cast<const G4PVDivision*>(physvol))  // Is it division?
     {
-      if(!G4Transform3D::Identity.isNear(invR * daughterR, kRelativePrecision))
-      {
-        G4String ErrorMessage = "Division volume in '" + name +
-                                "' can not be related to reflected solid!";
-        G4Exception("GDMLWriteStructure::TraverseVolumeTree()",
-                    "InvalidSetup", FatalException, ErrorMessage);
+      if (!G4Transform3D::Identity.isNear(invR * daughterR, kRelativePrecision)) {
+        G4String ErrorMessage = "Division volume in '" + name + "' can not be related to reflected solid!";
+        G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup", FatalException, ErrorMessage);
       }
       DivisionvolWrite(volumeElement, divisionvol);
-    }
-    else
-    {
-      if(physvol->IsParameterised())  // Is it a paramvol?
+    } else {
+      if (physvol->IsParameterised())  // Is it a paramvol?
       {
-        if(!G4Transform3D::Identity.isNear(invR * daughterR,
-                                           kRelativePrecision))
-        {
-          G4String ErrorMessage = "Parameterised volume in '" + name +
-                                  "' can not be related to reflected solid!";
-          G4Exception("GDMLWriteStructure::TraverseVolumeTree()",
-                      "InvalidSetup", FatalException, ErrorMessage);
+        if (!G4Transform3D::Identity.isNear(invR * daughterR, kRelativePrecision)) {
+          G4String ErrorMessage = "Parameterised volume in '" + name + "' can not be related to reflected solid!";
+          G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup", FatalException, ErrorMessage);
         }
         ParamvolWrite(volumeElement, physvol);
-      }
-      else
-      {
-        if(physvol->IsReplicated())  // Is it a replicavol?
+      } else {
+        if (physvol->IsReplicated())  // Is it a replicavol?
         {
-          if(!G4Transform3D::Identity.isNear(invR * daughterR,
-                                             kRelativePrecision))
-          {
-            G4String ErrorMessage = "Replica volume in '" + name +
-                                    "' can not be related to reflected solid!";
-            G4Exception("GDMLWriteStructure::TraverseVolumeTree()",
-                        "InvalidSetup", FatalException, ErrorMessage);
+          if (!G4Transform3D::Identity.isNear(invR * daughterR, kRelativePrecision)) {
+            G4String ErrorMessage = "Replica volume in '" + name + "' can not be related to reflected solid!";
+            G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup", FatalException, ErrorMessage);
           }
           ReplicavolWrite(volumeElement, physvol);
-        }
-        else  // Is it a physvol or an assembly?
+        } else  // Is it a physvol or an assembly?
         {
-          if(assemblyVolMap.find(physvol) != assemblyVolMap.cend())
-          {
+          if (assemblyVolMap.find(physvol) != assemblyVolMap.cend()) {
             G4int assemblyID = assemblyVolMap[physvol];
 
             G4String assemblyref = "Assembly_" + std::to_string(assemblyID);
@@ -668,9 +539,7 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
             // (but after the constituents volumes have been added)
             //
 
-            if(std::find(addedAssemblies.cbegin(), addedAssemblies.cend(),
-                         assemblyID) == addedAssemblies.cend())
-            {
+            if (std::find(addedAssemblies.cbegin(), addedAssemblies.cend(), assemblyID) == addedAssemblies.cend()) {
               AssemblyWrite(structureElement, assemblyID);
               addedAssemblies.push_back(assemblyID);
               assemblyIDToAddedImprints[assemblyID] = std::vector<G4int>();
@@ -683,18 +552,15 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
             // here I need a check if assembly has been already added to the
             // mother volume
             std::vector<G4int>& addedImprints = assemblyIDToAddedImprints[assemblyID];
-            if(std::find(addedImprints.cbegin(), addedImprints.cend(),
-                         imprintID) == addedImprints.cend())
-            {
+            if (std::find(addedImprints.cbegin(), addedImprints.cend(), imprintID) == addedImprints.cend()) {
               G4String imprintname = "Imprint_" + std::to_string(imprintID) + "_";
-              imprintname          = GenerateName(imprintname, physvol);
+              imprintname = GenerateName(imprintname, physvol);
 
               // I need to get those two from the  container of imprints from
               // the assembly I have the imprint ID, I need to get pos and rot
               //
-              G4Transform3D& transf = G4AssemblyStore::GetInstance()
-                                        ->GetAssembly(assemblyID)
-                                        ->GetImprintTransformation(imprintID);
+              G4Transform3D& transf =
+                  G4AssemblyStore::GetInstance()->GetAssembly(assemblyID)->GetImprintTransformation(imprintID);
 
               HepGeom::Scale3D scale;
               HepGeom::Rotate3D rotate;
@@ -715,22 +581,16 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
               volumerefElement->setAttributeNode(NewAttribute("ref", assemblyref));
               physvolElement->appendChild(volumerefElement);
 
-              if(std::fabs(pos.x()) > kLinearPrecision ||
-                 std::fabs(pos.y()) > kLinearPrecision ||
-                 std::fabs(pos.z()) > kLinearPrecision)
-              {
+              if (std::fabs(pos.x()) > kLinearPrecision || std::fabs(pos.y()) > kLinearPrecision ||
+                  std::fabs(pos.z()) > kLinearPrecision) {
                 PositionWrite(physvolElement, imprintname + "_pos", pos);
               }
-              if(std::fabs(rot.x()) > kAngularPrecision ||
-                 std::fabs(rot.y()) > kAngularPrecision ||
-                 std::fabs(rot.z()) > kAngularPrecision)
-              {
+              if (std::fabs(rot.x()) > kAngularPrecision || std::fabs(rot.y()) > kAngularPrecision ||
+                  std::fabs(rot.z()) > kAngularPrecision) {
                 RotationWrite(physvolElement, imprintname + "_rot", rot);
               }
-              if(std::fabs(scl.x() - 1.0) > kRelativePrecision ||
-                 std::fabs(scl.y() - 1.0) > kRelativePrecision ||
-                 std::fabs(scl.z() - 1.0) > kRelativePrecision)
-              {
+              if (std::fabs(scl.x() - 1.0) > kRelativePrecision || std::fabs(scl.y() - 1.0) > kRelativePrecision ||
+                  std::fabs(scl.z() - 1.0) > kRelativePrecision) {
                 ScaleWrite(physvolElement, name + "_scl", scl);
               }
 
@@ -738,18 +598,15 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
               //
               addedImprints.push_back(imprintID);
             }
-          }
-          else  // not part of assembly, so a normal physical volume
+          } else  // not part of assembly, so a normal physical volume
           {
             G4RotationMatrix rot;
-            if(physvol->GetFrameRotation() != nullptr)
-            {
+            if (physvol->GetFrameRotation() != nullptr) {
               rot = *(physvol->GetFrameRotation());
             }
             G4Transform3D P(rot, physvol->GetObjectTranslation());
 
-            PhysvolWrite(volumeElement, physvol, invR * P * daughterR,
-                         ModuleName);
+            PhysvolWrite(volumeElement, physvol, invR * P * daughterR, ModuleName);
           }
         }
       }
@@ -758,14 +615,12 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
     GetBorderSurface(physvol);
   }
 
-  if(cexport)
-  {
+  if (cexport) {
     ExportEnergyCuts(volumePtr);
   }
   // Add optional energy cuts
 
-  if(sdexport)
-  {
+  if (sdexport) {
     ExportSD(volumePtr);
   }
   // Add optional SDs
@@ -773,8 +628,7 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
   // Here write the auxiliary info
   //
   auxiter = auxmap.find(volumePtr);
-  if(auxiter != auxmap.cend())
-  {
+  if (auxiter != auxmap.cend()) {
     AddAuxInfo(&(auxiter->second), volumeElement);
   }
 
@@ -798,13 +652,10 @@ G4Transform3D GDMLWriteStructure::TraverseVolumeTree(
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
-                                              const G4LogicalVolume* const lvol)
-{
+void GDMLWriteStructure::AddVolumeAuxiliary(G4GDMLAuxStructType myaux, const G4LogicalVolume* const lvol) {
   auto pos = auxmap.find(lvol);
 
-  if(pos == auxmap.cend())
-  {
+  if (pos == auxmap.cend()) {
     auxmap[lvol] = G4GDMLAuxListType();
   }
 
@@ -812,40 +663,27 @@ void GDMLWriteStructure::AddVolumeAuxiliary(G4GDMLAuxStructType myaux,
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::SetEnergyCutsExport(G4bool fcuts)
-{
-  cexport = fcuts;
-}
+void GDMLWriteStructure::SetEnergyCutsExport(G4bool fcuts) { cexport = fcuts; }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::ExportEnergyCuts(const G4LogicalVolume* const lvol)
-{
+void GDMLWriteStructure::ExportEnergyCuts(const G4LogicalVolume* const lvol) {
   G4GDMLEvaluator eval;
-  G4ProductionCuts* pcuts     = lvol->GetRegion()->GetProductionCuts();
+  G4ProductionCuts* pcuts = lvol->GetRegion()->GetProductionCuts();
   G4ProductionCutsTable* ctab = G4ProductionCutsTable::GetProductionCutsTable();
-  G4Gamma* gamma              = G4Gamma::Gamma();
-  G4Electron* eminus          = G4Electron::Electron();
-  G4Positron* eplus           = G4Positron::Positron();
-  G4Proton* proton            = G4Proton::Proton();
+  G4Gamma* gamma = G4Gamma::Gamma();
+  G4Electron* eminus = G4Electron::Electron();
+  G4Positron* eplus = G4Positron::Positron();
+  G4Proton* proton = G4Proton::Proton();
 
-  G4double gamma_cut = ctab->ConvertRangeToEnergy(
-    gamma, lvol->GetMaterial(), pcuts->GetProductionCut("gamma"));
-  G4double eminus_cut = ctab->ConvertRangeToEnergy(
-    eminus, lvol->GetMaterial(), pcuts->GetProductionCut("e-"));
-  G4double eplus_cut = ctab->ConvertRangeToEnergy(
-    eplus, lvol->GetMaterial(), pcuts->GetProductionCut("e+"));
-  G4double proton_cut = ctab->ConvertRangeToEnergy(
-    proton, lvol->GetMaterial(), pcuts->GetProductionCut("proton"));
+  G4double gamma_cut = ctab->ConvertRangeToEnergy(gamma, lvol->GetMaterial(), pcuts->GetProductionCut("gamma"));
+  G4double eminus_cut = ctab->ConvertRangeToEnergy(eminus, lvol->GetMaterial(), pcuts->GetProductionCut("e-"));
+  G4double eplus_cut = ctab->ConvertRangeToEnergy(eplus, lvol->GetMaterial(), pcuts->GetProductionCut("e+"));
+  G4double proton_cut = ctab->ConvertRangeToEnergy(proton, lvol->GetMaterial(), pcuts->GetProductionCut("proton"));
 
-  G4GDMLAuxStructType gammainfo  = { "gammaECut",
-                                    eval.ConvertToString(gamma_cut), "MeV", 0 };
-  G4GDMLAuxStructType eminusinfo = { "electronECut",
-                                     eval.ConvertToString(eminus_cut), "MeV",
-                                     0 };
-  G4GDMLAuxStructType eplusinfo  = { "positronECut",
-                                    eval.ConvertToString(eplus_cut), "MeV", 0 };
-  G4GDMLAuxStructType protinfo   = { "protonECut",
-                                   eval.ConvertToString(proton_cut), "MeV", 0 };
+  G4GDMLAuxStructType gammainfo = {"gammaECut", eval.ConvertToString(gamma_cut), "MeV", 0};
+  G4GDMLAuxStructType eminusinfo = {"electronECut", eval.ConvertToString(eminus_cut), "MeV", 0};
+  G4GDMLAuxStructType eplusinfo = {"positronECut", eval.ConvertToString(eplus_cut), "MeV", 0};
+  G4GDMLAuxStructType protinfo = {"protonECut", eval.ConvertToString(proton_cut), "MeV", 0};
 
   AddVolumeAuxiliary(gammainfo, lvol);
   AddVolumeAuxiliary(eminusinfo, lvol);
@@ -854,41 +692,31 @@ void GDMLWriteStructure::ExportEnergyCuts(const G4LogicalVolume* const lvol)
 }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::SetSDExport(G4bool fsd)
-{
-  sdexport = fsd;
-}
+void GDMLWriteStructure::SetSDExport(G4bool fsd) { sdexport = fsd; }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::ExportSD(const G4LogicalVolume* const lvol)
-{
+void GDMLWriteStructure::ExportSD(const G4LogicalVolume* const lvol) {
   G4VSensitiveDetector* sd = lvol->GetSensitiveDetector();
 
-  if(sd != nullptr)
-  {
+  if (sd != nullptr) {
     G4String SDname = sd->GetName();
 
-    G4GDMLAuxStructType SDinfo = { "SensDet", SDname, "", 0 };
+    G4GDMLAuxStructType SDinfo = {"SensDet", SDname, "", 0};
     AddVolumeAuxiliary(SDinfo, lvol);
   }
 }
 
 // --------------------------------------------------------------------
-G4int GDMLWriteStructure::GetMaxExportLevel() const
-{
-  return maxLevel;
-}
+G4int GDMLWriteStructure::GetMaxExportLevel() const { return maxLevel; }
 
 // --------------------------------------------------------------------
-void GDMLWriteStructure::SetMaxExportLevel(G4int level)
-{
-  if(level <= 0)
-  {
-    G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup",
-                FatalException, "Levels to export must be greater than zero!");
+void GDMLWriteStructure::SetMaxExportLevel(G4int level) {
+  if (level <= 0) {
+    G4Exception("GDMLWriteStructure::TraverseVolumeTree()", "InvalidSetup", FatalException,
+                "Levels to export must be greater than zero!");
     return;
   }
   maxLevel = level;
-  levelNo  = 0;
+  levelNo = 0;
 }
-}
+}  // namespace RAT


### PR DESCRIPTION
This PR adds the capability for RAT-PAC to serialize and export its own simulation geometries and ratdb content so that they can be ingested by another program (for example, chroma). 

The overall geometry, material properties (as seen in Geant4 during simulation) are written to a [GDML](https://gdml.web.cern.ch/GDML/doc/GDMLmanual.pdf) file. We have copied over [Geant4's GDMLWrite directories](https://gitlab.cern.ch/geant4/geant4/-/tree/84a556a9dca683c2d541394a795642ecb4c07a3d/source/persistency/gdml) and extended it to account for RAT's custom solids (namely `GLG4TorusStack`), as well as extending the optical properties written (namely the dichroic surface properties). 

The entirety of the ratDB content is dumped into a single file, containing database entries as separate JSON entities. **Note that the dump currently only supports static tables located under the ratdb directory, but not entries grabbed from an online database instance.** This file is barely needed since material properties are mostly written into GDML. The only use for it in chroma at the moment is to retrieve the PMT channel information.