### PR TITLE
Use git-rev-parse to add the precommit hook to the right place, even …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build_directory := build
 install_directory := $(PWD)/install
 
 all:
-	ln -sf ../../cformat.sh ./.git/hooks/pre-commit
+	ln -sf ../../cformat.sh $(shell git rev-parse --git-common-dir)/hooks/pre-commit
 	cmake . -B$(build_directory) -DCMAKE_INSTALL_PREFIX=$(install_directory)
 	cmake --build $(build_directory) -- $(MAKEFLAGS)
 	cmake --install $(build_directory) &> /dev/null


### PR DESCRIPTION
…when someone is using worktrees