### PR TITLE
Handle edge case when trigger width is less than trigger resolution.

### DIFF
--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -107,10 +107,12 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
   for (int i = 0; i < nbins; i++) {
     double x = triggerTrain[i];
     if (x > 0) {
-      for (int j = i; j < i + int(fPulseWidth / bw); j++) {
+      int j = i;
+      do {
         if (j >= nbins) break;
         triggerHistogram[j] += x;
-      }
+        j++;
+      } while (j < i + int(fPulseWidth / bw));
     }
   }
 


### PR DESCRIPTION
Previously, this is not done correctly as the for loop will not run at all, resulting in `trigger_histogram` being empty.

We should consider, also, to increase the default for `trigger_resolution` to be something more reasonable. I would imagine that for most experiments, it's quite unlikely to have a 500ps trigger timing resolution, which is the current default. We can set it perhaps to something like 16ns. Obviously, this typically should be overridden by experiments themselves if needed.