### PR TITLE
Add PMT channel to PMTInfo

### DIFF
--- a/src/ds/include/RAT/DS/PMTInfo.hh
+++ b/src/ds/include/RAT/DS/PMTInfo.hh
@@ -41,7 +41,7 @@ class PMTInfo : public TObject {
   }
 
   virtual void AddPMT(const TVector3& _pos, const TVector3& _dir, const int _type) {
-    AddPMT(_pos, _dir, _type, -1.0, "", 1.0, 0.0, 0.0);
+    AddPMT(_pos, _dir, _type, -1, "", 1.0, 0.0, 0.0);
   }
 
   virtual Int_t GetPMTCount() const { return pos.size(); }

--- a/src/ds/include/RAT/DS/PMTInfo.hh
+++ b/src/ds/include/RAT/DS/PMTInfo.hh
@@ -21,12 +21,13 @@ class PMTInfo : public TObject {
   PMTInfo() : TObject() {}
   virtual ~PMTInfo() {}
 
-  virtual void AddPMT(const TVector3& _pos, const TVector3& _dir, const int _type, const std::string _model,
-                      const double _individual_efficiency_corr, const double _individual_noise_rate,
-                      const double _individual_afterpulse_fraction) {
+  virtual void AddPMT(const TVector3& _pos, const TVector3& _dir, const int _type, const int _ch,
+                      const std::string _model, const double _individual_efficiency_corr,
+                      const double _individual_noise_rate, const double _individual_afterpulse_fraction) {
     pos.push_back(_pos);
     dir.push_back(_dir);
     type.push_back(_type);
+    channel.push_back(_ch);
     individual_efficiency_corr.push_back(_individual_efficiency_corr);
     individual_noise_rate.push_back(_individual_noise_rate);
     individual_afterpulse_fraction.push_back(_individual_afterpulse_fraction);
@@ -40,7 +41,7 @@ class PMTInfo : public TObject {
   }
 
   virtual void AddPMT(const TVector3& _pos, const TVector3& _dir, const int _type) {
-    AddPMT(_pos, _dir, _type, "", 1.0, 0.0, 0.0);
+    AddPMT(_pos, _dir, _type, -1.0, "", 1.0, 0.0, 0.0);
   }
 
   virtual Int_t GetPMTCount() const { return pos.size(); }
@@ -50,6 +51,9 @@ class PMTInfo : public TObject {
 
   virtual TVector3 GetDirection(int id) const { return dir.at(id); }
   virtual void SetDirection(int id, const TVector3& _dir) { dir.at(id) = _dir; }
+
+  virtual int GetChannelNumber(int id) const { return channel.at(id); }
+  virtual void SetChannelNumber(int id, int _ch) { channel.at(id) = _ch; }
 
   virtual int GetType(int id) const { return type.at(id); }
   virtual void SetType(int id, int _type) { type.at(id) = _type; }
@@ -83,12 +87,13 @@ class PMTInfo : public TObject {
 
   virtual std::string GetModelNameByID(int id) const { return GetModelName(GetModel(id)); }
 
-  ClassDef(PMTInfo, 2);
+  ClassDef(PMTInfo, 3);
 
  protected:
   std::vector<TVector3> pos;
   std::vector<TVector3> dir;
   std::vector<int> type;
+  std::vector<int> channel;
   std::vector<int> modeltype;
   std::vector<std::string> models;
   std::vector<double> individual_efficiency_corr;

--- a/src/ds/include/RAT/DS/PMTInfo.hh
+++ b/src/ds/include/RAT/DS/PMTInfo.hh
@@ -27,10 +27,10 @@ class PMTInfo : public TObject {
     pos.push_back(_pos);
     dir.push_back(_dir);
     type.push_back(_type);
-    channel.push_back(_ch);
     individual_efficiency_corr.push_back(_individual_efficiency_corr);
     individual_noise_rate.push_back(_individual_noise_rate);
     individual_afterpulse_fraction.push_back(_individual_afterpulse_fraction);
+    channel_num.push_back(_ch);
     std::vector<std::string>::iterator which = std::find(models.begin(), models.end(), _model);
     if (which != models.end()) {
       modeltype.push_back(which - models.begin());
@@ -52,8 +52,8 @@ class PMTInfo : public TObject {
   virtual TVector3 GetDirection(int id) const { return dir.at(id); }
   virtual void SetDirection(int id, const TVector3& _dir) { dir.at(id) = _dir; }
 
-  virtual int GetChannelNumber(int id) const { return channel.at(id); }
-  virtual void SetChannelNumber(int id, int _ch) { channel.at(id) = _ch; }
+  virtual int GetChannelNumber(int id) const { return channel_num.at(id); }
+  virtual void SetChannelNumber(int id, int _ch) { channel_num.at(id) = _ch; }
 
   virtual int GetType(int id) const { return type.at(id); }
   virtual void SetType(int id, int _type) { type.at(id) = _type; }
@@ -93,7 +93,7 @@ class PMTInfo : public TObject {
   std::vector<TVector3> pos;
   std::vector<TVector3> dir;
   std::vector<int> type;
-  std::vector<int> channel;
+  std::vector<int> channel_num;
   std::vector<int> modeltype;
   std::vector<std::string> models;
   std::vector<double> individual_efficiency_corr;

--- a/src/geo/include/RAT/PMTFactoryBase.hh
+++ b/src/geo/include/RAT/PMTFactoryBase.hh
@@ -13,6 +13,7 @@ class PMTFactoryBase : public GeoFactory {
  protected:
   virtual G4VPhysicalVolume *ConstructPMTs(DBLinkPtr table, const std::vector<G4ThreeVector> &pmt_pos,
                                            const std::vector<G4ThreeVector> &pmt_dir, const std::vector<int> &pmt_type,
+                                           const std::vector<int> &pmt_channel_number,
                                            const std::vector<double> &pmt_effi_corr,
                                            const std::vector<double> &individual_noise_rate,
                                            const std::vector<double> &individual_afterpulse_fraction);

--- a/src/geo/include/RAT/PMTInfoParser.hh
+++ b/src/geo/include/RAT/PMTInfoParser.hh
@@ -37,11 +37,13 @@ class PMTInfoParser {
   const std::vector<double> &GetPMTNoiseRates() { return fNoiseRate; }
   const std::vector<double> &GetPMTAfterPulseFraction() { return fAfterPulseFraction; }
   const std::vector<int> &GetTypes() { return fType; }
+  const std::vector<int> &GetChannelNumbers() { return fChannelNumber; }
 
  protected:
   G4ThreeVector fLocalOffset;
   std::vector<G4ThreeVector> fPos;
   std::vector<G4ThreeVector> fDir;
+  std::vector<int> fChannelNumber;
   std::vector<int> fType;
   std::vector<double> fEfficiencyCorrection;
   std::vector<double> fNoiseRate;

--- a/src/geo/src/pmt/PMTArrayFactory.cc
+++ b/src/geo/src/pmt/PMTArrayFactory.cc
@@ -17,6 +17,7 @@ G4VPhysicalVolume *PMTArrayFactory::Construct(DBLinkPtr table) {
   PMTInfoParser pmtinfo(lpos_table, mother_name);
 
   const std::vector<int> &pmtinfo_types = pmtinfo.GetTypes();
+  const std::vector<int> &pmtinfo_channel_numbers = pmtinfo.GetChannelNumbers();
   const std::vector<G4ThreeVector> &pmtinfo_pos = pmtinfo.GetPMTLocations();
   const std::vector<G4ThreeVector> &pmtinfo_dir = pmtinfo.GetPMTDirections();
   const G4ThreeVector local_offset = pmtinfo.GetLocalOffset();
@@ -102,7 +103,8 @@ G4VPhysicalVolume *PMTArrayFactory::Construct(DBLinkPtr table) {
     }
   }
 
-  return ConstructPMTs(table, pos, dir, ptypes, pmtinfo_effcorrs, pmtinfo_noiserates, pmtinfo_afterpulse_fraction);
+  return ConstructPMTs(table, pos, dir, ptypes, pmtinfo_channel_numbers, pmtinfo_effcorrs, pmtinfo_noiserates,
+                       pmtinfo_afterpulse_fraction);
 }
 
 }  // namespace RAT

--- a/src/geo/src/pmt/PMTArrayFactory.cc
+++ b/src/geo/src/pmt/PMTArrayFactory.cc
@@ -17,13 +17,13 @@ G4VPhysicalVolume *PMTArrayFactory::Construct(DBLinkPtr table) {
   PMTInfoParser pmtinfo(lpos_table, mother_name);
 
   const std::vector<int> &pmtinfo_types = pmtinfo.GetTypes();
-  const std::vector<int> &pmtinfo_channel_numbers = pmtinfo.GetChannelNumbers();
   const std::vector<G4ThreeVector> &pmtinfo_pos = pmtinfo.GetPMTLocations();
   const std::vector<G4ThreeVector> &pmtinfo_dir = pmtinfo.GetPMTDirections();
   const G4ThreeVector local_offset = pmtinfo.GetLocalOffset();
   const std::vector<double> &pmtinfo_effcorrs = pmtinfo.GetEfficiencyCorrections();
   const std::vector<double> &pmtinfo_noiserates = pmtinfo.GetPMTNoiseRates();
   const std::vector<double> &pmtinfo_afterpulse_fraction = pmtinfo.GetPMTAfterPulseFraction();
+  const std::vector<int> &pmtinfo_channel_numbers = pmtinfo.GetChannelNumbers();
 
   int start_idx, end_idx;
   try {
@@ -83,9 +83,11 @@ G4VPhysicalVolume *PMTArrayFactory::Construct(DBLinkPtr table) {
 
   std::vector<G4ThreeVector> pos(end_idx - start_idx + 1), dir(end_idx - start_idx + 1);
   std::vector<int> ptypes(end_idx - start_idx + 1);
+  std::vector<int> channels(end_idx - start_idx + 1);
   for (int idx = start_idx, i = 0; idx <= end_idx; idx++, i++) {
     pos[i] = pmtinfo_pos[idx];
     ptypes[i] = pmtinfo_types[idx];
+    channels[i] = pmtinfo_channel_numbers[idx];
     if (rescale_radius) {
       pos[i].setMag(new_radius);
     }
@@ -103,7 +105,7 @@ G4VPhysicalVolume *PMTArrayFactory::Construct(DBLinkPtr table) {
     }
   }
 
-  return ConstructPMTs(table, pos, dir, ptypes, pmtinfo_channel_numbers, pmtinfo_effcorrs, pmtinfo_noiserates,
+  return ConstructPMTs(table, pos, dir, ptypes, channels, pmtinfo_effcorrs, pmtinfo_noiserates,
                        pmtinfo_afterpulse_fraction);
 }
 

--- a/src/geo/src/pmt/PMTCoverageFactory.cc
+++ b/src/geo/src/pmt/PMTCoverageFactory.cc
@@ -59,12 +59,14 @@ G4VPhysicalVolume *PMTCoverageFactory::Construct(DBLinkPtr table) {
   std::vector<double> individual_noise_rates(Npmt, 0.0);
   std::vector<double> individual_afterpulse_fraction(Npmt, 0.0);
   std::vector<int> type(Npmt, 0);
+  std::vector<int> channel_number(Npmt, -1);
   std::vector<double> effi_corr(Npmt, 1.0);
   for (int i = 0; i < Npmt; i++) {
     pos[i].set(xpmt[i], ypmt[i], zpmt[i]);
     dir[i].set(-xpmt[i], -ypmt[i], zpmt[i]);
   }
 
-  return ConstructPMTs(table, pos, dir, type, effi_corr, individual_noise_rates, individual_afterpulse_fraction);
+  return ConstructPMTs(table, pos, dir, type, channel_number, effi_corr, individual_noise_rates,
+                       individual_afterpulse_fraction);
 }
 }  // namespace RAT

--- a/src/geo/src/pmt/PMTFactoryBase.cc
+++ b/src/geo/src/pmt/PMTFactoryBase.cc
@@ -23,12 +23,10 @@ namespace RAT {
 
 DS::PMTInfo PMTFactoryBase::pmtinfo;
 
-G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vector<G4ThreeVector> &pmt_pos,
-                                                 const std::vector<G4ThreeVector> &pmt_dir,
-                                                 const std::vector<int> &pmt_type,
-                                                 const std::vector<double> &pmt_effi_corr,
-                                                 const std::vector<double> &individual_noise_rate,
-                                                 const std::vector<double> &individual_afterpulse_fraction) {
+G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(
+    DBLinkPtr table, const std::vector<G4ThreeVector> &pmt_pos, const std::vector<G4ThreeVector> &pmt_dir,
+    const std::vector<int> &pmt_type, const std::vector<int> &channel_number, const std::vector<double> &pmt_effi_corr,
+    const std::vector<double> &individual_noise_rate, const std::vector<double> &individual_afterpulse_fraction) {
   std::string volume_name = table->GetS("index");
   std::string mother_name = table->GetS("mother");
   std::string pmt_model = table->GetS("pmt_model");
@@ -245,7 +243,7 @@ G4VPhysicalVolume *PMTFactoryBase::ConstructPMTs(DBLinkPtr table, const std::vec
     // NOTE: Since the BField stuff isn't used currently, add the efficiency here.
     // If we revive the BField code, this needs to be moved after so that the efficiency is correct
     pmtinfo.AddPMT(TVector3(pmtpos.x(), pmtpos.y(), pmtpos.z()), TVector3(pmtdir.x(), pmtdir.y(), pmtdir.z()),
-                   pmt_type[i], pmt_model, pmt_effi_corr[i], individual_noise_rate[i],
+                   pmt_type[i], channel_number[i], pmt_model, pmt_effi_corr[i], individual_noise_rate[i],
                    individual_afterpulse_fraction[i]);
 
     // if requested, generates the magnetic efficiency corrections as the PMTs

--- a/src/geo/src/pmt/PMTInfoParser.cc
+++ b/src/geo/src/pmt/PMTInfoParser.cc
@@ -48,7 +48,7 @@ PMTInfoParser::PMTInfoParser(DBLinkPtr lpos_table, const std::string &mother_nam
     fChannelNumber = lpos_table->GetIArray("channel_number");
     Log::Assert(fPos.size() == fChannelNumber.size(), "PMTInfoParser: PMTInfo arrays must be same length!");
   } catch (DBNotFoundError &e) {
-    fChannelNumber.resize(0);
+    fChannelNumber.resize(fPos.size());
     fill(fChannelNumber.begin(), fChannelNumber.end(), -1);
   }
 

--- a/src/geo/src/pmt/PMTInfoParser.cc
+++ b/src/geo/src/pmt/PMTInfoParser.cc
@@ -44,6 +44,14 @@ PMTInfoParser::PMTInfoParser(DBLinkPtr lpos_table, const std::string &mother_nam
     fDir.resize(0);
   }
 
+  try {
+    fChannelNumber = lpos_table->GetIArray("channel_number");
+    Log::Assert(fPos.size() == fChannelNumber.size(), "PMTInfoParser: PMTInfo arrays must be same length!");
+  } catch (DBNotFoundError &e) {
+    fChannelNumber.resize(0);
+    fill(fChannelNumber.begin(), fChannelNumber.end(), -1);
+  }
+
   // Logical type of PMT (e.g. normal, veto, etc)
   try {
     fType = lpos_table->GetIArray("type");  // functional type (e.g. inner, veto, etc. - arbitrary integers)

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -67,6 +67,7 @@ class OutNtupleProc : public Processor {
   std::string macro;
   std::vector<int> pmtType;
   std::vector<int> pmtId;
+  std::vector<int> pmtChannel;
   std::vector<double> pmtX;
   std::vector<double> pmtY;
   std::vector<double> pmtZ;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -69,6 +69,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   metaTree->Branch("macro", &macro);
   metaTree->Branch("pmtType", &pmtType);
   metaTree->Branch("pmtId", &pmtId);
+  metaTree->Branch("pmtChannel", &pmtChannel);
   metaTree->Branch("pmtX", &pmtX);
   metaTree->Branch("pmtY", &pmtY);
   metaTree->Branch("pmtZ", &pmtZ);
@@ -446,10 +447,12 @@ OutNtupleProc::~OutNtupleProc() {
     DS::PMTInfo *pmtinfo = runBranch->GetPMTInfo();
     for (int id = 0; id < pmtinfo->GetPMTCount(); id++) {
       int type = pmtinfo->GetType(id);
+      int channel = pmtinfo->GetChannelNumber(id);
       TVector3 position = pmtinfo->GetPosition(id);
       TVector3 direction = pmtinfo->GetDirection(id);
       pmtType.push_back(type);
       pmtId.push_back(id);
+      pmtChannel.push_back(channel);
       pmtX.push_back(position.X());
       pmtY.push_back(position.Y());
       pmtZ.push_back(position.Z());


### PR DESCRIPTION
PMT ID populates in the order they're built in the geometry. Channel number can be used to make the actual channel number in the detector, to map from electronics channel to detector position. 