### PR TITLE
Specify experiment binaries with rattests

### DIFF
--- a/python/rattest.py
+++ b/python/rattest.py
@@ -36,7 +36,7 @@ parser.add_argument('-t', '--text-only',
 
 parser.add_argument('-e', '--experiment',
                     type=str, dest='experiment_bin', default=None,
-                    help='Absolute path to experiment binary to run test with.')
+                    help='Absolute path to experiment binary to run test with. Uses `rat` as default.')
 
 parser.add_argument('--make-template', type=str, dest='template', default=None,
                     help='Write a template rattest to current directory for you to edit. '\

--- a/python/rattest.py
+++ b/python/rattest.py
@@ -34,6 +34,10 @@ parser.add_argument('-t', '--text-only',
                     action='store_false', dest='web', default=True,
                     help='Do not open web pages with plots.')
 
+parser.add_argument('-e', '--experiment',
+                    type=str, dest='experiment_bin', default=None,
+                    help='Absolute path to experiment binary to run test with.')
+
 parser.add_argument('--make-template', type=str, dest='template', default=None,
                     help='Write a template rattest to current directory for you to edit. '\
                     'Supplied name is used for .mac and .C files.')
@@ -52,7 +56,7 @@ success = True
 for dirname in args.input:
     for dirpath, _, filenames in os.walk(dirname):
         if configname in filenames:
-            testcase = RatTest(os.path.join(dirpath, configname))
+            testcase = RatTest(os.path.join(dirpath, configname), rat_bin=args.experiment_bin)
             if args.update:
                 testcase.update(regen_mc=args.regen_mc, regen_plots=args.regen_plots)
             else:

--- a/python/rattest/__init__.py
+++ b/python/rattest/__init__.py
@@ -84,7 +84,7 @@ class RatTest:
     Also compares and saves the histograms.
     '''
 
-    def __init__(self, config_file):
+    def __init__(self, config_file, rat_bin=None):
         self.config_file = config_file
         self.testdir = os.path.abspath(os.path.dirname(config_file))
         # Create default name out of bottom level dir name
@@ -106,7 +106,11 @@ class RatTest:
         self.rat_macro = os.path.abspath(os.path.join(self.testdir, self.rat_macro))
         self.root_macro = os.path.abspath(os.path.join(self.testdir, self.root_macro))
         self.rat_script = os.path.abspath(os.path.join(os.environ['RATROOT'], 'bin', 'rat'))
-        self.rat_bin = os.path.abspath(os.path.join(os.environ['RATROOT'], 'bin', 'rat'))
+        # Allow users to specify rat binary so tests can be ran with downstream experiments
+        if rat_bin is None:
+            self.rat_bin = os.path.abspath(os.path.join(os.environ['RATROOT'], 'bin', 'rat'))
+        else:
+            self.rat_bin = rat_bin
 
         # Find name of file holding events from last macro
         mac = self.rat_macro
@@ -163,9 +167,9 @@ class RatTest:
                 suffix = "_" + str(i) + ".mac"
             mac = self.rat_macro.replace(".mac", suffix)
             if self.seed == -1:
-                self.run_cmd_in_testdir('rat ' + os.path.basename(mac))
+                self.run_cmd_in_testdir(self.rat_bin + ' ' + os.path.basename(mac))
             else:
-                self.run_cmd_in_testdir('rat -s ' + str(self.seed) + ' ' + os.path.basename(mac))
+                self.run_cmd_in_testdir(self.rat_bin + ' -s ' + str(self.seed) + ' ' + os.path.basename(mac))
 
     def run_root(self):
         '''


### PR DESCRIPTION
Add in command line argument to specify which experiment binary should be used with the rattests. This is useful because it allows for downstream experiments to use the rattests framework while running their tests using their own experiment binary.