### PR TITLE
Add volume tracking to outntuples

### DIFF
--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -168,6 +168,9 @@ class OutNtupleProc : public Processor {
   std::map<std::string, int> processCodeMap;
   std::vector<int> processCodeIndex;
   std::vector<std::string> processName;
+  std::map<std::string, int> volumeCodeMap;
+  std::vector<int> volumeCodeIndex;
+  std::vector<std::string> volumeName;
 
   std::vector<int> trackPDG;
   std::vector<std::vector<double>> trackPosX;
@@ -179,6 +182,7 @@ class OutNtupleProc : public Processor {
   std::vector<std::vector<double>> trackKE;
   std::vector<std::vector<double>> trackTime;
   std::vector<std::vector<int>> trackProcess;
+  std::vector<std::vector<int>> trackVolume;
 
   std::set<std::string> branchNames;
 

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -190,6 +190,8 @@ bool OutNtupleProc::OpenFile(std::string filename) {
     outputTree->Branch("trackTime", &trackTime);
     outputTree->Branch("trackProcess", &trackProcess);
     metaTree->Branch("processCodeMap", &processCodeMap);
+    outputTree->Branch("trackVolume", &trackVolume);
+    metaTree->Branch("volumeCodeMap", &volumeCodeMap);
   }
   if (options.digitizerwaveforms) {
     waveformTree = new TTree("waveforms", "waveforms");
@@ -267,11 +269,13 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     trackKE.clear();
     trackTime.clear();
     trackProcess.clear();
+    trackVolume.clear();
 
     std::vector<double> xtrack, ytrack, ztrack;
     std::vector<double> pxtrack, pytrack, pztrack;
     std::vector<double> kinetic, globaltime;
     std::vector<int> processMapID;
+    std::vector<int> volumeMapID;
     for (int trk = 0; trk < nTracks; trk++) {
       DS::MCTrack *track = mc->GetMCTrack(trk);
       trackPDG.push_back(track->GetPDGCode());
@@ -284,6 +288,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       kinetic.clear();
       globaltime.clear();
       processMapID.clear();
+      volumeMapID.clear();
       int nSteps = track->GetMCTrackStepCount();
       for (int stp = 0; stp < nSteps; stp++) {
         DS::MCTrackStep *step = track->GetMCTrackStep(stp);
@@ -294,6 +299,14 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
           processCodeIndex.push_back(processCodeMap.size() - 1);
           processName.push_back(proc);
         }
+        // Volume
+        std::string vol = step->GetVolume();
+        if (volumeCodeMap.find(vol) == volumeCodeMap.end()) {
+          volumeCodeMap[vol] = volumeCodeMap.size();
+          volumeCodeIndex.push_back(volumeCodeMap.size() - 1);
+          volumeName.push_back(vol);
+        }
+        volumeMapID.push_back(volumeCodeMap[vol]);
         processMapID.push_back(processCodeMap[proc]);
         TVector3 tv = step->GetEndpoint();
         TVector3 momentum = step->GetMomentum();
@@ -315,6 +328,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       trackMomY.push_back(pytrack);
       trackMomZ.push_back(pztrack);
       trackProcess.push_back(processMapID);
+      trackVolume.push_back(volumeMapID);
     }
   }
 


### PR DESCRIPTION
Add meta branch `volumeCodeMap` and output branch `trackVolume` to `OutNtupleProc`.
`trackVolume` is a 2D array of integers. The volume names corresponding to each integer can be found in `volumeCodeMap`. Volume name is the name of the physical volume as defined in the geometry.
These branches are only created and populated if tracking is on.

The second commit also removes some seemingly unused variables from OutNTupleProc, but if this is poor judgement on my part, please revert it. The first commit is enough for the purpose of this PR.