### PR TITLE
Move most cleanup activity to the `EndOfRun` branch 

### DIFF
--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -20,7 +20,6 @@ class OutNtupleProc : public Processor {
  public:
   static int run_num;
   OutNtupleProc();
-  virtual ~OutNtupleProc();
 
   enum mc_pe_type { noise = 0, cherenkov = 1, scintillation = 2, reemission = 3, unknown = 4 };
 
@@ -45,6 +44,7 @@ class OutNtupleProc : public Processor {
     const ULong64_t stonano = 1000000000;
     return static_cast<ULong64_t>(ts.GetSec()) * stonano + static_cast<ULong64_t>(ts.GetNanoSec());
   }
+  virtual void EndOfRun(DS::Run *run) override;
 
   // Extensible functions
   virtual void AssignAdditionalAddresses(){};

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -712,7 +712,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
   return Processor::OK;
 }
 
-OutNtupleProc::~OutNtupleProc() {
+void OutNtupleProc::EndOfRun(DS::Run *run) {
   if (outputFile) {
     outputFile->cd();
 
@@ -757,6 +757,7 @@ OutNtupleProc::~OutNtupleProc() {
     TTimeStamp rootTime = runBranch->GetStartTime();
     runTime = TTimeStamp_to_UnixTime(rootTime.GetSec());
     macro = Log::GetMacro();
+    FillMeta();
     metaTree->Fill();
     metaTree->Write();
     outputTree->Write();


### PR DESCRIPTION
Previously this was placed in the destructor for some reason. So if some downstream experiment tries to write a vector in FillMC this will cause memory issues. Thanks to @baldonia for reporting this.

This warrants a minor version bump, since downstream experiments would not run without changing their ntuple code slightly.