### PR TITLE
Remove trigger time from the timing

### DIFF
--- a/src/daq/include/RAT/Digitizer.hh
+++ b/src/daq/include/RAT/Digitizer.hh
@@ -33,7 +33,7 @@ class Digitizer {
   Digitizer(std::string);
 
   virtual void SetDigitizerType(std::string);
-  virtual void DigitizePMT(DS::MCPMT *mcpmt, int pmtID, double triggerTime, DS::PMTInfo *pmtinfo);
+  virtual void DigitizePMT(DS::MCPMT *mcpmt, int pmtID, DS::PMTInfo *pmtinfo);
   virtual void ClearWaveforms();
   virtual void WriteToEvent(DS::EV *ev);
   virtual void AddChannel(int ichannel, PMTWaveform pmtwf);

--- a/src/daq/include/RAT/PMTWaveformGenerator.hh
+++ b/src/daq/include/RAT/PMTWaveformGenerator.hh
@@ -14,7 +14,7 @@ class PMTWaveformGenerator {
   PMTWaveformGenerator(std::string modelName);
   virtual ~PMTWaveformGenerator();
 
-  virtual PMTWaveform GenerateWaveforms(DS::MCPMT* mcpmt, double triggerTime);
+  virtual PMTWaveform GenerateWaveforms(DS::MCPMT* mcpmt);
 
   // pick width of waveform from PDF
   double PickGaussianWidth();

--- a/src/daq/src/Digitizer.cc
+++ b/src/daq/src/Digitizer.cc
@@ -32,8 +32,8 @@ void Digitizer::AddWaveformGenerator(std::string modelName) {
   fPMTWaveformGenerators[modelName] = new PMTWaveformGenerator(modelName);
 }
 
-void Digitizer::DigitizePMT(DS::MCPMT* mcpmt, int pmtID, double triggerTime, DS::PMTInfo* pmtinfo) {
-  PMTWaveform pmtwfm = fPMTWaveformGenerators[pmtinfo->GetModelNameByID(pmtID)]->GenerateWaveforms(mcpmt, triggerTime);
+void Digitizer::DigitizePMT(DS::MCPMT* mcpmt, int pmtID, DS::PMTInfo* pmtinfo) {
+  PMTWaveform pmtwfm = fPMTWaveformGenerators[pmtinfo->GetModelNameByID(pmtID)]->GenerateWaveforms(mcpmt);
   AddChannel(pmtID, pmtwfm);
 }
 

--- a/src/daq/src/PMTWaveformGenerator.cc
+++ b/src/daq/src/PMTWaveformGenerator.cc
@@ -103,7 +103,7 @@ double PMTWaveformGenerator::PickGaussianWidth() {
   return fGausPulseWidth[fGausPulseWidth.size() - 1];
 }
 
-PMTWaveform PMTWaveformGenerator::GenerateWaveforms(DS::MCPMT *mcpmt, double triggerTime) {
+PMTWaveform PMTWaveformGenerator::GenerateWaveforms(DS::MCPMT *mcpmt) {
   PMTWaveform pmtwf;
 
   // Loop over PEs and create a pulse for each one
@@ -118,7 +118,7 @@ PMTWaveform PMTWaveformGenerator::GenerateWaveforms(DS::MCPMT *mcpmt, double tri
     pmtpulse->SetPulseMin(fPMTPulseMin);
     pmtpulse->SetPulseOffset(fPMTPulseOffset);
     pmtpulse->SetPulseTimeOffset(time_offset);
-    pmtpulse->SetPulseStartTime(mcpe->GetFrontEndTime() - triggerTime);
+    pmtpulse->SetPulseStartTime(mcpe->GetFrontEndTime());
     pmtpulse->SetPulsePolarity(fPMTPulsePolarity);
 
     if (fPMTPulseType == "analytic") {

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -161,11 +161,11 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
         DS::PMT *pmt = ev->GetOrCreatePMT(pmtID);
         double front_end_hit_time = *std::min_element(hitTimes.begin(), hitTimes.end());
         // PMT Hit time relative to the trigger
-        pmt->SetTime(front_end_hit_time - tt);
+        pmt->SetTime(front_end_hit_time);
         pmt->SetCharge(integratedCharge);
         totalEVCharge += integratedCharge;
         if (fDigitize) {
-          fDigitizer->DigitizePMT(mcpmt, pmtID, tt, pmtinfo);
+          fDigitizer->DigitizePMT(mcpmt, pmtID, pmtinfo);
         }
       }
     }  // Done looping over PMTs


### PR DESCRIPTION
This removes the addition of the trigger timing in the PMT and digitized PMT timing. There is no reason to add a "trigger time" to the PMT hit-times, particularly since the trigger simulation scheme is currently just a placeholder. Adding the trigger time currently causes nonphysical behavior in the timing (see below), which is resolved by removing it.
![image](https://github.com/user-attachments/assets/65c7fbb0-5b8d-4771-b4d6-fe7a702aae58)
