### PR TITLE
SetBranchValue now calls TTree->SetBranchAddress correctly

### DIFF
--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -185,7 +185,7 @@ class OutNtupleProc : public Processor {
   template <typename T>
   void SetBranchValue(std::string name, T *value) {
     if (branchNames.find(name) != branchNames.end()) {
-      outputTree->SetBranchAddress(name.c_str(), &value);
+      outputTree->SetBranchAddress(name.c_str(), value);
     } else {
       branchNames.insert(name);
       outputTree->Branch(name.c_str(), value);


### PR DESCRIPTION
.. the previous implementation does not work for any entries except for the first one.

I'm not sure if this code has _ever_ worked -- the method `SetBranchValue` has not seemingly worked for a couple months, at least. Looking at this fix, it should have never worked. However @llebanowski among others has reported fitcentroid writeout in ntuple has worked at some point. Perhaps it's a root update?