### PR TITLE
Make sure digitizers are cleared in between events. 

### DIFF
--- a/src/daq/include/RAT/Digitizer.hh
+++ b/src/daq/include/RAT/Digitizer.hh
@@ -35,7 +35,7 @@ class Digitizer {
   virtual void SetDigitizerType(std::string);
   virtual void DigitizePMT(DS::MCPMT *mcpmt, int pmtID, double triggerTime, DS::PMTInfo *pmtinfo);
   virtual void ClearWaveforms();
-  virtual void DigitizeSum(DS::EV *ev);
+  virtual void WriteToEvent(DS::EV *ev);
   virtual void AddChannel(int ichannel, PMTWaveform pmtwf);
 
   void AddWaveformGenerator(std::string modelName);

--- a/src/daq/include/RAT/Digitizer.hh
+++ b/src/daq/include/RAT/Digitizer.hh
@@ -34,6 +34,7 @@ class Digitizer {
 
   virtual void SetDigitizerType(std::string);
   virtual void DigitizePMT(DS::MCPMT *mcpmt, int pmtID, double triggerTime, DS::PMTInfo *pmtinfo);
+  virtual void ClearWaveforms();
   virtual void DigitizeSum(DS::EV *ev);
   virtual void AddChannel(int ichannel, PMTWaveform pmtwf);
 

--- a/src/daq/src/Digitizer.cc
+++ b/src/daq/src/Digitizer.cc
@@ -39,7 +39,7 @@ void Digitizer::DigitizePMT(DS::MCPMT* mcpmt, int pmtID, double triggerTime, DS:
 
 void Digitizer::ClearWaveforms() { fDigitWaveForm.clear(); }
 
-void Digitizer::DigitizeSum(DS::EV* ev) {
+void Digitizer::WriteToEvent(DS::EV* ev) {
   DS::Digit digit;
 
   std::map<int, std::vector<UShort_t>> waveforms = fDigitWaveForm;

--- a/src/daq/src/Digitizer.cc
+++ b/src/daq/src/Digitizer.cc
@@ -37,6 +37,8 @@ void Digitizer::DigitizePMT(DS::MCPMT* mcpmt, int pmtID, double triggerTime, DS:
   AddChannel(pmtID, pmtwfm);
 }
 
+void Digitizer::ClearWaveforms() { fDigitWaveForm.clear(); }
+
 void Digitizer::DigitizeSum(DS::EV* ev) {
   DS::Digit digit;
 
@@ -53,6 +55,7 @@ void Digitizer::DigitizeSum(DS::EV* ev) {
   digit.SetTerminationOhms(fTerminationOhms);
 
   ev->SetDigitizer(digit);
+  ClearWaveforms();
 }
 
 // Add channel to digitizer and immdediatly digitize analogue waveform

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -185,7 +185,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
     }  // Done looping over PMTs
 
     if (fDigitize) {
-      fDigitizer->DigitizeSum(ev);
+      fDigitizer->WriteToEvent(ev);
     }
 
     ev->SetTotalCharge(totalEVCharge);


### PR DESCRIPTION
This bug has been persistent for a very long time in the codebase. DS::Digitizer was not properly cleared in between events, resulting in old waveforms from past events being written to the current event. `ev.digitizer.@waveforms.size()` monotonically increases as a result. 