### PR TITLE
`DigitizeSum` incorrectly converts int to ushort

### DIFF
--- a/src/daq/src/Digitizer.cc
+++ b/src/daq/src/Digitizer.cc
@@ -42,7 +42,7 @@ void Digitizer::DigitizeSum(DS::EV* ev) {
 
   std::map<int, std::vector<UShort_t>> waveforms = fDigitWaveForm;
   for (std::map<int, std::vector<UShort_t>>::const_iterator it = waveforms.begin(); it != waveforms.end(); it++) {
-    digit.SetWaveform(it->first, waveforms[UShort_t(it->first)]);
+    digit.SetWaveform(it->first, waveforms[it->first]);
   }
 
   digit.SetDigitName(fDigitName);


### PR DESCRIPTION
Missed this conversion at commit `8ca4f62de20ddb8ca3b1295cc247e2dab36e37ac`. 