### PR TITLE
Adding a timestamp variable to the ntuple output. 

### DIFF
--- a/macros/validation/electron.mac
+++ b/macros/validation/electron.mac
@@ -13,7 +13,6 @@
 /rat/proc classifychargebalance
 
 /rat/proclast outroot
-/rat/proclast outntuple
 
 /generator/add combo gun:point:poisson
 /generator/vtx/set e- 0.0 0.0 0.0 2.5
@@ -21,4 +20,4 @@
 /generator/rate/set 2.0
 
 
-/run/beamOn 1000
+/run/beamOn 100

--- a/macros/validation/electron.mac
+++ b/macros/validation/electron.mac
@@ -13,9 +13,12 @@
 /rat/proc classifychargebalance
 
 /rat/proclast outroot
+/rat/proclast outntuple
 
 /generator/add combo gun:point:poisson
 /generator/vtx/set e- 0.0 0.0 0.0 2.5
 /generator/pos/set 0.0 0.0 0.0
+/generator/rate/set 2.0
 
-/run/beamOn 100
+
+/run/beamOn 1000

--- a/src/daq/src/LessSimpleDAQProc.cc
+++ b/src/daq/src/LessSimpleDAQProc.cc
@@ -202,6 +202,7 @@ Processor::Result LessSimpleDAQProc::DSEvent(DS::Root *ds) {
 
     // regster total charge of one subevent
     ev->SetTotalCharge(totalQ);
+    ev->SetUTC(mc->GetUTC());
   }
 
   return Processor::OK;

--- a/src/daq/src/SimpleDAQProc.cc
+++ b/src/daq/src/SimpleDAQProc.cc
@@ -61,7 +61,7 @@ Processor::Result SimpleDAQProc::DSEvent(DS::Root *ds) {
       calibQ += charge;
     }
   }
-
+  ev->SetUTC(mc->GetUTC());
   ev->SetTotalCharge(totalQ);
   // ev->SetCalibQ(calibQ);
 

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -142,6 +142,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
     DS::EV *ev = ds->AddNewEV();
     ev->SetID(fEventCounter++);
     ev->SetCalibratedTriggerTime(tt);
+    ev->SetUTC(mc->GetUTC());
     ev->SetDeltaT(tt - lastTrigger);
     lastTrigger = tt;
     double totalEVCharge = 0;  // What does total charge get used for?

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -88,7 +88,7 @@ class OutNtupleProc : public Processor {
   int subev;
   int nhits;
   double triggerTime;
-  ULong64_t timestamp; 
+  ULong64_t timestamp;
   double timeSinceLastTrigger_us;
   // MC Summary Information
   double scintEdep;

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -88,6 +88,7 @@ class OutNtupleProc : public Processor {
   int subev;
   int nhits;
   double triggerTime;
+  ULong64_t timestamp; 
   double timeSinceLastTrigger_us;
   // MC Summary Information
   double scintEdep;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -98,7 +98,8 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   outputTree->Branch("evid", &evid);
   outputTree->Branch("subev", &subev);
   outputTree->Branch("nhits", &nhits);
-  outputTree->Branch("triggerTime", &triggerTime);
+  outputTree->Branch("triggerTime", &triggerTime);// Local trigger time
+  outputTree->Branch("timestamp",&timestamp);     // Global trigger time
   outputTree->Branch("timeSinceLastTrigger_us", &timeSinceLastTrigger_us);
   // MC Information
   outputTree->Branch("mcid", &mcid);
@@ -360,6 +361,8 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     DS::EV *ev = ds->GetEV(subev);
     evid = ev->GetID();
     triggerTime = ev->GetCalibratedTriggerTime();
+    timestamp = (mc->GetUTC().GetSec() -runBranch->GetStartTime().GetSec() )* 1e9 + \
+(mc->GetUTC().GetNanoSec() - runBranch->GetStartTime().GetNanoSec()) + triggerTime; 
     timeSinceLastTrigger_us = ev->GetDeltaT();
     auto fitVector = ev->GetFitResults();
     std::map<std::string, double *> fitvalues;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -98,8 +98,8 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   outputTree->Branch("evid", &evid);
   outputTree->Branch("subev", &subev);
   outputTree->Branch("nhits", &nhits);
-  outputTree->Branch("triggerTime", &triggerTime);// Local trigger time
-  outputTree->Branch("timestamp",&timestamp);     // Global trigger time
+  outputTree->Branch("triggerTime", &triggerTime);  // Local trigger time
+  outputTree->Branch("timestamp", &timestamp);      // Global trigger time
   outputTree->Branch("timeSinceLastTrigger_us", &timeSinceLastTrigger_us);
   // MC Information
   outputTree->Branch("mcid", &mcid);
@@ -361,8 +361,8 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     DS::EV *ev = ds->GetEV(subev);
     evid = ev->GetID();
     triggerTime = ev->GetCalibratedTriggerTime();
-    timestamp = (mc->GetUTC().GetSec() -runBranch->GetStartTime().GetSec() )* 1e9 + \
-(mc->GetUTC().GetNanoSec() - runBranch->GetStartTime().GetNanoSec()) + triggerTime; 
+    timestamp = (ev->GetUTC().GetSec() - runBranch->GetStartTime().GetSec()) * 1e9 +
+                (ev->GetUTC().GetNanoSec() - runBranch->GetStartTime().GetNanoSec()) + triggerTime;
     timeSinceLastTrigger_us = ev->GetDeltaT();
     auto fitVector = ev->GetFitResults();
     std::map<std::string, double *> fitvalues;


### PR DESCRIPTION
This variable represent the global tracking of time since the start of run in ns. Currently no triggering effect are applied with the exeption that the ULong64_t format forces the variable to be integer.

![timestampVariable](https://github.com/user-attachments/assets/d1f65931-b266-421d-8b59-e3fba319cae4)
![triggerTimeVariable](https://github.com/user-attachments/assets/beb09fb6-8a3a-4ea2-ac16-cb2902595a4b)

This changes is required for analysis purposes for a few projects.