### PR TITLE
Allow user-specified position generator in VertexFile_Gen

### DIFF
--- a/src/gen/src/VertexFile_Gen.cc
+++ b/src/gen/src/VertexFile_Gen.cc
@@ -52,8 +52,7 @@ void VertexFile_Gen::GenerateEvent(G4Event *event) {
                                                         mcp->GetMomentum().Y(), mcp->GetMomentum().Z());
 
     if (!vertexset) {
-      if (!fPosGen)
-        pos = G4ThreeVector(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
+      if (!fPosGen) pos = G4ThreeVector(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
       vertex = new G4PrimaryVertex(pos, NextTime() + mcp->GetTime());
       vertexset = true;
     }
@@ -68,8 +67,7 @@ void VertexFile_Gen::GenerateEvent(G4Event *event) {
                                                         mcp->GetMomentum().Y(), mcp->GetMomentum().Z());
 
     if (!vertexset) {
-      if (!fPosGen)
-        pos = G4ThreeVector(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
+      if (!fPosGen) pos = G4ThreeVector(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
       vertex = new G4PrimaryVertex(pos, NextTime() + mcp->GetTime());
       vertexset = true;
     }

--- a/src/gen/src/VertexFile_Gen.cc
+++ b/src/gen/src/VertexFile_Gen.cc
@@ -40,6 +40,11 @@ void VertexFile_Gen::GenerateEvent(G4Event *event) {
 
   bool vertexset = false;
 
+  G4ThreeVector pos;
+  if (fPosGen) {
+    fPosGen->GeneratePosition(pos);
+  }
+
   // add any parents
   for (int i = 0; i < mc->GetMCParentCount(); i++) {
     const DS::MCParticle *mcp = mc->GetMCParent(i);
@@ -47,7 +52,8 @@ void VertexFile_Gen::GenerateEvent(G4Event *event) {
                                                         mcp->GetMomentum().Y(), mcp->GetMomentum().Z());
 
     if (!vertexset) {
-      G4ThreeVector pos(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
+      if (!fPosGen)
+        pos = G4ThreeVector(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
       vertex = new G4PrimaryVertex(pos, NextTime() + mcp->GetTime());
       vertexset = true;
     }
@@ -62,7 +68,8 @@ void VertexFile_Gen::GenerateEvent(G4Event *event) {
                                                         mcp->GetMomentum().Y(), mcp->GetMomentum().Z());
 
     if (!vertexset) {
-      G4ThreeVector pos(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
+      if (!fPosGen)
+        pos = G4ThreeVector(mcp->GetPosition().X(), mcp->GetPosition().Y(), mcp->GetPosition().Z());
       vertex = new G4PrimaryVertex(pos, NextTime() + mcp->GetTime());
       vertexset = true;
     }


### PR DESCRIPTION
If a position generator is specified in the macro for the `VertexFile_Gen` generator, it will be used for the event vertex position (the location of all primaries). Otherwise, the vertex information from the input file is used.