### PR TITLE
Fix up HEPEvt generator. AKA we now support marley

### DIFF
--- a/doc/users_guide/generators/vertex.rst
+++ b/doc/users_guide/generators/vertex.rst
@@ -10,3 +10,4 @@ polarization.
 .. include:: /users_guide/generators/vertex/reacibd.rst
 .. include:: /users_guide/generators/vertex/pbomb.rst
 .. include:: /users_guide/generators/vertex/spectrum.rst
+.. include:: /users_guide/generators/vertex/hepevt.rst

--- a/doc/users_guide/generators/vertex/hepevt.rst
+++ b/doc/users_guide/generators/vertex/hepevt.rst
@@ -1,0 +1,21 @@
+hepevt
+''''''
+
+::
+
+   /generator/vtx/set file_name
+
+This generator takes a HEPEvt file as an input. The generator will read
+the file and generate events based on the information in the file.
+HEPEvt is a legacy file format typically used with FORTRAN-based
+generators, but is also supported by some modern generators such as
+MARLEY. The file should contain the event information in a specific
+format, which includes particle information such as PDG codes, momenta,
+and vertex positions.
+
+Note that since this is only a vertex generator, it does not utilize the
+position and timing information provided in the HEPEvt file. Combination
+with a position and timing generator is still required.
+
+Detailed documentation of the format is documented in detail by MARLEY
+`here <https://www.marleygen.org/interpret_output.html#hepevt>`__.


### PR DESCRIPTION
This patch changes how the HEPEvt vertex generator works. Previously this generator uses some type of hepevt-adjacent file format that's not exactly hepevt (the lineage of this seems to trace back to the GenericLAND days). This has been replaced by new logic which supports the canonical HEPEvt file format. Since MARLEY supports HEPEVT as an output method, we now somewhat supports MARLEY. 

It remains to be seen if it would be necessary to integrate MARLEY even further into RATPAC2. In LArSoft, for example, MARLEY is called directly from the simulation software, and no additional gen step is needed. Looking at MARLEY's code base, they have some support for that type of integration already.