### PR TITLE
Companion changes for the Eos InHDF5Producer

### DIFF
--- a/src/core/src/ProducerBlock.cc
+++ b/src/core/src/ProducerBlock.cc
@@ -15,6 +15,9 @@ ProducerBlock::~ProducerBlock() { Clear(); }
 
 void ProducerBlock::Init(ProcBlock *theMainBlock) {
   mainBlock = theMainBlock;
+  for (Producer *p : fProducerList) {
+    p->SetMainBlock(mainBlock);
+  }
   AppendProducer<RunManager>();
   AppendProducer<InROOTProducer>();
   AppendProducer<InNetProducer>();

--- a/src/daq/include/RAT/Digitizer.hh
+++ b/src/daq/include/RAT/Digitizer.hh
@@ -47,7 +47,7 @@ class Digitizer {
   int fNSamples;            // Total number of samples per digitized trace
   double fTerminationOhms;  // Input impedence of digitizer
   // Channel:Digitized waveform for each channel
-  std::map<UShort_t, std::vector<UShort_t>> fDigitWaveForm;
+  std::map<int, std::vector<UShort_t>> fDigitWaveForm;
 
   std::map<std::string, PMTWaveformGenerator *> fPMTWaveformGenerators;
 

--- a/src/daq/include/RAT/WaveformAnalysis.hh
+++ b/src/daq/include/RAT/WaveformAnalysis.hh
@@ -28,9 +28,11 @@ namespace RAT {
 class WaveformAnalysis {
  public:
   WaveformAnalysis();
+  WaveformAnalysis(std::string analyzer_name);
   virtual ~WaveformAnalysis(){};
 
   void RunAnalysis(DS::DigitPMT *pmt, int pmtID, Digitizer *fDigitizer);
+  double RunAnalysisOnTrigger(int pmtID, Digitizer *fDigitizer);
 
   // Calculate baseline (in mV)
   void CalculatePedestal();
@@ -40,7 +42,15 @@ class WaveformAnalysis {
 
   // Apply a constant fraction discriminator to
   // calculate the threshold crossing
-  double CalculateTime();
+  double CalculateTimeCFD();
+
+  // Calculate the time a threshold crossing occurs, with a linear interpolation
+  double CalculateThresholdCrossingTime();
+
+  double CalculateThresholdCrossingTime(double voltage_threshold) {
+    fVoltageCrossing = voltage_threshold;
+    return CalculateThresholdCrossingTime();
+  }
 
   // Find the sample where a threshold crossing occurs
   void GetThresholdCrossing();
@@ -56,6 +66,8 @@ class WaveformAnalysis {
 
   // Integrate the digitized waveform to calculate charge
   void SlidingIntegral();
+
+  double DigitToVoltage(UShort_t digit) { return (digit - fPedestal) * fVoltageRes; }
 
  protected:
   // Digitizer settings

--- a/src/daq/src/Digitizer.cc
+++ b/src/daq/src/Digitizer.cc
@@ -40,13 +40,13 @@ void Digitizer::DigitizePMT(DS::MCPMT* mcpmt, int pmtID, double triggerTime, DS:
 void Digitizer::DigitizeSum(DS::EV* ev) {
   DS::Digit digit;
 
-  std::map<UShort_t, std::vector<UShort_t>> waveforms = fDigitWaveForm;
-  for (std::map<UShort_t, std::vector<UShort_t>>::const_iterator it = waveforms.begin(); it != waveforms.end(); it++) {
-    digit.SetWaveform(UShort_t(it->first), waveforms[UShort_t(it->first)]);
+  std::map<int, std::vector<UShort_t>> waveforms = fDigitWaveForm;
+  for (std::map<int, std::vector<UShort_t>>::const_iterator it = waveforms.begin(); it != waveforms.end(); it++) {
+    digit.SetWaveform(it->first, waveforms[UShort_t(it->first)]);
   }
 
   digit.SetDigitName(fDigitName);
-  digit.SetNSamples(UShort_t(fNSamples));
+  digit.SetNSamples(uint32_t(fNSamples));
   digit.SetNBits(UShort_t(fNBits));
   digit.SetDynamicRange((fVhigh - fVlow));
   digit.SetSamplingRate(fSamplingRate);
@@ -78,7 +78,7 @@ void Digitizer::AddChannel(int ichannel, PMTWaveform pmtwf) {
     }
 
     // Save sample
-    fDigitWaveForm[UShort_t(ichannel)].push_back(UShort_t(adcs));
+    fDigitWaveForm[ichannel].push_back(UShort_t(adcs));
 
     // Step on time
     currenttime += timeres;

--- a/src/daq/src/WaveformAnalysis.cc
+++ b/src/daq/src/WaveformAnalysis.cc
@@ -145,7 +145,7 @@ void WaveformAnalysis::GetThresholdCrossing() {
 
     // Reached the begining of the waveform
     // returned an invalid value
-    if (i == 0) {
+    if (i == back_window) {
       fThresholdCrossing = INVALID;
       break;
     }

--- a/src/ds/include/RAT/DS/Digit.hh
+++ b/src/ds/include/RAT/DS/Digit.hh
@@ -32,8 +32,8 @@ class Digit : public TObject {
   virtual Double_t GetSamplingRate() const { return sampling_rate; };
 
   // Total number of samples
-  virtual void SetNSamples(UShort_t _nsamples) { nsamples = _nsamples; };
-  virtual UShort_t GetNSamples() const { return nsamples; };
+  virtual void SetNSamples(uint32_t _nsamples) { nsamples = _nsamples; };
+  virtual uint32_t GetNSamples() const { return nsamples; };
 
   // ADC bits
   virtual void SetNBits(UShort_t _nbits) { nbits = _nbits; };
@@ -44,24 +44,23 @@ class Digit : public TObject {
   virtual Double_t GetDynamicRange() const { return dynamic_range; };
 
   /// Set a waveform, overwrites existing
-  virtual void SetWaveform(const UShort_t waveformID, const std::vector<UShort_t> &samples) {
+  virtual void SetWaveform(const int waveformID, const std::vector<UShort_t> &samples) {
     waveforms[waveformID] = samples;
   }
 
   // Get a map of waveform IDs to digitized waveforms
-  virtual std::map<UShort_t, std::vector<UShort_t>> GetAllWaveforms() const { return waveforms; }
+  virtual std::map<int, std::vector<UShort_t>> GetAllWaveforms() const { return waveforms; }
 
   // Get the waveform for a digitizer
-  virtual std::vector<UShort_t> GetWaveform(const UShort_t waveformID) const { return waveforms.at(waveformID); }
+  virtual std::vector<UShort_t> GetWaveform(const int waveformID) const { return waveforms.at(waveformID); }
 
   /// Check if a waveform exists
-  Bool_t ExistsWaveform(const UShort_t waveformID) const { return waveforms.count(waveformID) > 0; }
+  Bool_t ExistsWaveform(const int waveformID) const { return waveforms.count(waveformID) > 0; }
 
   /// Get a list (vector) of all the IDs that are available
-  std::vector<UShort_t> GetIDs() const {
-    std::vector<UShort_t> ret;
-    for (std::map<UShort_t, std::vector<UShort_t>>::const_iterator it = waveforms.begin(); it != waveforms.end();
-         it++) {
+  std::vector<int> GetIDs() const {
+    std::vector<int> ret;
+    for (std::map<int, std::vector<UShort_t>>::const_iterator it = waveforms.begin(); it != waveforms.end(); it++) {
       ret.push_back(it->first);
     }
     return ret;
@@ -70,15 +69,15 @@ class Digit : public TObject {
   /// Delete all waveforms
   virtual void PruneWaveforms() { waveforms.clear(); }
 
-  ClassDef(Digit, 2);
+  ClassDef(Digit, 3);
 
  protected:
   std::string name;
   Double_t sampling_rate;
-  UShort_t nsamples;
+  uint32_t nsamples;
   UShort_t nbits;
   Double_t dynamic_range;
-  std::map<UShort_t, std::vector<UShort_t>> waveforms;  ///< Map of input number to samples
+  std::map<int, std::vector<UShort_t>> waveforms;  ///< Map of input number to samples
 };
 
 }  // namespace DS

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -64,20 +64,25 @@ class DigitPMT : public TObject {
   virtual void SetPeakVoltage(Double_t _peak) { this->peak = _peak; }
   virtual Double_t GetPeakVoltage() { return peak; }
 
-  ClassDef(DigitPMT, 1);
+  /** Local trigger time at the location of the PMT. Useful for PMT timing corrections */
+  virtual void SetLocalTriggerTime(Double_t _trigger_time) { this->local_trigger_time = _trigger_time; }
+  virtual Double_t GetLocalTriggerTime() { return local_trigger_time; }
+
+  ClassDef(DigitPMT, 2);
 
  protected:
-  Int_t id;
-  Double_t dTime;
-  Double_t dCharge;
-  Double_t dTCharge;
-  Double_t iTime;
-  Int_t sTime;
-  Int_t nCrossings;
-  Double_t timeOverThresh;
-  Double_t voltageOverThresh;
-  Double_t pedestal;
-  Double_t peak;
+  Int_t id = -9999;
+  Double_t dTime = -9999;
+  Double_t dCharge = -9999;
+  Double_t dTCharge = -9999;
+  Double_t iTime = -9999;
+  Int_t sTime = -9999;
+  Int_t nCrossings = -9999;
+  Double_t timeOverThresh = -9999;
+  Double_t voltageOverThresh = -9999;
+  Double_t pedestal = -9999;
+  Double_t peak = -9999;
+  Double_t local_trigger_time = -9999;
 };
 
 }  // namespace DS

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -127,6 +127,7 @@ class OutNtupleProc : public Processor {
   std::vector<double> hitPMTDigitizedTime;
   std::vector<double> hitPMTDigitizedCharge;
   std::vector<int> hitPMTNCrossings;
+  std::vector<double> hitPMTDigitizedLocalTriggerTime;
   // Tracking
   std::map<std::string, int> processCodeMap;
   std::vector<int> processCodeIndex;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -203,14 +203,14 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     mcTime.push_back(particle->GetTime());
   }
   // First particle's position, direction, and time
-  mcpdg = pdgcodes[0];
-  mcx = mcPosx[0];
-  mcy = mcPosy[0];
-  mcz = mcPosz[0];
-  mcu = mcDirx[0];
-  mcv = mcDiry[0];
-  mcw = mcDirz[0];
-  mct = mcTime[0];
+  mcpdg = mcpcount ? pdgcodes[0] : -9999;
+  mcx = mcpcount ? mcPosx[0] : -9999;
+  mcy = mcpcount ? mcPosy[0] : -9999;
+  mcz = mcpcount ? mcPosz[0] : -9999;
+  mcu = mcpcount ? mcDirx[0] : -9999;
+  mcv = mcpcount ? mcDiry[0] : -9999;
+  mcw = mcpcount ? mcDirz[0] : -9999;
+  mct = mcpcount ? mcTime[0] : -9999;
   mcke = accumulate(mcKEnergies.begin(), mcKEnergies.end(), 0.0);
   // Tracking
   if (options.tracking) {

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -128,6 +128,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
     outputTree->Branch("hitPMTDigitizedTime", &hitPMTDigitizedTime);
     outputTree->Branch("hitPMTDigitizedCharge", &hitPMTDigitizedCharge);
     outputTree->Branch("hitPMTNCrossings", &hitPMTNCrossings);
+    outputTree->Branch("hitPMTDigitizedLocalTriggerTime", &hitPMTDigitizedLocalTriggerTime);
   }
   if (options.mchits) {
     // Save full MC PMT hit information
@@ -407,6 +408,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       hitPMTDigitizedTime.clear();
       hitPMTDigitizedCharge.clear();
       hitPMTNCrossings.clear();
+      hitPMTDigitizedLocalTriggerTime.clear();
 
       for (int pmtc = 0; pmtc < ev->GetPMTCount(); pmtc++) {
         RAT::DS::PMT *pmt = ev->GetPMT(pmtc);
@@ -419,6 +421,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
         hitPMTDigitizedTime.push_back(digitpmt->GetDigitizedTime());
         hitPMTDigitizedCharge.push_back(digitpmt->GetDigitizedCharge());
         hitPMTNCrossings.push_back(digitpmt->GetNCrossings());
+        hitPMTDigitizedLocalTriggerTime.push_back(digitpmt->GetLocalTriggerTime());
       }
     }
     this->FillEvent(ds, ev);
@@ -434,6 +437,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       hitPMTDigitizedTime.clear();
       hitPMTDigitizedCharge.clear();
       hitPMTNCrossings.clear();
+      hitPMTDigitizedLocalTriggerTime.clear();
     }
     this->FillNoTriggerEvent(ds);
     outputTree->Fill();

--- a/src/ratbase/include/RAT/Rat.hh
+++ b/src/ratbase/include/RAT/Rat.hh
@@ -5,6 +5,7 @@
 #include <RAT/AnyParse.hh>
 #include <RAT/DB.hh>
 #include <RAT/DBMessenger.hh>
+#include <RAT/ProducerBlock.hh>
 #include <RAT/RatMessenger.hh>
 #include <set>
 
@@ -26,6 +27,7 @@ class Rat {
   DB *rdb;
   DBMessenger *rdb_messenger;
   RatMessenger *rat_messenger;
+  ProducerBlock prodBlock;
 
  public:
   inline static std::set<std::string> ratdb_directories = {};

--- a/src/ratbase/src/Rat.cc
+++ b/src/ratbase/src/Rat.cc
@@ -15,7 +15,6 @@
 #include <RAT/OutROOTProc.hh>
 #include <RAT/ProcBlock.hh>
 #include <RAT/ProcBlockManager.hh>
-#include <RAT/ProducerBlock.hh>
 #include <RAT/PythonProc.hh>
 #include <RAT/Rat.hh>
 #include <RAT/SignalHandler.hh>
@@ -140,10 +139,8 @@ void Rat::Begin() {
       info << "Setting default vector file to " << this->vector_filename << newline;
     }
 
-    // Build event producers
-    ProducerBlock *prodBlock = new ProducerBlock();
     // Main analysis block
-    ProcBlock *mainBlock = new ProcBlock(prodBlock);
+    ProcBlock *mainBlock = new ProcBlock(&prodBlock);
     // Process block manager -- supplies user commands to construct analyis
     // sequence and does the processor creation
     ProcBlockManager *blockManager = new ProcBlockManager(mainBlock);
@@ -184,7 +181,6 @@ void Rat::Begin() {
 
     delete blockManager;
     delete mainBlock;
-    delete prodBlock;
     delete rdb_messenger;
     delete trackingMessenger;
   } catch (DBNotFoundError &e) {


### PR DESCRIPTION
- Allow producers to be added in experiments built on top of ratpac2, such as EosSimulation.
- Fixes segfaults caused by OutNTuple when there are zero MC particles.
- Refactored and extended WaveformAnalysis:
  - Allow it to take in different ratdb entries by specifying their indices.
  - To allow for both Constant fraction discriminator and simple threshold timing
  - Use the simple threshold timing to allow simple step-like traces coming from digitized triggers to be analyzed.