### PR TITLE
Change default charge_scale selection.

### DIFF
--- a/ratdb/CHANNEL_STATUS_DEFAULTS.ratdb
+++ b/ratdb/CHANNEL_STATUS_DEFAULTS.ratdb
@@ -24,7 +24,7 @@
   "name": "charge_scale",
   "index": "selected_charge_scale",
   "run_range": [0, 0],
-  "selection": "fitted", 
+  "selection": "", 
 }
 
 {


### PR DESCRIPTION
.. as rattests fail due to the missing db.