### PR TITLE
Add a hit cleaning word to DigitPMT.

### DIFF
--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -110,13 +110,27 @@ class DigitPMT : public TObject {
    * @param bit the literal bit position
    * @param val the value to write.
    */
-  virtual void SetHitCleaningMask(uint8_t bit, bool val) {
-    u_int32_t mask = val << bit;
-    hit_cleaning_mask = hit_cleaning_mask | mask;
+  virtual void SetHitCleaningBit(int bit, bool val = true) {
+    if (bit > (sizeof(hit_cleaning_mask) * 8) - 1) {  // Bits to bytes, then 0-indexing
+      warn << "Tried to set bit out of hit cleaning bitmask range, ignoring." << newline;
+      return;
+    }
+    uint32_t mask = (1 << bit);
+    if (val) {
+      hit_cleaning_mask = hit_cleaning_mask | mask;
+    } else {
+      hit_cleaning_mask = hit_cleaning_mask & (~mask);
+    }
   }
 
   /** Retrieve hit cleaning mask */
-  virtual uint32_t GetHitCleaningMask() { return hit_cleaning_mask; }
+  virtual bool CheckHitCleaningBit(uint8_t bit) {
+    uint64_t mask = 1 << bit;
+    return (hit_cleaning_mask & mask);
+  }
+
+  /** Retrieve hit cleaning mask */
+  virtual uint64_t GetHitCleaningMask() { return hit_cleaning_mask; }
 
   ClassDef(DigitPMT, 6);
 
@@ -137,7 +151,7 @@ class DigitPMT : public TObject {
   Double_t local_trigger_time = -9999;
   Double_t time_offset = 0;
   std::map<std::string, WaveformAnalysisResult> fit_results;
-  uint32_t hit_cleaning_mask = 0x0;
+  uint64_t hit_cleaning_mask = 0x0;
 };
 
 }  // namespace DS

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -105,6 +105,19 @@ class DigitPMT : public TObject {
     return fitter_names;
   }
 
+  /**
+   * Set a bit in the hit cleaning mask.
+   * @param bit the literal bit position
+   * @param val the value to write.
+   */
+  virtual void SetHitCleaningMask(uint8_t bit, bool val) {
+    u_int32_t mask = val << bit;
+    hit_cleaning_mask = hit_cleaning_mask | mask;
+  }
+
+  /** Retrieve hit cleaning mask */
+  virtual uint32_t GetHitCleaningMask() { return hit_cleaning_mask; }
+
   ClassDef(DigitPMT, 6);
 
  protected:
@@ -124,6 +137,7 @@ class DigitPMT : public TObject {
   Double_t local_trigger_time = -9999;
   Double_t time_offset = 0;
   std::map<std::string, WaveformAnalysisResult> fit_results;
+  uint32_t hit_cleaning_mask = 0x0;
 };
 
 }  // namespace DS

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -124,7 +124,11 @@ class DigitPMT : public TObject {
   }
 
   /** Check a bit of the hit cleaning mask */
-  virtual bool CheckHitCleaningBit(uint8_t bit) {
+  virtual bool CheckHitCleaningBit(int bit) {
+    if (bit > (sizeof(hit_cleaning_mask) * 8) - 1) {  // Bits to bytes, then 0-indexing
+      warn << "Tried to read bit out of hit cleaning bitmask range, ignoring." << newline;
+      return false;
+    }
     uint64_t mask = 1 << bit;
     return (hit_cleaning_mask & mask);
   }

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -110,7 +110,7 @@ class DigitPMT : public TObject {
    * @param bit the literal bit position
    * @param val the value to write.
    */
-  virtual void SetHitCleaningBit(int bit, bool val = true) {
+  virtual void SetHitCleaningBit(uint bit, bool val = true) {
     if (bit > (sizeof(hit_cleaning_mask) * 8) - 1) {  // Bits to bytes, then 0-indexing
       warn << "Tried to set bit out of hit cleaning bitmask range, ignoring." << newline;
       return;
@@ -124,7 +124,7 @@ class DigitPMT : public TObject {
   }
 
   /** Check a bit of the hit cleaning mask */
-  virtual bool CheckHitCleaningBit(int bit) {
+  virtual bool CheckHitCleaningBit(uint bit) {
     if (bit > (sizeof(hit_cleaning_mask) * 8) - 1) {  // Bits to bytes, then 0-indexing
       warn << "Tried to read bit out of hit cleaning bitmask range, ignoring." << newline;
       return false;

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -123,7 +123,7 @@ class DigitPMT : public TObject {
     }
   }
 
-  /** Retrieve hit cleaning mask */
+  /** Check a bit of the hit cleaning mask */
   virtual bool CheckHitCleaningBit(uint8_t bit) {
     uint64_t mask = 1 << bit;
     return (hit_cleaning_mask & mask);

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -136,7 +136,7 @@ class DigitPMT : public TObject {
   /** Retrieve hit cleaning mask */
   virtual uint64_t GetHitCleaningMask() { return hit_cleaning_mask; }
 
-  ClassDef(DigitPMT, 6);
+  ClassDef(DigitPMT, 7);
 
  protected:
   Int_t id = -9999;


### PR DESCRIPTION
Uses a 64 bit unsigned int to keep track of hit cleaning for DigitPMT waveforms.