### PR TITLE
Fix bug in threshold crossing interpolation

### DIFF
--- a/src/util/src/WaveformUtil.cc
+++ b/src/util/src/WaveformUtil.cc
@@ -157,7 +157,11 @@ double CalculateTimeCFD(const std::vector<double>& waveform, int peakSample, int
   double dt = 0;
   if (time + 1 < static_cast<int>(waveform.size())) {
     double deltav = waveform.at(time + 1) - waveform.at(time);
-    dt = (voltageThreshold - waveform.at(time)) / deltav;
+    if (deltav != 0) {
+      dt = (voltageThreshold - waveform.at(time)) / deltav;
+    } else {
+      dt = 0;
+    }
   }
   return (time + dt) * timeStep;
 }


### PR DESCRIPTION
The linear interpolation used to get precise threshold crossings of waveforms could return an infinite time if the voltage difference is zero. I've implemented a fix by setting the interpolation to zero if the voltage difference is zero.

Addresses issue https://github.com/rat-pac/ratpac-two/issues/245