### PR TITLE
Write sensible PulseStartTime

### DIFF
--- a/src/daq/include/RAT/PMTPulse.hh
+++ b/src/daq/include/RAT/PMTPulse.hh
@@ -22,8 +22,8 @@ class PMTPulse {
 
   virtual void SetGausPulseWidth(double _fGausPulseWidth) { fGausPulseWidth = _fGausPulseWidth; };
 
-  virtual void SetPulseTimes(std::vector<double> _fPulseTimes) { fPulseTimes = _fPulseTimes; };
-  virtual void SetPulseValues(std::vector<double> _fPulseValues) { fPulseValues = _fPulseValues; };
+  virtual void SetPulseShapeTimes(std::vector<double> _fPulseTimes) { fPulseTimes = _fPulseTimes; };
+  virtual void SetPulseShapeValues(std::vector<double> _fPulseValues) { fPulseValues = _fPulseValues; };
 
   virtual double GetDataDrivenPulseVal(double time);
 

--- a/src/daq/include/RAT/PMTPulse.hh
+++ b/src/daq/include/RAT/PMTPulse.hh
@@ -28,7 +28,8 @@ class PMTPulse {
   virtual double GetDataDrivenPulseVal(double time);
 
   virtual double GetPulseHeight(double time);
-  virtual double GetPulseStartTime() { return fStartTime; };
+  virtual double GetPulseStartTimeNoOffset() { return fStartTime; };
+  virtual double GetPulseStartTimeWithOffset() { return fStartTime + fPulseTimeOffset; };
 
  private:
   std::string fPulseType;

--- a/src/daq/src/PMTWaveform.cc
+++ b/src/daq/src/PMTWaveform.cc
@@ -9,7 +9,7 @@ PMTWaveform::~PMTWaveform() {}
 
 double PMTWaveform::GetHeight(double currenttime) {
   double height = 0.;
-  for (unsigned int i = 0; i < fPulse.size() && fPulse[i].GetPulseStartTime() <= currenttime; i++) {
+  for (unsigned int i = 0; i < fPulse.size(); i++) {
     height += fPulse[i].GetPulseHeight(currenttime);
   }
   return height;

--- a/src/daq/src/PMTWaveformGenerator.cc
+++ b/src/daq/src/PMTWaveformGenerator.cc
@@ -127,8 +127,8 @@ PMTWaveform PMTWaveformGenerator::GenerateWaveforms(DS::MCPMT *mcpmt, double tri
         pmtpulse->SetGausPulseWidth(PickGaussianWidth());
       }
     } else if (fPMTPulseType == "datadriven") {
-      pmtpulse->SetPulseTimes(fPMTPulseShapeTimes);
-      pmtpulse->SetPulseValues(fPMTPulseShapeValues);
+      pmtpulse->SetPulseShapeTimes(fPMTPulseShapeTimes);
+      pmtpulse->SetPulseShapeValues(fPMTPulseShapeValues);
     }
   }
 


### PR DESCRIPTION
1. There was previously a check in PMTWaveform that prevents out-of-window pulses from being included in the pulse height. This was mis-handled since it did not include the timeOffset in PMTPulse. I have removed this check. We suffer somewhat a performance penalty.. we can rethink this by adding some more sophisticated bound checks. 
2. Allow the digitizer to report it's own time in a sensible way, removing the confusing of whether an offset is applied or not.
@syjeon162 please take a look and see if this is agreeable given your recent changes in PMTWaveform. Thanks!