### PR TITLE
Moving towards supporting multiple waveform analysis algorithms

### DIFF
--- a/ratdb/DIGITIZER_ANALYSIS.ratdb
+++ b/ratdb/DIGITIZER_ANALYSIS.ratdb
@@ -26,4 +26,5 @@ fit_window_high: 15.0,
 // Fit shape
 lognormal_shape: 0.15,
 lognormal_scale: 10.5,
+apply_cable_offset: 0,
 }

--- a/ratdb/DIGITIZER_ANALYSIS.ratdb
+++ b/ratdb/DIGITIZER_ANALYSIS.ratdb
@@ -26,5 +26,8 @@ fit_window_high: 15.0,
 // Fit shape
 lognormal_shape: 0.15,
 lognormal_scale: 10.5,
+
+// Run configuration
 apply_cable_offset: 0,
+zero_suppress: 1  // If true, do not keep digitPMTs if the waveform never passes threshold
 }

--- a/src/cmd/src/ProcBlockManager.cc
+++ b/src/cmd/src/ProcBlockManager.cc
@@ -26,6 +26,7 @@
 #include <RAT/SimpleDAQProc.hh>
 #include <RAT/SplitEVDAQProc.hh>
 #include <RAT/TrueDAQProc.hh>
+#include <RAT/WaveformAnalysis.hh>
 
 namespace RAT {
 
@@ -88,6 +89,7 @@ ProcBlockManager::ProcBlockManager(ProcBlock *theMainBlock) {
   AppendProcessor<LessSimpleDAQProc>();
   AppendProcessor<LessSimpleDAQ2Proc>();
   AppendProcessor<TrueDAQProc>();
+  AppendProcessor<WaveformAnalysis>();
   // Misc
   AppendProcessor<CountProc>();
   AppendProcessor<PruneProc>();

--- a/src/daq/include/RAT/WaveformAnalysis.hh
+++ b/src/daq/include/RAT/WaveformAnalysis.hh
@@ -132,6 +132,7 @@ class WaveformAnalysis : public Processor {
 
   // USe Cable offsets specified in channel status?
   int fApplyCableOffset;
+  int fZeroSuppress;
 
   // Invalid value for bad waveforms
   const UShort_t INVALID = 9999;

--- a/src/daq/include/RAT/WaveformAnalysis.hh
+++ b/src/daq/include/RAT/WaveformAnalysis.hh
@@ -21,17 +21,21 @@
 #include <RAT/DB.hh>
 #include <RAT/DS/DigitPMT.hh>
 #include <RAT/Digitizer.hh>
+#include <RAT/Processor.hh>
 #include <vector>
 
 namespace RAT {
 
-class WaveformAnalysis {
+class WaveformAnalysis : public Processor {
  public:
   WaveformAnalysis();
   WaveformAnalysis(std::string analyzer_name);
   virtual ~WaveformAnalysis(){};
 
-  void RunAnalysis(DS::DigitPMT *pmt, int pmtID, Digitizer *fDigitizer, double timeOffset = 0.0);
+  void Configure(const std::string &analyzer_name);
+  void RunAnalysis(DS::DigitPMT *digitpmt, int pmtID, Digitizer *fDigitizer, double timeOffset = 0.0);
+  void RunAnalysis(DS::DigitPMT *digitpmt, int pmtID, DS::Digit *dsdigit, double timeOffset = 0.0);
+
   double RunAnalysisOnTrigger(int pmtID, Digitizer *fDigitizer);
 
   // Calculate baseline (in mV)
@@ -72,6 +76,11 @@ class WaveformAnalysis {
 
   // Fit the digitized waveform using a lognormal function
   void FitWaveform();
+
+  virtual Processor::Result Event(DS::Root *ds, DS::EV *ev);
+  virtual void SetS(std::string param, std::string value);
+  virtual void SetD(std::string param, double value);
+  virtual void SetI(std::string param, int value);
 
  protected:
   // Digitizer settings
@@ -121,8 +130,13 @@ class WaveformAnalysis {
   double fFittedBaseline;
   double fChi2NDF;
 
+  // USe Cable offsets specified in channel status?
+  int fApplyCableOffset;
+
   // Invalid value for bad waveforms
   const UShort_t INVALID = 9999;
+
+  void DoAnalysis(DS::DigitPMT *pmt, double timeOffset);
 };
 
 }  // namespace RAT

--- a/src/daq/src/LessSimpleDAQ2Proc.cc
+++ b/src/daq/src/LessSimpleDAQ2Proc.cc
@@ -120,8 +120,7 @@ Processor::Result LessSimpleDAQ2Proc::DSEvent(DS::Root *ds) {
 
       for (unsigned long bb = startIndex[b]; bb < tArraySort.size(); bb++) {
         if (subIndex[bb] == b) {
-          pmt = ev->AddNewPMT();
-          pmt->SetID(idArraySort[bb]);
+          pmt = ev->GetPMT(idArraySort[bb]);
           pmt->SetTime(tArraySort[bb]);
           pmt->SetCharge(qArraySort[bb]);
 

--- a/src/daq/src/LessSimpleDAQProc.cc
+++ b/src/daq/src/LessSimpleDAQProc.cc
@@ -190,8 +190,7 @@ Processor::Result LessSimpleDAQProc::DSEvent(DS::Root *ds) {
 
     // we can then set these events on the PMT for one subevent
     for (unsigned long dd = 0; dd < idGroup.size(); dd++) {
-      pmt = ev->AddNewPMT();
-      pmt->SetID(idGroup[dd]);
+      pmt = ev->GetPMT(idGroup[dd]);
       pmt->SetTime(tGroup[dd]);
       pmt->SetCharge(qGroup[dd]);
     }

--- a/src/daq/src/SimpleDAQProc.cc
+++ b/src/daq/src/SimpleDAQProc.cc
@@ -37,8 +37,7 @@ Processor::Result SimpleDAQProc::DSEvent(DS::Root *ds) {
 
     if (mcpmt->GetMCPhotonCount() > 0) {
       // Need at least one photon to trigger
-      DS::PMT *pmt = ev->AddNewPMT();
-      pmt->SetID(pmtID);
+      DS::PMT *pmt = ev->GetPMT(pmtID);
 
       // Create one sample, hit time is determined by first hit,
       // "infinite" charge integration time

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -165,8 +165,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
       }
       std::sort(hitTimes.begin(), hitTimes.end());
       if (pmtInEvent) {
-        DS::PMT *pmt = ev->AddNewPMT();
-        pmt->SetID(pmtID);
+        DS::PMT *pmt = ev->GetPMT(pmtID);
         double front_end_hit_time = *std::min_element(hitTimes.begin(), hitTimes.end());
         // PMT Hit time relative to the trigger
         pmt->SetTime(front_end_hit_time - tt);
@@ -175,8 +174,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
         if (fDigitize) {
           fDigitizer->DigitizePMT(mcpmt, pmtID, tt, pmtinfo);
           if (fAnalyze) {
-            DS::DigitPMT *digitpmt = ev->AddNewDigitPMT();
-            digitpmt->SetID(pmtID);
+            DS::DigitPMT *digitpmt = ev->GetDigitPMT(pmtID);
             double timing_offset =
                 fDigitizer->fPMTWaveformGenerators[pmtinfo->GetModelNameByID(pmtID)]->fPMTPulseTimeOffset;
             fWaveformAnalysis->RunAnalysis(digitpmt, pmtID, fDigitizer, timing_offset);

--- a/src/daq/src/WaveformAnalysis.cc
+++ b/src/daq/src/WaveformAnalysis.cc
@@ -29,6 +29,7 @@ void WaveformAnalysis::Configure(const std::string& analyzer_name) {
     fSlidingWindow = fDigit->GetD("sliding_window_width");
     fChargeThresh = fDigit->GetD("sliding_window_thresh");
     fRunFit = fDigit->GetI("run_fitting");
+    fApplyCableOffset = fDigit->GetI("apply_cable_offset");
     if (fRunFit) {
       fFitWindowLow = fDigit->GetD("fit_window_low");
       fFitWindowHigh = fDigit->GetD("fit_window_high");
@@ -438,8 +439,7 @@ Processor::Result WaveformAnalysis::Event(DS::Root* ds, DS::EV* ev) {
   for (int pmt_id : pmt_ids) {
     // Do not analyze negative pmtid channels, since they do not correspond to real PMTs.
     if (pmt_id < 0) continue;
-    DS::DigitPMT* digitpmt = ev->AddNewDigitPMT();
-    digitpmt->SetID(pmt_id);
+    DS::DigitPMT* digitpmt = ev->GetDigitPMT(pmt_id);
     double time_offset = fApplyCableOffset ? ch_status.GetCableOffsetByPMTID(pmt_id) : 0.0;
     RunAnalysis(digitpmt, pmt_id, dsdigit, time_offset);
   }

--- a/src/daq/src/WaveformAnalysis.cc
+++ b/src/daq/src/WaveformAnalysis.cc
@@ -439,6 +439,7 @@ Processor::Result WaveformAnalysis::Event(DS::Root* ds, DS::EV* ev) {
   for (int pmt_id : pmt_ids) {
     // Do not analyze negative pmtid channels, since they do not correspond to real PMTs.
     if (pmt_id < 0) continue;
+    if (!ch_status.GetOnlineByPMTID(pmt_id)) continue;
     DS::DigitPMT* digitpmt = ev->GetDigitPMT(pmt_id);
     double time_offset = fApplyCableOffset ? ch_status.GetCableOffsetByPMTID(pmt_id) : 0.0;
     RunAnalysis(digitpmt, pmt_id, dsdigit, time_offset);

--- a/src/daq/src/WaveformAnalysis.cc
+++ b/src/daq/src/WaveformAnalysis.cc
@@ -5,11 +5,18 @@
 #include <RAT/Log.hh>
 #include <RAT/WaveformAnalysis.hh>
 
+#include "RAT/DS/DigitPMT.hh"
+#include "RAT/DS/RunStore.hh"
+
 namespace RAT {
 
 WaveformAnalysis::WaveformAnalysis() : WaveformAnalysis::WaveformAnalysis("") {}
 
-WaveformAnalysis::WaveformAnalysis(std::string analyzer_name) {
+WaveformAnalysis::WaveformAnalysis(std::string analyzer_name) : Processor("WaveformAnalysis") {
+  Configure(analyzer_name);
+}
+
+void WaveformAnalysis::Configure(const std::string& analyzer_name) {
   try {
     fDigit = DB::Get()->GetLink("DIGITIZER_ANALYSIS", analyzer_name);
     fPedWindowLow = fDigit->GetI("pedestal_window_low");
@@ -33,12 +40,74 @@ WaveformAnalysis::WaveformAnalysis(std::string analyzer_name) {
   }
 }
 
+void WaveformAnalysis::SetS(std::string param, std::string value) {
+  if (param == "analyzer_name") {
+    Configure(value);
+  } else {
+    throw Processor::ParamUnknown(param);
+  }
+}
+
+void WaveformAnalysis::SetI(std::string param, int value) {
+  if (param == "run_fitting") {
+    fRunFit = value;
+  } else if (param == "pedestal_window_low") {
+    fPedWindowLow = value;
+  } else if (param == "pedestal_window_high") {
+    fPedWindowHigh = value;
+  } else if (param == "apply_cable_offset") {
+    fApplyCableOffset = value;
+  } else {
+    throw Processor::ParamUnknown(param);
+  }
+}
+
+void WaveformAnalysis::SetD(std::string param, double value) {
+  if (param == "lookback") {
+    fLookback = value;
+  } else if (param == "integration_window_low") {
+    fIntWindowLow = value;
+  } else if (param == "integration_window_high") {
+    fIntWindowHigh = value;
+  } else if (param == "constant_fraction") {
+    fConstFrac = value;
+  } else if (param == "voltage_threshold") {
+    fThreshold = value;
+  } else if (param == "sliding_window_width") {
+    fSlidingWindow = value;
+  } else if (param == "sliding_window_thresh") {
+    fChargeThresh = value;
+  } else if (param == "fit_window_low") {
+    fFitWindowLow = value;
+  } else if (param == "fit_window_high") {
+    fFitWindowHigh = value;
+  } else if (param == "lognormal_shape") {
+    fFitShape = value;
+  } else if (param == "lognormal_scale") {
+    fFitScale = value;
+  } else {
+    throw Processor::ParamUnknown(param);
+  }
+}
+
 void WaveformAnalysis::RunAnalysis(DS::DigitPMT* digitpmt, int pmtID, Digitizer* fDigitizer, double timeOffset) {
   fVoltageRes = (fDigitizer->fVhigh - fDigitizer->fVlow) / (pow(2, fDigitizer->fNBits));
   fTimeStep = 1.0 / fDigitizer->fSamplingRate;  // in ns
 
   fDigitWfm = fDigitizer->fDigitWaveForm[pmtID];
+  fTermOhms = fDigitizer->fTerminationOhms;
+  DoAnalysis(digitpmt, timeOffset);
+}
 
+void WaveformAnalysis::RunAnalysis(DS::DigitPMT* digitpmt, int pmtID, DS::Digit* dsdigit, double timeOffset) {
+  fVoltageRes = dsdigit->GetVoltageResolution();
+  fTimeStep = dsdigit->GetTimeStepNS();
+  fDigitWfm = dsdigit->GetWaveform(pmtID);
+  fTermOhms = dsdigit->GetTerminationOhms();
+  DoAnalysis(digitpmt, timeOffset);
+}
+
+void WaveformAnalysis::DoAnalysis(DS::DigitPMT* digitpmt, double timeOffset) {
   // Calculate baseline in mV
   CalculatePedestal();
 
@@ -51,7 +120,6 @@ void WaveformAnalysis::RunAnalysis(DS::DigitPMT* digitpmt, int pmtID, Digitizer*
   // Get the total number of threshold crossings
   GetNCrossings();
 
-  fTermOhms = fDigitizer->fTerminationOhms;
   // Integrate the waveform to calculate the charge
   Integrate();
   SlidingIntegral();
@@ -360,6 +428,22 @@ void WaveformAnalysis::FitWaveform() {
 
   delete wfm;
   delete ln_fit;
+}
+
+Processor::Result WaveformAnalysis::Event(DS::Root* ds, DS::EV* ev) {
+  DS::Digit* dsdigit = &ev->GetDigitizer();
+  DS::Run* run = DS::RunStore::GetRun(ds->GetRunID());
+  const DS::ChannelStatus& ch_status = run->GetChannelStatus();
+  std::vector<int> pmt_ids = dsdigit->GetIDs();
+  for (int pmt_id : pmt_ids) {
+    // Do not analyze negative pmtid channels, since they do not correspond to real PMTs.
+    if (pmt_id < 0) continue;
+    DS::DigitPMT* digitpmt = ev->AddNewDigitPMT();
+    digitpmt->SetID(pmt_id);
+    double time_offset = fApplyCableOffset ? ch_status.GetCableOffsetByPMTID(pmt_id) : 0.0;
+    RunAnalysis(digitpmt, pmt_id, dsdigit, time_offset);
+  }
+  return Processor::Result::OK;
 }
 
 }  // namespace RAT

--- a/src/ds/include/RAT/DS/EV.hh
+++ b/src/ds/include/RAT/DS/EV.hh
@@ -55,6 +55,10 @@ class EV : public TObject {
     digitpmt[id].SetID(id);
     return &digitpmt[id];
   }
+  virtual size_t EraseDigitPMT(Int_t id) {
+    size_t n_erased = digitpmt.erase(id);
+    return n_erased;
+  }
   virtual Int_t GetDigitPMTCount() const { return digitpmt.size(); }
   virtual void PruneDigitPMT() { digitpmt.clear(); }
 

--- a/src/ds/include/RAT/DS/EV.hh
+++ b/src/ds/include/RAT/DS/EV.hh
@@ -43,22 +43,20 @@ class EV : public TObject {
   virtual void SetUTC(const TTimeStamp &_utc) { utc = _utc; }
 
   /** List of pmts with at least one charge sample in this event. */
-  virtual PMT *GetPMT(Int_t i) { return &pmt[i]; }
-  virtual Int_t GetPMTCount() const { return pmt.size(); }
-  virtual PMT *AddNewPMT() {
-    pmt.resize(pmt.size() + 1);
-    return &pmt.back();
+  virtual PMT *GetPMT(Int_t id) {
+    pmt[id].SetID(id);
+    return &pmt[id];
   }
-  virtual void PrunePMT() { pmt.resize(0); }
+  virtual Int_t GetPMTCount() const { return pmt.size(); }
+  virtual void PrunePMT() { pmt.clear(); }
 
   /** List of pmts with at least one charge sample in this event. */
-  virtual DigitPMT *GetDigitPMT(Int_t i) { return &digitpmt[i]; }
-  virtual Int_t GetDigitPMTCount() const { return digitpmt.size(); }
-  virtual DigitPMT *AddNewDigitPMT() {
-    digitpmt.resize(digitpmt.size() + 1);
-    return &digitpmt.back();
+  virtual DigitPMT *GetDigitPMT(Int_t id) {
+    digitpmt[id].SetID(id);
+    return &digitpmt[id];
   }
-  virtual void PruneDigitPMT() { digitpmt.resize(0); }
+  virtual Int_t GetDigitPMTCount() const { return digitpmt.size(); }
+  virtual void PruneDigitPMT() { digitpmt.clear(); }
 
   /** Number of PMTs which were hit at least once. (Convenience method) */
   virtual Int_t Nhits() const { return GetPMTCount(); }
@@ -105,7 +103,7 @@ class EV : public TObject {
   // Prune digitizer information
   virtual void PruneDigitizer() { digitizer.resize(0); }
 
-  ClassDef(EV, 2);
+  ClassDef(EV, 3);
 
  protected:
   Int_t id;
@@ -113,8 +111,8 @@ class EV : public TObject {
   Double_t calibratedTriggerTime;
   Double_t deltat;
   TTimeStamp utc;
-  std::vector<PMT> pmt;
-  std::vector<DigitPMT> digitpmt;
+  std::map<Int_t, PMT> pmt;
+  std::map<Int_t, DigitPMT> digitpmt;
   std::vector<LAPPD> lappd;
   std::vector<FitResult *> fitResults;
   std::vector<Classifier *> classifierResults;


### PR DESCRIPTION
Motivation: We would like to eventually support multiple types of waveform analysis to be performed on digitization traces. To accomplish this, we need to have the following

- [x] Convert the current WaveformAnalysis class to a RAT::Processor. This allows user to swap between different analysis algorithms, similar to how users can swap between existing DAQ modules. 
- [ ] However, there's a lot of features that should ideally be shared between all the waveform analyzers. Examples being: calculating the pedestal and computing the number of threshold crossings. These features currently exist in the old WaveformAnalysis class, and should perhaps be re-factored into static methods that can be called by any processor that requires it.
- [x] There could be information about the digitization that come upstream of the waveform analysis. For example, one might want to set the local trigger time via the producer, and reconstruct the waveforms themselves later (as we do in Eos). So let's use a std::map keyed by PMTID, instead of std::vector to keep track of the pmts. This allows the `GetDigitPMT` method to create an empty digitPMT if needed, and retrieve the existing PMT if it has already been instantiated. This also removes a potentially confusing indexing of digitPMTs in `DS::EV`, since the index position of the digitPMTs in the vector may not agree with the value written in `digitPMT.id`. 
- [ ] DigitPMT should support multi-pe scenarios. Perhaps using the same structure as MCPMT, where you can have multiple MCPEs associated with a single DigitPMT