### PR TITLE
Handle fitter seeding in FitterInputHandler

### DIFF
--- a/ratdb/FITTER.ratdb
+++ b/ratdb/FITTER.ratdb
@@ -3,6 +3,9 @@
 "index": "",
 "mode": 0, // 0 = use DS::PMT; 1 = use DS::DigitPMT DigitTime/Charge; 2 = use WaveformAnalysisResult
 "waveform_analyzer": "Lognormal", // only required if mode = 2
+"vertex_seed": "quadfitter",
+"direction_seed": "fitdirectioncenter",
+"energy_seed": "DOESNOTEXIST"
 }
 
 {


### PR DESCRIPTION
How this is currently implemented allows for a global fitter to be set as the seed for position, direction, and energy, respectively. Since we currently don't have a good energy fitter the default is set to a bogus value at the moment and calling this seeding will fail.

The current implementation also allows the fitters to directly request a seed given a `fitter_name`, allowing the fitters to control where the seeds come from themselves, without changing the global default. However, doing this will require more code on the fitter side.

A lot of code is added to the handler, but hopefully it is clear that most of it is jut boilerplate.