### PR TITLE
include G4's dependency headers in case geant4 didn't build with thes…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ include(${ROOT_USE_FILE})
 find_package(Geant4 REQUIRED COMPONENTS qt)
 include(${Geant4_USE_FILE})
 include_directories(${Geant4_INCLUDE_DIRS})
+include_directories(${CLHEP_INCLUDE_DIRS})
+include_directories(${XercesC_INCLUDE_DIRS})
 
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
…e in the default header path

Mostly for HPC compatibility, specifically spack.