### PR TITLE
Fix Materials.cc when scaling scint pdf

### DIFF
--- a/src/geo/src/Materials.cc
+++ b/src/geo/src/Materials.cc
@@ -460,6 +460,7 @@ G4MaterialPropertyVector *Materials::LoadProperty(DBLinkPtr table, std::string n
       if (E_value != 0.0) {
         double lam = E_value;
         E_value = CLHEP::twopi * CLHEP::hbarc / (lam * CLHEP::nanometer);
+        if (wavelength_opt == 1) p_value *= 1.0 / (E_value * E_value);
         if (wavelength_opt == 2) p_value *= lam / E_value;
       } else {
         warn << "Materials property std::vector zero wavelength!" << newline;


### PR DESCRIPTION
Fixes #141.  This only applies the Jacobian element to optical ratdb entries with the 'wavelength' key option specified (wavelength_opt == 1).  The 'dy_dwavelength' keyword (wavelength_opt == 2) will need a closer look as I am unfamiliar with what y stands for in this context.
[EOS_ratpac_jacobian.pdf](https://github.com/user-attachments/files/16088445/EOS_ratpac_jacobian.pdf)
