### PR TITLE
Have PMTInfo account for Local Offset

### DIFF
--- a/src/geo/include/RAT/PMTInfoParser.hh
+++ b/src/geo/include/RAT/PMTInfoParser.hh
@@ -23,6 +23,7 @@ class PMTInfoParser {
   // Returns the offset between local and global coordinates
   // e.g. local = global - offset
   G4ThreeVector GetLocalOffset() { return fLocalOffset; }
+  static G4ThreeVector ComputeLocalOffset(const std::string &);
 
   // Returns the direction vector of the front face of the PMTs
   const std::vector<G4ThreeVector> &GetPMTDirections() const { return fDir; };

--- a/src/geo/src/pmt/PMTInfoParser.cc
+++ b/src/geo/src/pmt/PMTInfoParser.cc
@@ -96,15 +96,19 @@ PMTInfoParser::PMTInfoParser(DBLinkPtr lpos_table, const std::string &mother_nam
   if (phys_mother == 0) {
     Log::Die("PMTParser: PMT mother physical volume " + mother_name + " not found");
   }
+  fLocalOffset = ComputeLocalOffset(mother_name);
+}
 
+G4ThreeVector PMTInfoParser::ComputeLocalOffset(const std::string &mother_name) {
   // PMTINFO is always in global coordinates - so calculate the local offset first
-  fLocalOffset = G4ThreeVector(0.0, 0.0, 0.0);
+  G4ThreeVector offset(0.0, 0.0, 0.0);
   for (string parent_name = mother_name; parent_name != "";) {
     G4VPhysicalVolume *parent_phys = GeoFactory::FindPhysMother(parent_name);
-    fLocalOffset -= parent_phys->GetFrameTranslation();
+    offset -= parent_phys->GetFrameTranslation();
     DBLinkPtr parent_table = DB::Get()->GetLink("GEO", parent_name);
     parent_name = parent_table->GetS("mother");
   }
+  return offset;
 }
 
 G4RotationMatrix PMTInfoParser::GetPMTRotation(int i) const {


### PR DESCRIPTION
If the mother volume of the PMT arrays have an offset with respect to the world volume, pmtinfo will record pmt positions based on the mother volume's coordinate system. This patch accounts for it by:
- Adding a local_offset file in `DS::PMTInfo`, meaning that the offset will be recorded in outroot files.
- Have PMTInfo record the correct position, with respect to the world coordinates. This means that ntuple files as well as rat processors should now have access to the correct pmt positions.

@llebanowski -- this should address some of the offsets you are seeing when using the centroid fit processor (among any others). 

*Potentially breaking.*