### PR TITLE
throw the db error from up to its callers

### DIFF
--- a/src/ds/include/RAT/DS/ChannelStatus.hh
+++ b/src/ds/include/RAT/DS/ChannelStatus.hh
@@ -88,7 +88,7 @@ class ChannelStatus : public TObject {
           lcns.push_back(current_lcn);
         }
       } catch (DBNotFoundError& e) {
-        Log::Die("LCN cannot be specified!");
+        throw;  // upstream should hanndle this
       }
     }
     return lcns;


### PR DESCRIPTION
This resulted in a bug, because apparently GetDBLinktPtr doesn't throw a DBNotFound error when it can't find the table..

Thanks to @llebanowski and @hbjamin for reporting this.