### PR TITLE
PMT Factory changes to accomodate mesh generation.

### DIFF
--- a/src/geo/src/pmt/RevolutionPMTConstruction.cc
+++ b/src/geo/src/pmt/RevolutionPMTConstruction.cc
@@ -107,7 +107,7 @@ G4LogicalVolume *RevolutionPMTConstruction::BuildVolume(const std::string &prefi
 
   // tolerance gap between inner1 and inner2, needed to prevent overlap due to
   // floating point roundoff
-  G4double hhgap = 0.5e-7;  // half the needed gap between the front and back of the PMT
+  G4double hhgap = 0.5e-3;  // half the needed gap between the front and back of the PMT
   G4double toleranceGapRadius = fParams.rInner[inner_equator_idx];  // gap goes at equator
 
   G4Tubs *central_gap_solid =

--- a/src/geo/src/pmt/RevolutionPMTConstruction.cc
+++ b/src/geo/src/pmt/RevolutionPMTConstruction.cc
@@ -85,6 +85,26 @@ G4LogicalVolume *RevolutionPMTConstruction::BuildVolume(const std::string &prefi
       break;
     }
   }
+  if (inner_equator_idx == 0) {
+    Log::Die("RevolutionPMTConstruction: inner equator not found");
+  }
+  // Snap to zero for inner equator, since we need to transition from photocathode to mirror at z=0
+  if (abs(fParams.zInner[inner_equator_idx]) < 1e-3) {
+    fParams.zInner[inner_equator_idx] = 0.0;
+  } else if (abs(fParams.zInner[inner_equator_idx - 1]) < 1e-3) {
+    fParams.zInner[inner_equator_idx - 1] = 0.0;
+    inner_equator_idx -= 1;
+  } else {
+    // linear interpolate what the radius should be at z=0
+    double &za = fParams.zInner[inner_equator_idx - 1];
+    double &zb = fParams.zInner[inner_equator_idx];
+    double &ra = fParams.rInner[inner_equator_idx - 1];
+    double &rb = fParams.rInner[inner_equator_idx];
+    double r0 = ra + (rb - ra) * (0.0 - za) / (zb - za);
+    fParams.zInner.insert(fParams.zInner.begin() + inner_equator_idx, 0.0);
+    fParams.rInner.insert(fParams.rInner.begin() + inner_equator_idx, r0);
+  }
+
   size_t edge_equator_idx;  // defined as zero in z
   for (edge_equator_idx = 0; edge_equator_idx < fParams.zEdge.size(); edge_equator_idx++) {
     if (fParams.zEdge[edge_equator_idx] <= 0.0) {

--- a/src/geo/src/pmt/ToroidalPMTConstruction.cc
+++ b/src/geo/src/pmt/ToroidalPMTConstruction.cc
@@ -132,7 +132,7 @@ G4LogicalVolume *ToroidalPMTConstruction::BuildVolume(const std::string &prefix)
 
   // tolerance gap between inner1 and inner2, needed to prevent overlap due to
   // floating point roundoff
-  G4double hhgap = 0.5e-7;  // half the needed gap between the front and back of the PMT
+  G4double hhgap = 0.5e-3;  // half the needed gap between the front and back of the PMT
   G4double toleranceGapRadius = innerRhoEdge[equatorIndex];  // the outer radius of the gap needs to be
   // equal to the inner radius of the PMT where
   // inner1 and inner2 join


### PR DESCRIPTION
This PR includes modifications to the PMT Factories that allows triangulated geometries to be more easily generated:
- There exist a "gap" volume in the PMT factories to avoid volume overlaps between the two inner volumes (one covered by photocathode, the other covered in mirror). This gap results in cylinders of very small height, resulting in numerical precision issues during mesh generation. The gap width is adjusted from 1e-07 to 1e-03 mm such that it is small enough to not greatly alter the PMT geometry, but alleviates the precision issues.

- The revolution PMT geometry currently has overlap issues if no datapoint is specifically set at z=0, since there is no check in Z coordinate position when the inner volume is split in half. A check is added to insert an interpolated datapoint at z=0, if needed.