### PR TITLE
Simulated dead channels

### DIFF
--- a/ratdb/RUN.ratdb
+++ b/ratdb/RUN.ratdb
@@ -2,6 +2,8 @@
 {
 name: "RUN",
 run_range: [0, 0],
+// index into channel_status table to use
+channel_status: "",
 
 runtype: 0,
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ add_subdirectory(util)
 add_subdirectory(ds)
 add_subdirectory(ratbase)
 
+
+
 ###########################################################
 # Create our libraries and executables
 
@@ -60,18 +62,12 @@ target_include_directories(RATEvent SYSTEM PUBLIC ${ROOT_INCLUDE_DIRS}/stlplus)
 target_include_directories(RATEvent PUBLIC ${RATPAC_INCLUDE_DIR})
 target_link_libraries(RATEvent PUBLIC 
        ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} RATDict)
+
+file(GLOB stlplus_src "stlplus/src/*.cc" "stlplus/include/stlplus/*")
 set_source_files_properties(
-       stlplus/src/debug.cc
-       stlplus/src/dprintf.cc
-       stlplus/src/exceptions.cc
-       stlplus/src/file_system.cc
-       stlplus/src/fileio.cc
-       stlplus/src/multiio.cc
-       stlplus/src/string_utilities.cc
-       stlplus/src/stringio.cc
-       stlplus/src/textio.cc
-       PROPERTIES COMPILE_FLAGS -w
-)
+        ${stlplus_src}
+        TARGET_DIRECTORY cmd core daq db ds fit gen geo io physics ratbase stlplus util RATDict RATEvent
+        PROPERTIES COMPILE_FLAGS -w)
 
 # This copies the root dict files to <build>/lib
 add_custom_command(TARGET RATEvent POST_BUILD

--- a/src/core/include/RAT/GLG4HitPMTCollection.hh
+++ b/src/core/include/RAT/GLG4HitPMTCollection.hh
@@ -13,6 +13,8 @@
 #include <vector>
 
 #include "GLG4HitPMT.hh"
+#include "RAT/DS/ChannelStatus.hh"
+#include "RAT/Log.hh"
 
 /** GLG4HitPMTCollection stores GLG4HitPMT objects.
 
@@ -42,12 +44,14 @@ class GLG4HitPMTCollection {
   int GetEntries() const;
   GLG4HitPMT *GetPMT(int i) const;
   GLG4HitPMT *GetPMT_ByID(int id) const;
+  void SetChannelStatus(const RAT::DS::ChannelStatus *_ch_status) { fChannelStatus = _ch_status; }
 
   void Print(std::ostream &) const;
 
  private:
   std::vector<GLG4HitPMT *> fPMT;
   std::map<int, GLG4HitPMT *> fHitmap;
+  const RAT::DS::ChannelStatus *fChannelStatus;
 };
 
 #endif  // __GLG4HitPMTCollection_hh__

--- a/src/core/include/RAT/Gsim.hh
+++ b/src/core/include/RAT/Gsim.hh
@@ -9,6 +9,7 @@
 #include <G4UserEventAction.hh>
 #include <G4UserRunAction.hh>
 #include <G4UserTrackingAction.hh>
+#include <RAT/DS/ChannelStatus.hh>
 #include <RAT/DS/PMTInfo.hh>
 #include <RAT/DS/Root.hh>
 #include <RAT/DS/Run.hh>

--- a/src/core/src/GLG4HitPMTCollection.cc
+++ b/src/core/src/GLG4HitPMTCollection.cc
@@ -29,7 +29,14 @@ void GLG4HitPMTCollection::Clear() {
 
 /** find or make appropriate HitPMT, and DetectPhoton in that HitPMT */
 void GLG4HitPMTCollection::DetectPhoton(GLG4HitPhoton *new_photon) {
-  GLG4HitPMT *hitpmtptr = GetPMT_ByID(new_photon->GetPMTID());
+  if (fChannelStatus == NULL) {
+    RAT::Log::Die("Found Null channel status!");
+  }
+  int pmtid = new_photon->GetPMTID();
+  if (!fChannelStatus->GetOnlineByPMTID(pmtid)) {
+    return;
+  }
+  GLG4HitPMT *hitpmtptr = GetPMT_ByID(pmtid);
 
   if (hitpmtptr != NULL) {
     // found a HitPMT with this ID

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -420,7 +420,11 @@ void Gsim::MakeRun(int _runID) {
   run->SetID(_runID);
   run->SetType((unsigned)lrun->GetI("runtype"));
   run->SetStartTime(utc);
-  run->SetPMTInfo(&PMTFactoryBase::GetPMTInfo());
+  const DS::PMTInfo *pmtinfo = &PMTFactoryBase::GetPMTInfo();
+  run->SetPMTInfo(pmtinfo);
+  DS::ChannelStatus ch_status;
+  ch_status.Load(pmtinfo, lrun->GetS("channel_status"));
+  run->SetChannelStatus(ch_status);
 
   DS::RunStore::AddNewRun(run);
 }

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -179,6 +179,7 @@ void Gsim::BeginOfRunAction(const G4Run * /*aRun*/) {
 
   run = DS::RunStore::GetRun(runID);
   fPMTInfo = run->GetPMTInfo();
+  GLG4VEventAction::GetTheHitPMTCollection()->SetChannelStatus(&run->GetChannelStatus());
 
   for (size_t i = 0; i < fPMTTime.size(); i++) {
     delete fPMTTime[i];

--- a/src/ds/CMakeLists.txt
+++ b/src/ds/CMakeLists.txt
@@ -19,7 +19,6 @@ file(COPY include/ DESTINATION ${RATPAC_INCLUDE_DIR})
 
 # hack hack hack hack hack
 include_directories(${RATPAC_INCLUDE_DIR})
-
 root_generate_dictionary(G__RATDict
         RAT/DS/Root.hh
         RAT/DS/Classifier.hh
@@ -37,6 +36,7 @@ root_generate_dictionary(G__RATDict
         RAT/DS/RunStore.hh
         RAT/DS/Run.hh
         RAT/DS/PMTInfo.hh
+        RAT/DS/ChannelStatus.hh
         RAT/DS/MCTrack.hh
         RAT/DS/MCTrackStep.hh
         RAT/DS/Calib.hh
@@ -54,8 +54,8 @@ root_generate_dictionary(G__RATDict
         RAT/ObjInt.hh
         RAT/ObjDbl.hh
         LINKDEF include/RAT/DS/LinkDef.hh
-        DEPENDENCIES core ds db io)
-
+        DEPENDENCIES core ds db io
+        OPTIONS -Wno-exceptions)
 add_library(RATDict OBJECT G__RATDict.cxx)
 target_include_directories(RATDict SYSTEM PUBLIC 
         $<BUILD_INTERFACE:${RATPAC_INCLUDE_DIR}/stlplus>)

--- a/src/ds/include/RAT/DS/ChannelStatus.hh
+++ b/src/ds/include/RAT/DS/ChannelStatus.hh
@@ -50,19 +50,16 @@ class ChannelStatus : public TObject {
   }
   virtual void Load(const PMTInfo* pmtinfo, const std::string index = "") {
     try {
+      info << "Using channel status table with index: " << index << newline;
       DBLinkPtr lChStatus = DB::Get()->GetLink("channel_status", index);
-      info << "Found Table" << newline;
       std::vector<int> lcns = lChStatus->GetIArray("channel_number");
-      info << "Found lcns" << newline;
       std::vector<int> onlines = lChStatus->GetIArray("online");
-      info << "Found online" << newline;
       std::vector<double> offsets = lChStatus->GetDArray("offset");
-      info << "Found offsets" << newline;
       for (size_t idx = 0; idx < lcns.size(); idx++) {
         AddChannel(lcns[idx], onlines[idx], offsets[idx]);
       }
     } catch (DBNotFoundError& e) {
-      warn << "DB Not found!" << newline;
+      warn << "Channel Status table Not found!" << newline;
     }
     for (int pmtid = 0; pmtid < pmtinfo->GetPMTCount(); pmtid++) {
       int lcn = pmtinfo->GetChannelNumber(pmtid);

--- a/src/ds/include/RAT/DS/ChannelStatus.hh
+++ b/src/ds/include/RAT/DS/ChannelStatus.hh
@@ -1,0 +1,86 @@
+/**
+ * @class DS::ChannelStatus
+ * Data Structure: Hardware channel status information
+ *
+ * @author James Shen <jierans@sas.upenn.edu>
+ * Information about hardware channels, including which channels are online,
+ * cable delays, etc.
+ *
+ * Channel information is stored in terms of Logical Channel Numbers (LCNs).
+ * Mapping to PMTs are stored in PMTINFO under the `channel_number` field.
+ */
+
+#ifndef __RAT_DS_ChannelStatus__
+#define __RAT_DS_ChannelStatus__
+
+#include <TObject.h>
+
+#include <RAT/DB.hh>
+#include <RAT/DS/PMTInfo.hh>
+#include <RAT/Log.hh>
+#include <map>
+#include <string>
+
+namespace RAT {
+namespace DS {
+class ChannelStatus : public TObject {
+ public:
+  ChannelStatus() : TObject() {}
+  virtual ~ChannelStatus() {}
+
+  virtual void AddChannel(int lcn, int is_online, double offset) {
+    lcns.push_back(lcn);
+    online.push_back(is_online);
+    cable_offset.push_back(offset);
+    lcn_to_index[lcn] = lcns.size() - 1;
+  }
+
+  virtual bool GetOnlineByChannel(int lcn) const { return online.at(lcn_to_index.at(lcn)); }
+  virtual bool GetOnlineByPMTID(int pmtid) const { return online.at(pmtid_to_index.at(pmtid)); }
+
+  virtual double GetCableOffsetByChannel(int lcn) const { return cable_offset.at(lcn_to_index.at(lcn)); }
+  virtual double GetCableOffsetByPMTID(int pmtid) const { return cable_offset.at(pmtid_to_index.at(pmtid)); }
+
+  virtual void LinkPMT(int pmtid, int lcn) {
+    if (lcn_to_index.find(lcn) == lcn_to_index.end()) {
+      warn << "PMT " << pmtid << " (LCN " << lcn << ") not found in channel_status, using defaults" << newline;
+      AddChannel(lcn, true, 0.0);
+    }
+    pmtid_to_index[pmtid] = lcn_to_index[lcn];
+  }
+  virtual void Load(const PMTInfo* pmtinfo, const std::string index = "") {
+    try {
+      DBLinkPtr lChStatus = DB::Get()->GetLink("channel_status", index);
+      info << "Found Table" << newline;
+      std::vector<int> lcns = lChStatus->GetIArray("channel_number");
+      info << "Found lcns" << newline;
+      std::vector<int> onlines = lChStatus->GetIArray("online");
+      info << "Found online" << newline;
+      std::vector<double> offsets = lChStatus->GetDArray("offset");
+      info << "Found offsets" << newline;
+      for (size_t idx = 0; idx < lcns.size(); idx++) {
+        AddChannel(lcns[idx], onlines[idx], offsets[idx]);
+      }
+    } catch (DBNotFoundError& e) {
+      warn << "DB Not found!" << newline;
+    }
+    for (int pmtid = 0; pmtid < pmtinfo->GetPMTCount(); pmtid++) {
+      int lcn = pmtinfo->GetChannelNumber(pmtid);
+      LinkPMT(pmtid, lcn);
+    }
+  }
+
+  ClassDef(ChannelStatus, 1);
+
+ protected:
+  std::map<int, size_t> lcn_to_index;
+  std::map<int, size_t> pmtid_to_index;
+  std::vector<int> lcns;
+  std::vector<int> online;
+  std::vector<double> cable_offset;
+};
+
+}  // namespace DS
+}  // namespace RAT
+
+#endif

--- a/src/ds/include/RAT/DS/LinkDef.hh
+++ b/src/ds/include/RAT/DS/LinkDef.hh
@@ -2,6 +2,7 @@
 
 #pragma link C++ class RAT::DS::Root + ;
 #pragma link C++ class RAT::DS::PMTInfo + ;
+#pragma link C++ class RAT::DS::ChannelStatus + ;
 
 #pragma link C++ class RAT::DS::MC + ;
 #pragma link C++ class RAT::DS::MCParticle + ;
@@ -58,6 +59,7 @@
 
 #pragma link C++ class vector < RAT::DS::Root>;
 #pragma link C++ class vector < RAT::DS::PMTInfo>;
+#pragma link C++ class vector < RAT::DS::ChannelStatus>;
 
 #pragma link C++ class vector < RAT::DS::MC>;
 #pragma link C++ class vector < RAT::DS::MCParticle>;

--- a/src/ds/include/RAT/DS/Run.hh
+++ b/src/ds/include/RAT/DS/Run.hh
@@ -11,6 +11,7 @@
 #include <TObject.h>
 #include <TTimeStamp.h>
 
+#include <RAT/DS/ChannelStatus.hh>
 #include <RAT/DS/PMTInfo.hh>
 #include <vector>
 
@@ -50,13 +51,18 @@ class Run : public TObject {
   virtual bool ExistPMTInfo() { return !pmtinfo.empty(); }
   virtual void PrunePMTInfo() { pmtinfo.resize(0); }
 
-  ClassDef(Run, 2);
+  /** Channel status */
+  virtual ChannelStatus const &GetChannelStatus() const { return ch_status; }
+  virtual void SetChannelStatus(const ChannelStatus &_ch_status) { ch_status = _ch_status; }
+
+  ClassDef(Run, 3);
 
  protected:
   Int_t id;
   ULong64_t type;
   TTimeStamp startTime;
-  std::vector<PMTInfo> pmtinfo;
+  std::vector<PMTInfo> pmtinfo;  // ah.. why is this a vector?
+  ChannelStatus ch_status;
 };
 
 }  // namespace DS

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -70,6 +70,8 @@ class OutNtupleProc : public Processor {
   std::vector<int> pmtType;
   std::vector<int> pmtId;
   std::vector<int> pmtChannel;
+  std::vector<bool> pmtIsOnline;
+  std::vector<double> pmtCableOffset;
   std::vector<double> pmtX;
   std::vector<double> pmtY;
   std::vector<double> pmtZ;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -72,6 +72,8 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   metaTree->Branch("pmtType", &pmtType);
   metaTree->Branch("pmtId", &pmtId);
   metaTree->Branch("pmtChannel", &pmtChannel);
+  metaTree->Branch("pmtIsOnline", &pmtIsOnline);
+  metaTree->Branch("pmtCableOffset", &pmtCableOffset);
   metaTree->Branch("pmtX", &pmtX);
   metaTree->Branch("pmtY", &pmtY);
   metaTree->Branch("pmtZ", &pmtZ);
@@ -508,6 +510,7 @@ OutNtupleProc::~OutNtupleProc() {
     outputFile->cd();
 
     DS::PMTInfo *pmtinfo = runBranch->GetPMTInfo();
+    const DS::ChannelStatus &ch_status = runBranch->GetChannelStatus();
     for (int id = 0; id < pmtinfo->GetPMTCount(); id++) {
       int type = pmtinfo->GetType(id);
       int channel = pmtinfo->GetChannelNumber(id);
@@ -516,6 +519,8 @@ OutNtupleProc::~OutNtupleProc() {
       pmtType.push_back(type);
       pmtId.push_back(id);
       pmtChannel.push_back(channel);
+      pmtIsOnline.push_back(ch_status.GetOnlineByPMTID(id));
+      pmtCableOffset.push_back(ch_status.GetCableOffsetByPMTID(id));
       pmtX.push_back(position.X());
       pmtY.push_back(position.Y());
       pmtZ.push_back(position.Z());

--- a/src/stlplus/CMakeLists.txt
+++ b/src/stlplus/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(stlplus OBJECT
         src/stringio.cc
         src/textio.cc)
 
-target_compile_options(stlplus PUBLIC -w)
 # Set our include directories
 target_include_directories(stlplus SYSTEM PUBLIC 
         $<BUILD_INTERFACE:${RATPAC_INCLUDE_DIR}/stlplus>)


### PR DESCRIPTION
- Add new channel status class that incorporates any hardware channel information. Analogous to the ChanHWStatus class in other rat experiments. 
  - By default, apply timing offset of 0 and turn PMT online, so backward compatibility should be ensured.
- Disable photoelectron generation in Gsim if a channel is not set to `online` .
- Minor refactoring to CMake compilation flags to suppress stlplus-induced warnings.