### PR TITLE
Waveform fitter FoMs in NtupleProc

### DIFF
--- a/ratdb/IO.ratdb
+++ b/ratdb/IO.ratdb
@@ -23,5 +23,10 @@ include_digitizerfits: true,
 include_digitizerwaveforms: false,
 include_untriggered_events: true,
 include_mchits: true,
-waveform_fitters: ["Lognormal", "Gaussian", "Sinc"]
+
+waveform_fitters: ["Lognormal", "Gaussian", "Sinc"],
+
+waveform_fitter_FOM_Lognormal: ["baseline","chi2ndf"],
+waveform_fitter_FOM_Gaussian: ["baseline","width","chi2ndf"],
+waveform_fitter_FOM_Sinc: ["peak"]
 }

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -63,6 +63,7 @@ class OutNtupleProc : public Processor {
   NtupleOptions options;
 
   std::vector<std::string> waveform_fitters;
+  std::map<std::string, std::vector<std::string>> waveform_fitter_FOMs;
 
  protected:
   std::string defaultFilename;
@@ -163,6 +164,7 @@ class OutNtupleProc : public Processor {
   std::map<std::string, std::vector<int>> fitPmtID;
   std::map<std::string, std::vector<double>> fitTime;
   std::map<std::string, std::vector<double>> fitCharge;
+  std::map<std::string, std::map<std::string, std::vector<double>>> fitFOM;
   // std::vector<double> fitTime;
   std::vector<double> fitBaseline;
   std::vector<double> fitPeak;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -63,6 +63,13 @@ OutNtupleProc::OutNtupleProc() : Processor("outntuple") {
   }
   if (options.digitizerfits) {
     waveform_fitters = table->GetSArray("waveform_fitters");
+    for (const std::string &fitter_name : waveform_fitters) {
+      try {
+        waveform_fitter_FOMs[fitter_name] = table->GetSArray("waveform_fitter_FOM_" + fitter_name);
+      } catch (DBNotFoundError &e) {
+        waveform_fitter_FOMs[fitter_name].clear();
+      }
+    }
   }
 }
 
@@ -158,6 +165,9 @@ bool OutNtupleProc::OpenFile(std::string filename) {
       outputTree->Branch(TString("fit_pmtid_" + fitter_name), &fitPmtID[fitter_name]);
       outputTree->Branch(TString("fit_time_" + fitter_name), &fitTime[fitter_name]);
       outputTree->Branch(TString("fit_charge_" + fitter_name), &fitCharge[fitter_name]);
+      for (const std::string &fom_name : waveform_fitter_FOMs[fitter_name]) {
+        outputTree->Branch(TString("fit_FOM_" + fitter_name + "_" + fom_name), &fitFOM[fitter_name][fom_name]);
+      }
     }
   }
   if (options.mchits) {
@@ -497,6 +507,9 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
           fitPmtID[fitter_name].clear();
           fitTime[fitter_name].clear();
           fitCharge[fitter_name].clear();
+          for (const std::string &fom_name : waveform_fitter_FOMs[fitter_name]) {
+            fitFOM[fitter_name][fom_name].clear();
+          }
         }
       }
 
@@ -519,7 +532,9 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
               fitPmtID[fitter_name].push_back(digitpmt->GetID());
               fitTime[fitter_name].push_back(fit_result->getTime(hitidx));
               fitCharge[fitter_name].push_back(fit_result->getCharge(hitidx));
-              // TODO: figures of merit -- you probably need some nested map
+              for (const std::string &fom_name : waveform_fitter_FOMs[fitter_name]) {
+                fitFOM[fitter_name][fom_name].push_back(fit_result->getFOM(fom_name, hitidx));
+              }
             }
           }
         }
@@ -589,6 +604,9 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
           fitPmtID[fitter_name].clear();
           fitTime[fitter_name].clear();
           fitCharge[fitter_name].clear();
+          for (const std::string &fom_name : waveform_fitter_FOMs[fitter_name]) {
+            fitFOM[fitter_name][fom_name].clear();
+          }
         }
       }
     }


### PR DESCRIPTION
Adds branches for waveform fitter figures of merit to outntuple.
The FoMs to be included in outntuple needs to be specified in `IO.ratdb`.