### PR TITLE
Add channel number to the DS for the PMT objects

### DIFF
--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -548,6 +548,7 @@ void Gsim::MakeEvent(const G4Event *g4ev, DS::Root *ds) {
     // the index of the PMT we just added
     rat_mcpmt->SetID(a_pmt->GetID());
     rat_mcpmt->SetType(fPMTInfo->GetType(a_pmt->GetID()));
+    rat_mcpmt->SetChannel(fPMTInfo->GetChannelNumber(a_pmt->GetID()));
 
     numPE += a_pmt->GetEntries();
 

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -142,6 +142,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
     for (int imcpmt = 0; imcpmt < mc->GetMCPMTCount(); imcpmt++) {
       DS::MCPMT *mcpmt = mc->GetMCPMT(imcpmt);
       int pmtID = mcpmt->GetID();
+      int channel = mcpmt->GetChannel();
       // Check if the mcpmt has a time within one pulsewidth of the trigger window
       bool pmtInEvent = false;
       double integratedCharge = 0;
@@ -161,6 +162,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
       if (pmtInEvent) {
         DS::PMT *pmt = ev->AddNewPMT();
         pmt->SetID(pmtID);
+        pmt->SetChannel(channel);
         double front_end_hit_time = *std::min_element(hitTimes.begin(), hitTimes.end());
         // PMT Hit time relative to the trigger
         pmt->SetTime(front_end_hit_time - tt);
@@ -171,6 +173,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
           if (fAnalyze) {
             DS::DigitPMT *digitpmt = ev->AddNewDigitPMT();
             digitpmt->SetID(pmtID);
+            digitpmt->SetChannel(channel);
             fWaveformAnalysis->RunAnalysis(digitpmt, pmtID, fDigitizer);
           }
         }

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -24,6 +24,10 @@ class DigitPMT : public TObject {
   virtual void SetID(Int_t _id) { this->id = _id; }
   virtual Int_t GetID() { return id; }
 
+  /** Channel number of PMT */
+  virtual void SetChannel(Int_t _ch) { this->ch = _ch; }
+  virtual Int_t GetChannel() { return ch; }
+
   /** Threshold crossing time in ns */
   virtual void SetDigitizedTime(Double_t _dTime) { this->dTime = _dTime; }
   virtual Double_t GetDigitizedTime() { return dTime; }
@@ -80,10 +84,11 @@ class DigitPMT : public TObject {
   virtual void SetLocalTriggerTime(Double_t _trigger_time) { this->local_trigger_time = _trigger_time; }
   virtual Double_t GetLocalTriggerTime() { return local_trigger_time; }
 
-  ClassDef(DigitPMT, 3);
+  ClassDef(DigitPMT, 4);
 
  protected:
   Int_t id = -9999;
+  Int_t ch = -9999;
   Double_t dTime = -9999;
   Double_t dCharge = -9999;
   Double_t dTCharge = -9999;

--- a/src/ds/include/RAT/DS/MCPMT.hh
+++ b/src/ds/include/RAT/DS/MCPMT.hh
@@ -27,6 +27,10 @@ class MCPMT : public TObject {
   virtual Int_t GetID() const { return id; };
   virtual void SetID(Int_t _id) { id = _id; };
 
+  /** Channel number of PMT */
+  virtual void SetChannel(Int_t _ch) { this->ch = _ch; }
+  virtual Int_t GetChannel() { return ch; }
+
   /** Charge */
   virtual Double_t GetCharge() const;
 
@@ -57,10 +61,11 @@ class MCPMT : public TObject {
                  photon.end());
   }
 
-  ClassDef(MCPMT, 3);
+  ClassDef(MCPMT, 4);
 
  protected:
   Int_t id;
+  Int_t ch;
   Int_t type;
   std::vector<MCPhoton> photon;
 };

--- a/src/ds/include/RAT/DS/PMT.hh
+++ b/src/ds/include/RAT/DS/PMT.hh
@@ -22,6 +22,10 @@ class PMT : public TObject {
   virtual void SetID(Int_t _id) { this->id = _id; }
   virtual Int_t GetID() { return id; }
 
+  /** Channel number of PMT */
+  virtual void SetChannel(Int_t _ch) { this->ch = _ch; }
+  virtual Int_t GetChannel() { return ch; }
+
   /** Total charge in waveform (pC) */
   virtual void SetCharge(Double_t _charge) { this->charge = _charge; }
   virtual Double_t GetCharge() { return charge; }
@@ -61,10 +65,11 @@ class PMT : public TObject {
   virtual void SetPeakVoltage(Double_t _peak) { this->peak = _peak; }
   virtual Double_t GetPeakVoltage() { return peak; }
 
-  ClassDef(PMT, 4);
+  ClassDef(PMT, 5);
 
  protected:
   Int_t id;
+  Int_t ch;
   Double_t charge;
   Double_t time;
   Double_t dTime;

--- a/src/geo/include/RAT/PMTInfoParser.hh
+++ b/src/geo/include/RAT/PMTInfoParser.hh
@@ -23,6 +23,7 @@ class PMTInfoParser {
   // Returns the offset between local and global coordinates
   // e.g. local = global - offset
   G4ThreeVector GetLocalOffset() { return fLocalOffset; }
+  static G4ThreeVector ComputeLocalOffset(const std::string &);
 
   // Returns the direction vector of the front face of the PMTs
   const std::vector<G4ThreeVector> &GetPMTDirections() const { return fDir; };

--- a/src/geo/src/pmt/PMTInfoParser.cc
+++ b/src/geo/src/pmt/PMTInfoParser.cc
@@ -96,15 +96,19 @@ PMTInfoParser::PMTInfoParser(DBLinkPtr lpos_table, const std::string &mother_nam
   if (phys_mother == 0) {
     Log::Die("PMTParser: PMT mother physical volume " + mother_name + " not found");
   }
+  fLocalOffset = ComputeLocalOffset(mother_name);
+}
 
+G4ThreeVector PMTInfoParser::ComputeLocalOffset(const std::string &mother_name) {
   // PMTINFO is always in global coordinates - so calculate the local offset first
-  fLocalOffset = G4ThreeVector(0.0, 0.0, 0.0);
+  G4ThreeVector offset(0.0, 0.0, 0.0);
   for (string parent_name = mother_name; parent_name != "";) {
     G4VPhysicalVolume *parent_phys = GeoFactory::FindPhysMother(parent_name);
-    fLocalOffset -= parent_phys->GetFrameTranslation();
+    offset -= parent_phys->GetFrameTranslation();
     DBLinkPtr parent_table = DB::Get()->GetLink("GEO", parent_name);
     parent_name = parent_table->GetS("mother");
   }
+  return offset;
 }
 
 G4RotationMatrix PMTInfoParser::GetPMTRotation(int i) const {

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -96,6 +96,7 @@ class OutNtupleProc : public Processor {
   int mcnhits;
   int mcpecount;
   std::vector<int> mcpmtid;
+  std::vector<int> mcpmtchannel;
   std::vector<int> mcpmtnpe;
   std::vector<double> mcpmtcharge;
   // MCPE
@@ -125,15 +126,17 @@ class OutNtupleProc : public Processor {
   std::vector<double> fitu, fitv, fitw;
   // Store PMT Hit Positions
   std::vector<int> hitPMTID;
+  std::vector<int> hitChannel;
   std::vector<double> hitPMTTime;
   std::vector<double> hitPMTCharge;
   // Store PMT information from digitized waveform
+  std::vector<int> digitPMTID;
+  std::vector<int> digitChannel;
   std::vector<double> digitPeak;
   std::vector<double> digitTime;
   std::vector<double> digitCharge;
   std::vector<double> digitLocalTriggerTime;
   std::vector<int> digitNCrossings;
-  std::vector<int> digitPMTID;
   // Information from fit to the waveforms
   std::vector<double> fitTime;
   std::vector<double> fitBaseline;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -124,6 +124,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   if (options.pmthits) {
     // Save full PMT hit informations
     outputTree->Branch("hitPMTID", &hitPMTID);
+    outputTree->Branch("hitChannel", &hitChannel);
     // Information about *first* detected PE
     outputTree->Branch("hitPMTTime", &hitPMTTime);
     outputTree->Branch("hitPMTCharge", &hitPMTCharge);
@@ -131,6 +132,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   if (options.digitizerhits) {
     // Output of the waveform analysis
     outputTree->Branch("digitPMTID", &digitPMTID);
+    outputTree->Branch("digitChannel", &digitChannel);
     outputTree->Branch("digitTime", &digitTime);
     outputTree->Branch("digitCharge", &digitCharge);
     outputTree->Branch("digitNCrossings", &digitNCrossings);
@@ -146,6 +148,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   if (options.mchits) {
     // Save full MC PMT hit information
     outputTree->Branch("mcPMTID", &mcpmtid);
+    outputTree->Branch("mcPMTChannel", &mcpmtchannel);
     outputTree->Branch("mcPMTNPE", &mcpmtnpe);
     outputTree->Branch("mcPMTCharge", &mcpmtcharge);
 
@@ -302,6 +305,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
 
   // MCPMT information
   mcpmtid.clear();
+  mcpmtchannel.clear();
   mcpmtnpe.clear();
   mcpmtcharge.clear();
 
@@ -321,6 +325,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     for (int ipmt = 0; ipmt < mc->GetMCPMTCount(); ipmt++) {
       DS::MCPMT *mcpmt = mc->GetMCPMT(ipmt);
       mcpmtid.push_back(mcpmt->GetID());
+      mcpmtchannel.push_back(mcpmt->GetChannel());
       mcpmtnpe.push_back(mcpmt->GetMCPhotonCount());
       mcpmtcharge.push_back(mcpmt->GetCharge());
       TVector3 position = pmtinfo->GetPosition(mcpmt->GetID());
@@ -417,22 +422,25 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     nhits = ev->GetPMTCount();
     if (options.pmthits) {
       hitPMTID.clear();
+      hitChannel.clear();
       hitPMTTime.clear();
       hitPMTCharge.clear();
 
       for (int pmtc = 0; pmtc < ev->GetPMTCount(); pmtc++) {
         RAT::DS::PMT *pmt = ev->GetPMT(pmtc);
         hitPMTID.push_back(pmt->GetID());
+        hitChannel.push_back(pmt->GetChannel());
         hitPMTTime.push_back(pmt->GetTime());
         hitPMTCharge.push_back(pmt->GetCharge());
       }
     }
     if (options.digitizerhits) {
+      digitPMTID.clear();
+      digitChannel.clear();
       digitTime.clear();
       digitCharge.clear();
       digitNCrossings.clear();
       digitPeak.clear();
-      digitPMTID.clear();
       digitLocalTriggerTime.clear();
 
       if (options.digitizerfits) {
@@ -444,6 +452,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       for (int pmtc = 0; pmtc < ev->GetDigitPMTCount(); pmtc++) {
         RAT::DS::DigitPMT *digitpmt = ev->GetDigitPMT(pmtc);
         digitPMTID.push_back(digitpmt->GetID());
+        digitChannel.push_back(digitpmt->GetChannel());
         digitTime.push_back(digitpmt->GetDigitizedTime());
         digitCharge.push_back(digitpmt->GetDigitizedCharge());
         digitNCrossings.push_back(digitpmt->GetNCrossings());
@@ -464,15 +473,17 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     triggerTime = 0;
     if (options.pmthits) {
       hitPMTID.clear();
+      hitChannel.clear();
       hitPMTTime.clear();
       hitPMTCharge.clear();
     }
     if (options.digitizerhits) {
+      digitPMTID.clear();
+      digitChannel.clear();
       digitTime.clear();
       digitCharge.clear();
       digitNCrossings.clear();
       digitPeak.clear();
-      digitPMTID.clear();
       digitLocalTriggerTime.clear();
       if (options.digitizerfits) {
         fitTime.clear();


### PR DESCRIPTION
This allows one to grab the channel number directly rather than relying on using the meta data to create a map from PMT ID to channel number.