### PR TITLE
Fix untriggered EV info in ntuple

### DIFF
--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -467,7 +467,10 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     outputTree->Fill();
   }
   if (options.untriggered && ds->GetEVCount() == 0) {
+    // EV information
     evid = -1;
+    subev = -1;
+    nhits = -1;
     triggerTime = 0;
     timeSinceLastTrigger_us = 0;
     if (options.pmthits) {


### PR DESCRIPTION
Assign invalid values to the two EV branches currently not 'reset' for untriggered events.  
Without this change, untriggered events inherit `nhits` values from the previous triggered event.  