### PR TITLE
New WaveformAnalysisSinc class to interpolate waveforms

### DIFF
--- a/ratdb/IO.ratdb
+++ b/ratdb/IO.ratdb
@@ -23,5 +23,6 @@ include_digitizerfits: true,
 include_digitizerwaveforms: false,
 include_untriggered_events: true,
 include_mchits: true,
-waveform_fitters: ["Lognormal"]
+waveform_fitters: ["Lognormal", "Sinc"]
+waveform_FOMs: ["baseline", "chi2ndf", "peak"]
 }

--- a/src/cmd/src/ProcBlockManager.cc
+++ b/src/cmd/src/ProcBlockManager.cc
@@ -28,6 +28,7 @@
 #include <RAT/TrueDAQProc.hh>
 #include <RAT/WaveformAnalysis.hh>
 #include <RAT/WaveformAnalysisLognormal.hh>
+#include <RAT/WaveformAnalysisSinc.hh>
 #include <RAT/WaveformPrep.hh>
 
 namespace RAT {
@@ -94,6 +95,7 @@ ProcBlockManager::ProcBlockManager(ProcBlock *theMainBlock) {
   AppendProcessor<WaveformAnalysis>();
   AppendProcessor<WaveformPrep>();
   AppendProcessor<WaveformAnalysisLognormal>();
+  AppendProcessor<WaveformAnalysisSinc>();
   // Misc
   AppendProcessor<CountProc>();
   AppendProcessor<PruneProc>();

--- a/src/daq/CMakeLists.txt
+++ b/src/daq/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(daq OBJECT
   src/WaveformPrep.cc
   src/WaveformAnalyzerBase.cc
   src/WaveformAnalysisLognormal.cc
+  src/WaveformAnalysisSinc.cc
   )
 
 # Set our include directories

--- a/src/daq/include/RAT/WaveformAnalysisSinc.hh
+++ b/src/daq/include/RAT/WaveformAnalysisSinc.hh
@@ -10,11 +10,11 @@
 ///
 /// REVISION HISTORY:\n
 ///     25 Nov 2024: Initial commit
-/// 
+///
 /// \details
-/// This class provides full support for interpolating 
+/// This class provides full support for interpolating
 /// the waveforms by convolution using a tapered sinc (tsinc)
-/// kernel. Based on the implementation of the existing 
+/// kernel. Based on the implementation of the existing
 /// WaveformAnalysis class and WaveformAnalysisLognormal class.
 ////////////////////////////////////////////////////////////////////
 #ifndef __RAT_WaveformAnalysisSinc__
@@ -27,8 +27,8 @@
 #include <RAT/Digitizer.hh>
 #include <RAT/Processor.hh>
 #include <RAT/WaveformAnalyzerBase.hh>
-#include <vector>
 #include <cmath>
+#include <vector>
 
 namespace RAT {
 
@@ -43,7 +43,7 @@ class WaveformAnalysisSinc : public WaveformAnalyzerBase {
   virtual void SetD(std::string param, double value) override;
 
   // Interpolate the digitized waveform by convolution using a sinc kernel
-  std::vector<double> convolve_wfm(const std::vector<double>& wfm, const std::vector<double>& kernel);
+  std::vector<double> convolve_wfm(const std::vector<double> &wfm, const std::vector<double> &kernel);
   void InterpolateWaveform(const std::vector<double> &voltWfm);
 
  protected:

--- a/src/daq/include/RAT/WaveformAnalysisSinc.hh
+++ b/src/daq/include/RAT/WaveformAnalysisSinc.hh
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////
+/// \class RAT::WaveformAnalysisSinc
+///
+/// \brief Interpolate waveforms by convolution using sinc kernel
+///
+/// \author Yashwanth Bezawada <ysbezawada@berkeley.edu>
+/// \author Tanner Kaptanoglu <tannerbk@berkeley.edu>
+/// \author Ravi Pitelka <rpitelka@sas.upenn.edu>
+/// \author James Shen <jierans@sas.upenn.edu>
+///
+/// REVISION HISTORY:\n
+///     25 Nov 2024: Initial commit
+/// 
+/// \details
+/// This class provides full support for interpolating 
+/// the waveforms by convolution using a tapered sinc (tsinc)
+/// kernel. Based on the implementation of the existing 
+/// WaveformAnalysis class and WaveformAnalysisLognormal class.
+////////////////////////////////////////////////////////////////////
+#ifndef __RAT_WaveformAnalysisSinc__
+#define __RAT_WaveformAnalysisSinc__
+
+#include <TObject.h>
+
+#include <RAT/DB.hh>
+#include <RAT/DS/DigitPMT.hh>
+#include <RAT/Digitizer.hh>
+#include <RAT/Processor.hh>
+#include <RAT/WaveformAnalyzerBase.hh>
+#include <vector>
+#include <cmath>
+
+namespace RAT {
+
+class WaveformAnalysisSinc : public WaveformAnalyzerBase {
+ public:
+  WaveformAnalysisSinc() : WaveformAnalysisSinc(""){};
+  WaveformAnalysisSinc(std::string config_name) : WaveformAnalyzerBase("WaveformAnalysisSinc", config_name) {
+    Configure(config_name);
+  };
+  virtual ~WaveformAnalysisSinc(){};
+  void Configure(const std::string &config_name) override;
+  virtual void SetD(std::string param, double value) override;
+
+  // Interpolate the digitized waveform by convolution using a sinc kernel
+  std::vector<double> convolve_wfm(const std::vector<double>& wfm, const std::vector<double>& kernel);
+  void InterpolateWaveform(const std::vector<double> &voltWfm);
+
+ protected:
+  // Digitizer settings
+  DBLinkPtr fDigit;
+
+  // Analysis constants
+  int fPedWindowLow;
+  int fPedWindowHigh;
+  double fFitWindowLow;
+  double fFitWindowHigh;
+
+  // Coming from WaveformPrep
+  double fDigitTimeInWindow;
+
+  // Fit variables
+  double fFitTime;
+  double fFitCharge;
+  double fFitPeak;
+
+  void DoAnalysis(DS::DigitPMT *pmt, const std::vector<UShort_t> &digitWfm) override;
+};
+
+}  // namespace RAT
+
+#endif

--- a/src/daq/src/WaveformAnalysisSinc.cc
+++ b/src/daq/src/WaveformAnalysisSinc.cc
@@ -41,8 +41,7 @@ void WaveformAnalysisSinc::DoAnalysis(DS::DigitPMT* digitpmt, const std::vector<
   std::vector<double> voltWfm = WaveformUtil::ADCtoVoltage(digitWfm, fVoltageRes, pedestal = pedestal);
   fDigitTimeInWindow = digitpmt->GetDigitizedTimeNoOffset();
 
-  if (std::isinf(fDigitTimeInWindow) || fDigitTimeInWindow < 0)
-  {
+  if (std::isinf(fDigitTimeInWindow) || fDigitTimeInWindow < 0) {
     return;
   }
 
@@ -52,10 +51,11 @@ void WaveformAnalysisSinc::DoAnalysis(DS::DigitPMT* digitpmt, const std::vector<
   fit_result->AddPE(fFitTime, fFitCharge, {{"peak", fFitPeak}});
 }
 
-std::vector<double> WaveformAnalysisSinc::convolve_wfm(const std::vector<double>& wfm, const std::vector<double>& kernel) {
+std::vector<double> WaveformAnalysisSinc::convolve_wfm(const std::vector<double>& wfm,
+                                                       const std::vector<double>& kernel) {
   int n = wfm.size();
   int m = kernel.size();
-  std::vector<double> result(n + m - 1, 0.0); // Size of the output
+  std::vector<double> result(n + m - 1, 0.0);  // Size of the output
   // Perform the convolution
   for (int i = 0; i < n; ++i) {
     for (int j = 0; j < m; ++j) {
@@ -66,7 +66,6 @@ std::vector<double> WaveformAnalysisSinc::convolve_wfm(const std::vector<double>
 }
 
 void WaveformAnalysisSinc::InterpolateWaveform(const std::vector<double>& voltWfm) {
-
   // Fit range
   double bf = fDigitTimeInWindow - fFitWindowLow;
   double tf = fDigitTimeInWindow + fFitWindowHigh;
@@ -77,25 +76,25 @@ void WaveformAnalysisSinc::InterpolateWaveform(const std::vector<double>& voltWf
 
   // Get samples values within the fit range
   std::vector<double> fit_wfm;
-  int sample_low = static_cast<int>(floor(bf/fTimeStep));
-  int sample_high = static_cast<int>(floor(tf/fTimeStep));
+  int sample_low = static_cast<int>(floor(bf / fTimeStep));
+  int sample_high = static_cast<int>(floor(tf / fTimeStep));
   sample_high = std::min(static_cast<int>(voltWfm.size()) - 1, sample_high);
-  for (int j=sample_low; j<sample_high+1; j++){
+  for (int j = sample_low; j < sample_high + 1; j++) {
     fit_wfm.push_back(voltWfm[j]);
   }
 
   // Calculating tapered sinc kernel
   std::vector<double> tsinc_kernel;
-  int N = 8; //number of interpolated points per data point
-  double T = 30.0; //tapering constant
-  for (int k=-48; k<49; k++){
-    double val = k*3.1415/(float)N;
+  int N = 8;        // number of interpolated points per data point
+  double T = 30.0;  // tapering constant
+  for (int k = -48; k < 49; k++) {
+    double val = k * 3.1415 / (float)N;
     double sinc = sin(val);
     if (k == 0)
       sinc = 1.0;
     else
       sinc /= val;
-    tsinc_kernel.push_back(sinc*exp(-pow(k/T,2)));
+    tsinc_kernel.push_back(sinc * exp(-pow(k / T, 2)));
   }
 
   // Interpolated waveform
@@ -105,7 +104,7 @@ void WaveformAnalysisSinc::InterpolateWaveform(const std::vector<double>& voltWf
   fFitPeak = peakSampleVolt.second;
   fFitTime = bf + peakSampleVolt.first * fTimeStep / (float)N;
   fFitCharge = 0;
-  for (auto & vlt : interp_wfm) {
+  for (auto& vlt : interp_wfm) {
     fFitCharge += WaveformUtil::VoltagetoCharge(vlt, fTimeStep / (float)N, fTermOhms);  // in pC
   }
 }

--- a/src/daq/src/WaveformAnalysisSinc.cc
+++ b/src/daq/src/WaveformAnalysisSinc.cc
@@ -1,0 +1,113 @@
+#include <TF1.h>
+#include <TH1D.h>
+#include <TMath.h>
+
+#include <RAT/Log.hh>
+#include <RAT/WaveformAnalysisSinc.hh>
+
+#include "RAT/DS/DigitPMT.hh"
+#include "RAT/DS/WaveformAnalysisResult.hh"
+#include "RAT/WaveformUtil.hh"
+
+namespace RAT {
+void WaveformAnalysisSinc::Configure(const std::string& config_name) {
+  try {
+    fDigit = DB::Get()->GetLink("DIGITIZER_ANALYSIS", config_name);
+    fPedWindowLow = fDigit->GetI("pedestal_window_low");
+    fPedWindowHigh = fDigit->GetI("pedestal_window_high");
+    fFitWindowLow = fDigit->GetD("fit_window_low");
+    fFitWindowHigh = fDigit->GetD("fit_window_high");
+  } catch (DBNotFoundError) {
+    RAT::Log::Die("WaveformAnalysisSinc: Unable to find analysis parameters.");
+  }
+}
+
+void WaveformAnalysisSinc::SetD(std::string param, double value) {
+  if (param == "fit_window_low") {
+    fFitWindowLow = value;
+  } else if (param == "fit_window_high") {
+    fFitWindowHigh = value;
+  } else {
+    throw Processor::ParamUnknown(param);
+  }
+}
+
+void WaveformAnalysisSinc::DoAnalysis(DS::DigitPMT* digitpmt, const std::vector<UShort_t>& digitWfm) {
+  double pedestal = digitpmt->GetPedestal();
+  if (pedestal == -9999) {
+    RAT::Log::Die("WaveformAnalysisSinc: Pedestal is invalid! Did you run WaveformPrep first?");
+  }
+  // Convert from ADC to mV
+  std::vector<double> voltWfm = WaveformUtil::ADCtoVoltage(digitWfm, fVoltageRes, pedestal = pedestal);
+  fDigitTimeInWindow = digitpmt->GetDigitizedTimeNoOffset();
+
+  if (std::isinf(fDigitTimeInWindow) || fDigitTimeInWindow < 0)
+  {
+    return;
+  }
+
+  InterpolateWaveform(voltWfm);
+
+  DS::WaveformAnalysisResult* fit_result = digitpmt->GetOrCreateWaveformAnalysisResult("Sinc");
+  fit_result->AddPE(fFitTime, fFitCharge, {{"peak", fFitPeak}});
+}
+
+std::vector<double> WaveformAnalysisSinc::convolve_wfm(const std::vector<double>& wfm, const std::vector<double>& kernel) {
+  int n = wfm.size();
+  int m = kernel.size();
+  std::vector<double> result(n + m - 1, 0.0); // Size of the output
+  // Perform the convolution
+  for (int i = 0; i < n; ++i) {
+    for (int j = 0; j < m; ++j) {
+      result[i + j] += wfm[i] * kernel[j];
+    }
+  }
+  return result;
+}
+
+void WaveformAnalysisSinc::InterpolateWaveform(const std::vector<double>& voltWfm) {
+
+  // Fit range
+  double bf = fDigitTimeInWindow - fFitWindowLow;
+  double tf = fDigitTimeInWindow + fFitWindowHigh;
+
+  // Check the fit range is within the digitizer window
+  bf = (bf > 0) ? bf : 0;
+  tf = (tf > voltWfm.size() * fTimeStep) ? voltWfm.size() * fTimeStep : tf;
+
+  // Get samples values within the fit range
+  std::vector<double> fit_wfm;
+  int sample_low = static_cast<int>(floor(bf/fTimeStep));
+  int sample_high = static_cast<int>(floor(tf/fTimeStep));
+  sample_high = std::min(static_cast<int>(voltWfm.size()) - 1, sample_high);
+  for (int j=sample_low; j<sample_high+1; j++){
+    fit_wfm.push_back(voltWfm[j]);
+  }
+
+  // Calculating tapered sinc kernel
+  std::vector<double> tsinc_kernel;
+  int N = 8; //number of interpolated points per data point
+  double T = 30.0; //tapering constant
+  for (int k=-48; k<49; k++){
+    double val = k*3.1415/(float)N;
+    double sinc = sin(val);
+    if (k == 0)
+      sinc = 1.0;
+    else
+      sinc /= val;
+    tsinc_kernel.push_back(sinc*exp(-pow(k/T,2)));
+  }
+
+  // Interpolated waveform
+  std::vector<double> interp_wfm = convolve_wfm(fit_wfm, tsinc_kernel);
+  std::pair<int, double> peakSampleVolt = WaveformUtil::FindHighestPeak(interp_wfm);
+
+  fFitPeak = peakSampleVolt.second;
+  fFitTime = bf + peakSampleVolt.first * fTimeStep / (float)N;
+  fFitCharge = 0;
+  for (auto & vlt : interp_wfm) {
+    fFitCharge += WaveformUtil::VoltagetoCharge(vlt, fTimeStep / (float)N, fTermOhms);  // in pC
+  }
+}
+
+}  // namespace RAT

--- a/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
+++ b/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
@@ -41,11 +41,11 @@ class WaveformAnalysisResult : public TObject {
   virtual Double_t getTimeOffset() { return time_offset; }
   virtual Double_t getTime(size_t idx) { return times.at(idx); }
   virtual Double_t getCharge(size_t idx) { return charges.at(idx); }
-  virtual std::vector<std::string> getFOMNames() { //Function to retrive the names of figures of merit
+  virtual std::vector<std::string> getFOMNames() {  // Function to retrive the names of figures of merit
     std::vector<std::string> FOMNames;
     FOMNames.reserve(figures_of_merit.size());
     for (const auto& pair : figures_of_merit) {
-      FOMNames.push_back(pair.first); 
+      FOMNames.push_back(pair.first);
     }
     return FOMNames;
   }

--- a/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
+++ b/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
@@ -41,7 +41,15 @@ class WaveformAnalysisResult : public TObject {
   virtual Double_t getTimeOffset() { return time_offset; }
   virtual Double_t getTime(size_t idx) { return times.at(idx); }
   virtual Double_t getCharge(size_t idx) { return charges.at(idx); }
-  virtual Double_t getFOM(std::string key, size_t idx) { return figures_of_merit.at(key).at(idx); }
+  virtual std::vector<std::string> getFOMNames() { //Function to retrive the names of figures of merit
+    std::vector<std::string> FOMNames;
+    FOMNames.reserve(figures_of_merit.size());
+    for (const auto& pair : figures_of_merit) {
+      FOMNames.push_back(pair.first); 
+    }
+    return FOMNames;
+  }
+  virtual Double_t getFOMValue(std::string key, size_t idx) { return figures_of_merit.at(key).at(idx); }
   virtual int getNhits() { return times.size(); }
   ClassDef(WaveformAnalysisResult, 1);
 

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -63,6 +63,7 @@ class OutNtupleProc : public Processor {
   NtupleOptions options;
 
   std::vector<std::string> waveform_fitters;
+  std::vector<std::string> waveform_FOMs;
 
  protected:
   std::string defaultFilename;
@@ -161,6 +162,8 @@ class OutNtupleProc : public Processor {
   std::map<std::string, std::vector<int>> fitPmtID;
   std::map<std::string, std::vector<double>> fitTime;
   std::map<std::string, std::vector<double>> fitCharge;
+  std::map<std::string, std::vector<double>> figsOfMerit;
+  // std::map<std::string, std::map<std::strin g, std::vector<double>>> figsOfMerit;
   // std::vector<double> fitTime;
   std::vector<double> fitBaseline;
   std::vector<double> fitPeak;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -19,11 +19,11 @@
 #include <RAT/Log.hh>
 #include <RAT/OutNtupleProc.hh>
 #include <iostream>
+#include <memory>
 #include <numeric>
 #include <sstream>
 #include <string>
 #include <vector>
-#include <memory>
 
 #include "RAT/DS/ChannelStatus.hh"
 
@@ -161,7 +161,8 @@ bool OutNtupleProc::OpenFile(std::string filename) {
       outputTree->Branch(TString("fit_time_" + fitter_name), &fitTime[fitter_name]);
       outputTree->Branch(TString("fit_charge_" + fitter_name), &fitCharge[fitter_name]);
       for (const std::string &FOM_name : waveform_FOMs) {
-        outputTree->Branch(TString("fit_" + FOM_name + "_" + fitter_name), &figsOfMerit["fit_" + FOM_name + "_" + fitter_name]);
+        outputTree->Branch(TString("fit_" + FOM_name + "_" + fitter_name),
+                           &figsOfMerit["fit_" + FOM_name + "_" + fitter_name]);
       }
     }
   }


### PR DESCRIPTION
Added a new `WaveformAnalysisSinc` class (based on the existing WaveformAnalysis class and the WaveformAnalysisLognormal class). 

Updated the `WaveformAnalysisResult` class to include a function `getFOMNames` to get the names of the figures of merit in a waveform analysis. Renamed the function `getFOM` to `getFOMValue`.

Updated the `OutNtupleProc` class to store the figures of merit (FOMs) from a waveform analysis in a root file. In this implementation, you need to add a `waveform_FOMs` field to `IO.ratdb`, to list the names of all the FOMs to be stored in the output root file. For example,  `waveform_FOMs: ["baseline", "chi2ndf", "peak"]`.