### PR TITLE
Add seperate branches in ntuple for MCPE frontend time and hit time

### DIFF
--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -96,7 +96,7 @@ class OutNtupleProc : public Processor {
   std::vector<int> mcpmtid;
   std::vector<int> mcpmtnpe;
   // MCPE
-  std::vector<double> mcpetime;
+  std::vector<double> mcpehittime;
   std::vector<double> mcpefrontendtime;
   std::vector<int> mcpeprocess;
   std::vector<double> mcpewavelength;

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -97,6 +97,7 @@ class OutNtupleProc : public Processor {
   std::vector<int> mcpmtnpe;
   // MCPE
   std::vector<double> mcpetime;
+  std::vector<double> mcpefrontendtime;
   std::vector<int> mcpeprocess;
   std::vector<double> mcpewavelength;
   std::vector<double> mcpex;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -135,6 +135,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
     outputTree->Branch("mcPMTNPE", &mcpmtnpe);
 
     outputTree->Branch("mcPETime", &mcpetime);
+    outputTree->Branch("mcPEFrontEndTime", &mcpefrontendtime);
     // Production process
     // 1=Cherenkov, 0=Dark noise, 2=Scint., 3=Reem., 4=Unknown
     outputTree->Branch("mcPEProcess", &mcpeprocess);
@@ -288,6 +289,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
 
   // MCPE information
   mcpetime.clear();
+  mcpefrontendtime.clear();
   mcpeprocess.clear();
   mcpewavelength.clear();
   mcpex.clear();
@@ -304,7 +306,8 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       TVector3 position = pmtinfo->GetPosition(mcpmt->GetID());
       for (int ipe = 0; ipe < mcpmt->GetMCPhotonCount(); ipe++) {
         RAT::DS::MCPhoton *mcph = mcpmt->GetMCPhoton(ipe);
-        mcpetime.push_back(mcph->GetFrontEndTime());
+        mcpetime.push_back(mcph->GetHitTime());
+        mcpefrontendtime.push_back(mcph->GetFrontEndTime());
         mcpewavelength.push_back(mcph->GetLambda());
         mcpex.push_back(position.X());
         mcpey.push_back(position.Y());

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -134,7 +134,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
     outputTree->Branch("mcPMTID", &mcpmtid);
     outputTree->Branch("mcPMTNPE", &mcpmtnpe);
 
-    outputTree->Branch("mcPETime", &mcpetime);
+    outputTree->Branch("mcPEHitTime", &mcpehittime);
     outputTree->Branch("mcPEFrontEndTime", &mcpefrontendtime);
     // Production process
     // 1=Cherenkov, 0=Dark noise, 2=Scint., 3=Reem., 4=Unknown
@@ -288,7 +288,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
   mcpmtnpe.clear();
 
   // MCPE information
-  mcpetime.clear();
+  mcpehittime.clear();
   mcpefrontendtime.clear();
   mcpeprocess.clear();
   mcpewavelength.clear();
@@ -306,7 +306,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       TVector3 position = pmtinfo->GetPosition(mcpmt->GetID());
       for (int ipe = 0; ipe < mcpmt->GetMCPhotonCount(); ipe++) {
         RAT::DS::MCPhoton *mcph = mcpmt->GetMCPhoton(ipe);
-        mcpetime.push_back(mcph->GetHitTime());
+        mcpehittime.push_back(mcph->GetHitTime());
         mcpefrontendtime.push_back(mcph->GetFrontEndTime());
         mcpewavelength.push_back(mcph->GetLambda());
         mcpex.push_back(position.X());


### PR DESCRIPTION
**Potentially breaking!**

Old `mcPETime` in ntuple is the time that front-end electronics see a detected photon, which includes timing effects of the PMT. This PR modifies this behavior such that the branch `mcPETime` now records the time that a photon hits the PMT. The front-end time is written to a new branch named `mcPEFrontEndTime`.

Since this change assigns an old variable name to a new definition, previously-implemented analysis may need to be modified to account for it.