### PR TITLE
Enabling switch to non-deprecated version of function for G4.11.3

### DIFF
--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -519,17 +519,10 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     }
   }
 
-#if G4VERSION_NUMBER > 1130
   fastStep.ProposePrimaryTrackFinalPosition(pos);
   fastStep.ProposePrimaryTrackFinalTime(time);
   fastStep.ProposePrimaryTrackFinalMomentumDirection(dir);
   fastStep.ProposePrimaryTrackFinalPolarization(pol);
-#else
-  fastStep.SetPrimaryTrackFinalPosition(pos);
-  fastStep.SetPrimaryTrackFinalTime(time);
-  fastStep.SetPrimaryTrackFinalMomentum(dir);
-  fastStep.SetPrimaryTrackFinalPolarization(pol);
-#endif
 
   // fastStep.SetPrimaryTrackPathLength( trackLength ); // does anyone care?
   if (weight <= 0) {
@@ -539,11 +532,7 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     }
   } else {
     // in case multiphoton has been partly absorbed and partly reflected
-#if G4VERSION_NUMBER > 1130
     fastStep.ProposePrimaryTrackFinalEventBiasingWeight(weight);
-#else
-    fastStep.SetPrimaryTrackFinalEventBiasingWeight(weight);
-#endif
   }
 
   if (iloop >= max_iloop) {

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -519,10 +519,18 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     }
   }
 
+#if G4VERSION_NUMBER > 1130
+  fastStep.ProposePrimaryTrackFinalPosition(pos);
+  fastStep.ProposePrimaryTrackFinalTime(time);
+  fastStep.ProposePrimaryTrackFinalMomentumDirection(dir);
+  fastStep.ProposePrimaryTrackFinalPolarization(pol);
+#else
   fastStep.SetPrimaryTrackFinalPosition(pos);
   fastStep.SetPrimaryTrackFinalTime(time);
   fastStep.SetPrimaryTrackFinalMomentum(dir);
   fastStep.SetPrimaryTrackFinalPolarization(pol);
+#endif
+
   // fastStep.SetPrimaryTrackPathLength( trackLength ); // does anyone care?
   if (weight <= 0) {
     fastStep.ProposeTrackStatus(fStopAndKill);
@@ -531,7 +539,11 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
     }
   } else {
     // in case multiphoton has been partly absorbed and partly reflected
+#if G4VERSION_NUMBER > 1130
+    fastStep.ProposePrimaryTrackFinalEventBiasingWeight(weight);
+#else
     fastStep.SetPrimaryTrackFinalEventBiasingWeight(weight);
+#endif
   }
 
   if (iloop >= max_iloop) {


### PR DESCRIPTION
Adding G4 flag to switch function depending on G4 version user has installed. Works with latest G4.11.3

There is currently a warning due to optics that needs to be resolved. If someone could test this works on version below 11.3 I would appreciate.

fixes #192 