### PR TITLE
Fix probability check in PMTOpticalModel

### DIFF
--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -377,15 +377,13 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     An = 1.0 - (fT_n + fR_n);           // The absorption at normal incidence
     collection_eff = _efficiency / An;  // net QE = _efficiency for normal inc.
 
-#ifdef G4DEBUG
     if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || A * collection_eff > 1.0) {
+#ifdef G4DEBUG
       RAT::debug << "GLG4PMTOpticalModel::DoIt(): Strange coefficients!" << newline;
       RAT::debug << "T, R, A, An, weight: " << T << " " << R << " " << A << " " << An << " " << weight << newline;
       RAT::debug << "collection eff, std QE: " << collection_eff << " " << _efficiency << newline;
       RAT::debug << "=========================================================" << newline;
-    }
 #endif
-    if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || A * collection_eff > 1.0) {
       collection_eff = _efficiency;
       if (A <= 0.0) {
         A = 0.0;

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -378,18 +378,25 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     collection_eff = _efficiency / An;  // net QE = _efficiency for normal inc.
 
 #ifdef G4DEBUG
-    if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || collection_eff > 1.0) {
+    if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || A * collection_eff > 1.0) {
       RAT::debug << "GLG4PMTOpticalModel::DoIt(): Strange coefficients!" << newline;
       RAT::debug << "T, R, A, An, weight: " << T << " " << R << " " << A << " " << An << " " << weight << newline;
       RAT::debug << "collection eff, std QE: " << collection_eff << " " << _efficiency << newline;
       RAT::debug << "=========================================================" << newline;
-      A = collection_eff = 0.5;  // safe values???
     }
 #endif
+    if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || A * collection_eff > 1.0) {
+      A = 1.0;
+      collection_eff = _efficiency;
+      if (A < 0.0) {
+        A = 0.0;
+      }
+    }
 
     collection_eff *= RAT::PhotonThinning::GetFactor();
-    if (collection_eff > 1.0) {
-      RAT::Log::Die(dformat("PMT collection efficiency of %f is >1.0! Is thin_factor too big?", collection_eff));
+    if (A * collection_eff > 1.0) {
+      RAT::Log::Die(dformat("p.e. probability is %f (>1.0)! Is thin_factor (%f) too big?", A * collection_eff,
+                            RAT::PhotonThinning::GetFactor()));
     }
 
     // Now decide how many pe we make.

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -386,10 +386,11 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     }
 #endif
     if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || A * collection_eff > 1.0) {
-      A = 1.0;
       collection_eff = _efficiency;
-      if (A < 0.0) {
+      if (A <= 0.0) {
         A = 0.0;
+      } else {
+        A = 1.0;
       }
     }
 

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -362,7 +362,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     CalculateCoefficients();
 
     // Calculate Transmission, Reflection, and Absorption coefficients
-    G4double T, R, A, An, collection_eff;
+    G4double T, R, A, An, P_pe;
     G4double E_s2;
     if (_sin_theta1 > 0.0) {
       E_s2 = (pol * dir.cross(norm)) / _sin_theta1;
@@ -374,36 +374,54 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     T = fT_s * E_s2 + fT_p * (1.0 - E_s2);
     R = fR_s * E_s2 + fR_p * (1.0 - E_s2);
     A = 1.0 - (T + R);
-    An = 1.0 - (fT_n + fR_n);           // The absorption at normal incidence
-    collection_eff = _efficiency / An;  // net QE = _efficiency for normal inc.
+    An = 1.0 - (fT_n + fR_n);  // Absorption at normal incidence
 
-    if (A < 0.0 || A > 1.0 || collection_eff < 0.0 || A * collection_eff > 1.0) {
+    if (A < 0.0 || A > 1.0 || An < 0.0 || An > 1.0) {
 #ifdef G4DEBUG
       RAT::debug << "GLG4PMTOpticalModel::DoIt(): Strange coefficients!" << newline;
       RAT::debug << "T, R, A, An, weight: " << T << " " << R << " " << A << " " << An << " " << weight << newline;
-      RAT::debug << "collection eff, std QE: " << collection_eff << " " << _efficiency << newline;
       RAT::debug << "=========================================================" << newline;
 #endif
-      collection_eff = _efficiency;
-      if (A <= 0.0) {
+      if (A < 0.0) {
         A = 0.0;
-      } else {
+      } else if (A > 1) {
         A = 1.0;
+      }
+      if (An < 0.0) {
+        An = 0.0;
+      } else if (An > 1.0) {
+        An = 1.0;
       }
     }
 
-    collection_eff *= RAT::PhotonThinning::GetFactor();
-    if (A * collection_eff > 1.0) {
-      RAT::Log::Die(dformat("p.e. probability is %f (>1.0)! Is thin_factor (%f) too big?", A * collection_eff,
+    if (An == 0) {
+      P_pe = _efficiency;
+    } else {
+      P_pe = A / An * _efficiency;  // Nominal probability of a p.e.
+    }
+
+    if (P_pe > 1.0) {
+#ifdef G4DEBUG
+      RAT::debug << "GLG4PMTOpticalModel::DoIt(): P_pe > 1.0!  Setting equal to 1.0." << newline;
+      RAT::debug << "T, R, A, An, weight: " << T << " " << R << " " << A << " " << An << " " << weight << newline;
+      RAT::debug << "P_pe, std QE: " << P_pe << " " << _efficiency << newline;
+      RAT::debug << "=========================================================" << newline;
+#endif
+      P_pe = 1.0;
+    }
+
+    P_pe *= RAT::PhotonThinning::GetFactor();
+    if (P_pe > 1.0) {
+      RAT::Log::Die(dformat("p.e. probability is %f (>1.0)! Is thin_factor (%f) too big?", P_pe,
                             RAT::PhotonThinning::GetFactor()));
     }
 
     // Now decide how many pe we make.
-    // When weight == 1, probability of a pe is A*collection_eff.
+    // When weight == 1, probability of a pe is P_pe.
     // There is a certain correlation between "a pe is made" and
     // "the track is absorbed", which is implemented correctly below for
     // the weight == 1 case, and as good as can be done for weight>1 case.
-    G4double mean_N_pe = weight * A * collection_eff;
+    G4double mean_N_pe = weight * P_pe;
     if (EfficiencyCorrection.count(ipmt)) {
       if (EfficiencyCorrection[ipmt] >= 0) {
         mean_N_pe *= EfficiencyCorrection[ipmt];


### PR DESCRIPTION
Addresses Issue #242 [@gyang9].  This issue was independently observed by @ZachL00 and this PR was found to resolve it.  

Issues: Tests of bounds on collection_eff and A (absorption probability) were inside a debug conditional, meaning they did not run in general.  If out of bounds, both collection_eff and A were set to 0.5, which is entirely arbitrary.  
Without changing the core behavior, this PR:

1.   Tests bounds outside of debug mode.
2.   Corrects one of the bounds to use the p.e. probability (A*collefction_eff) instead of just collection_eff, which could have a value greater than 1 without being incorrect.
3.   Assigns reasonable values to out of bounds parameters.

fixes #242 