### PR TITLE
Write total charge in Waveform analysis processing func

### DIFF
--- a/src/daq/src/WaveformAnalysis.cc
+++ b/src/daq/src/WaveformAnalysis.cc
@@ -439,6 +439,7 @@ Processor::Result WaveformAnalysis::Event(DS::Root* ds, DS::EV* ev) {
   DS::Run* run = DS::RunStore::GetRun(ds->GetRunID());
   const DS::ChannelStatus& ch_status = run->GetChannelStatus();
   std::vector<int> pmt_ids = dsdigit->GetIDs();
+  double total_charge = 0;
   for (int pmt_id : pmt_ids) {
     // Do not analyze negative pmtid channels, since they do not correspond to real PMTs.
     if (pmt_id < 0) continue;
@@ -446,6 +447,10 @@ Processor::Result WaveformAnalysis::Event(DS::Root* ds, DS::EV* ev) {
     DS::DigitPMT* digitpmt = ev->GetOrCreateDigitPMT(pmt_id);
     double time_offset = fApplyCableOffset ? ch_status.GetCableOffsetByPMTID(pmt_id) : 0.0;
     RunAnalysis(digitpmt, pmt_id, dsdigit, time_offset);
+    if (digitpmt->GetNCrossings() > 0) {
+      total_charge += digitpmt->GetDigitizedCharge();
+    }
+    ev->SetTotalCharge(total_charge);
     if (fZeroSuppress) {
       if (digitpmt->GetNCrossings() <= 0) {
         size_t nerased = ev->EraseDigitPMT(pmt_id);


### PR DESCRIPTION
This was not written for any digitPMT workflow, both in MC and data. I'm open to suggestion on what we should write here, but I think this is the closest thing to what we write in the PMT workflow right now. 

By the way, in MC this will overwrite the current value wrote, which is generated based on MCPhoton information, from DS::PMT. We can think about branching this to two values as well. Currently this valule is not written to ntuples. 