### PR TITLE
Add procset functions to Quad fitter

### DIFF
--- a/macros/examples/quadfitter.mac
+++ b/macros/examples/quadfitter.mac
@@ -13,7 +13,9 @@
 /rat/procset update 100
 
 /rat/proc classifychargebalance
+
 /rat/proc quadfitter
+/rat/procset max_radius 4250.0  # Set max_radius > r_max of Valid.geo to account for resolution
 
 /rat/proclast outntuple
 

--- a/src/fit/include/RAT/FitQuadProc.hh
+++ b/src/fit/include/RAT/FitQuadProc.hh
@@ -11,6 +11,8 @@ class FitQuadProc : public Processor {
   FitQuadProc();
   virtual ~FitQuadProc() {}
   void BeginOfRun(DS::Run *run);
+  virtual void SetI(std::string param, int value);
+  virtual void SetD(std::string param, double value);
   Processor::Result Event(DS::Root *ds, DS::EV *ev);
 
  private:

--- a/src/fit/src/FitQuadProc.cc
+++ b/src/fit/src/FitQuadProc.cc
@@ -24,7 +24,33 @@ void FitQuadProc::BeginOfRun(DS::Run *run) {
     Log::Die("Quad tried to set a table_cut_off larger than the size of fNumPointsTbl.");
   }
   fLightSpeed = quad_db->GetD("light_speed");
+  if (fLightSpeed <= 0.0 || fLightSpeed > 299.792458)
+    Log::Die("Quad tried to set a light_speed <= 0 or > 299.792458 mm/ns.");
   fMaxRadius = quad_db->GetD("max_radius");
+}
+
+void FitQuadProc::SetI(std::string param, int value) {
+  if (param == "num_points") {
+    fNumQuadPoints = value;
+  } else if (param == "max_points") {
+    fMaxQuadPoints = value;
+  } else if (param == "table_cut_off") {
+    fTableCutOff = value;
+    if (fTableCutOff > fNumPointsTbl.size())
+      throw ParamInvalid(param, "table_cut_off cannot be larger than the size of fNumPointsTbl.");
+  } else
+    throw ParamUnknown(param);
+}
+
+void FitQuadProc::SetD(std::string param, double value) {
+  if (param == "light_speed") {
+    if (value <= 0.0 || value > 299.792458)
+      throw ParamInvalid(param, "light_speed must be positive and <= 299.792458 mm/ns.");
+    fLightSpeed = value;
+  } else if (param == "max_radius") {
+    fMaxRadius = value;
+  } else
+    throw ParamUnknown(param);
 }
 
 // Create a table of all the ways to pick 4 numbers out of n


### PR DESCRIPTION
FitQuadProc allows a user to specify input values through a ratdb table.  
Adding procset functions will allow different values to be set for each instance of the processor in a macro.