### PR TITLE
Fix bug affecting data driven pmt pulses

### DIFF
--- a/src/daq/src/PMTPulse.cc
+++ b/src/daq/src/PMTPulse.cc
@@ -49,7 +49,7 @@ double PMTPulse::GetPulseHeight(double utime) {
     }
   } else if (fPulseType == "datadriven") {
     if (delta_t >= fPulseTimes[0]) {
-      GetDataDrivenPulseVal(delta_t);
+      val = GetDataDrivenPulseVal(delta_t);
     }
   }
 


### PR DESCRIPTION
The voltage readout from data driven pmt pulses was not being assigned to the pmtpulse output correctly. This should fix it.

Addresses issue https://github.com/rat-pac/ratpac-two/issues/243