### PR TITLE
Allow run plane to fall back to default plane when an entry is not found

### DIFF
--- a/src/db/include/RAT/DBLink.hh
+++ b/src/db/include/RAT/DBLink.hh
@@ -177,18 +177,16 @@ T DBLink::Get(const std::string &fieldname) {
   DBTable *tbl;
   // First try user plane
   tbl = db->GetUserTable(tblname, index);
+  // Then try the run plane
   if (!tbl || tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) {
-    // Then try the run plane
     tbl = db->GetRunTable(tblname, index, currentRun);
-    if (tbl) {
-      if (tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) throw DBNotFoundError(tblname, index, fieldname);
-    } else {
-      // Finally try default plane
-      tbl = db->GetDefaultTable(tblname, index);
-      if (!tbl || tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) {
-        throw DBNotFoundError(tblname, index, fieldname);
-      }
-    }
+  }
+  // Then try the default plane
+  if (!tbl || tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) {
+    tbl = db->GetDefaultTable(tblname, index);
+  }
+  if (!tbl || tbl->GetFieldType(fieldname) == DBTable::NOTFOUND) {
+    throw DBNotFoundError(tblname, index, fieldname);
   }
 
   // Make class explicit to satisfy Sun CC 5.3


### PR DESCRIPTION
Alternative fix to issue addressed in #188. 

Currently, if a table is found in the run plane, but the required data is not, we emit a DBNotFoundError directly. In this patch, we look for the value in the default plane even if a run plane table is not found. **Either** this or #188 should be merged. 