### PR TITLE
Fix bug in WaveformUtil::CalculateTimeCFD

### DIFF
--- a/ratdb/DIGITIZER_ANALYSIS.ratdb
+++ b/ratdb/DIGITIZER_ANALYSIS.ratdb
@@ -7,7 +7,7 @@ valid_end: [0,0],
 pedestal_window_low: 0,
 pedestal_window_high: 10,
 constant_fraction: 0.40,
-// Number of samples to look back after the peak
+// Time to look back after the peak in ns
 lookback: 20.0,
 // Integration window, in samples
 integration_window_low: 4,

--- a/src/ds/include/RAT/DS/DigitPMT.hh
+++ b/src/ds/include/RAT/DS/DigitPMT.hh
@@ -13,6 +13,7 @@
 
 #include <RAT/DS/WaveformAnalysisResult.hh>
 #include <RAT/Log.hh>
+#include <RAT/WaveformUtil.hh>
 #include <limits>
 
 namespace RAT {
@@ -31,9 +32,9 @@ class DigitPMT : public TObject {
   virtual Int_t GetID() { return id; }
 
   /** Threshold crossing time in ns */
-  virtual void SetDigitizedTime(Double_t _dTime) { this->dTime = _dTime - time_offset; }
-  virtual Double_t GetDigitizedTime() { return dTime; }
-  virtual Double_t GetDigitizedTimeNoOffset() { return dTime + time_offset; }
+  virtual void SetDigitizedTime(Double_t _dTime) { this->dTime = _dTime; }
+  virtual Double_t GetDigitizedTime() { return (dTime == WaveformUtil::INVALID) ? dTime : dTime - time_offset; }
+  virtual Double_t GetDigitizedTimeNoOffset() { return dTime; }
 
   /** Integrated charge around the peak [pC] */
   virtual void SetDigitizedCharge(Double_t _dCharge) { this->dCharge = _dCharge; }

--- a/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
+++ b/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
@@ -10,6 +10,7 @@
 #include <TObject.h>
 
 #include <RAT/Log.hh>
+#include <RAT/WaveformUtil.hh>
 #include <algorithm>
 #include <map>
 #include <string>
@@ -27,7 +28,7 @@ class WaveformAnalysisResult : public TObject {
    * @param fom    map of all figures of merits. key should be name of the field (e.g. chi2ndf)
    * */
   virtual size_t AddPE(Double_t time, Double_t charge, std::map<std::string, Double_t> fom = {}) {
-    Double_t time_corrected = time - time_offset;
+    Double_t time_corrected = (time == WaveformUtil::INVALID) ? time : time - time_offset;
     size_t insertion_index = std::upper_bound(times.begin(), times.end(), time_corrected) - times.begin();
     times.insert(times.begin() + insertion_index, time_corrected);
     charges.insert(charges.begin() + insertion_index, charge);

--- a/src/util/src/WaveformUtil.cc
+++ b/src/util/src/WaveformUtil.cc
@@ -41,7 +41,7 @@ int GetThresholdCrossingBeforePeak(const std::vector<double>& waveform, int peak
   /*
   Identifies the sample at which threshold crossing occurs before a given peak
    */
-  int thresholdCrossing = 0;
+  int thresholdCrossing = INVALID;
   // Make sure we don't scan past the beginning of the waveform
   int lb = peakSample - int(lookBack / timeStep);
   int back_window = (lb > 0) ? lb : 0;
@@ -58,18 +58,11 @@ int GetThresholdCrossingBeforePeak(const std::vector<double>& waveform, int peak
   }
 
   // Start at the peak and scan backwards
-  for (int i = peakSample; i > back_window; i--) {
+  for (int i = peakSample; i >= back_window; i--) {
     double voltage = waveform[i];
 
     if (voltage > voltageThreshold) {
       thresholdCrossing = i;
-      break;
-    }
-
-    // Reached the begining of the waveform
-    // returned an invalid value
-    if (i == back_window) {
-      thresholdCrossing = INVALID;  // Invalid value for bad waveforms
       break;
     }
   }

--- a/src/util/src/WaveformUtil.cc
+++ b/src/util/src/WaveformUtil.cc
@@ -147,6 +147,11 @@ double CalculateTimeCFD(const std::vector<double>& waveform, int peakSample, int
   }
   int time = GetThresholdCrossingBeforePeak(waveform, peakSample, voltageThreshold, lookBack, timeStep);
   if (time == INVALID) {
+    // If we didn't find threshold crossing but we also weren't able to scan the entire lookback range
+    // because we reached the beginning of the waveform, return 0 instead of INVALID... and don't interpolate.
+    if (peakSample - int(lookBack / timeStep) < 0) {
+      return 0;
+    }
     return INVALID;
   }
   // Linearly interpolate threshold crossing time, if time is not last sample of waveform

--- a/src/util/src/WaveformUtil.cc
+++ b/src/util/src/WaveformUtil.cc
@@ -150,10 +150,11 @@ double CalculateTimeCFD(const std::vector<double>& waveform, int peakSample, int
   double dt = 0;
   if (time + 1 < static_cast<int>(waveform.size())) {
     double deltav = waveform.at(time + 1) - waveform.at(time);
-    if (deltav != 0) {
-      dt = (voltageThreshold - waveform.at(time)) / deltav;
-    } else {
-      dt = 0;
+    dt = (deltav == 0) ? 0 : (voltageThreshold - waveform.at(time)) / deltav;
+    if (dt < 0) {
+      debug << "WaveformUtil::CalculateTimeCFD: Interpolating to value before threshold crossing. "
+            << "This should not happen." << newline;
+      return INVALID;
     }
   }
   return (time + dt) * timeStep;

--- a/src/util/src/WaveformUtil.cc
+++ b/src/util/src/WaveformUtil.cc
@@ -45,6 +45,11 @@ int GetThresholdCrossingBeforePeak(const std::vector<double>& waveform, int peak
   // Make sure we don't scan past the beginning of the waveform
   int lb = peakSample - int(lookBack / timeStep);
   int back_window = (lb > 0) ? lb : 0;
+  // No threshold crossing if highest peak is below threshold
+  if (waveform.at(peakSample) > voltageThreshold) {
+    debug << "WaveformUtil::GetThresholdCrossingBeforePeak: Peak not above threshold.\n";
+    return INVALID;
+  }
 
   if (static_cast<size_t>(back_window) >= waveform.size()) {
     debug << "WaveformUtil::GetThresholdCrossingBeforePeak: Start of lookback window not before end of waveform."
@@ -53,8 +58,6 @@ int GetThresholdCrossingBeforePeak(const std::vector<double>& waveform, int peak
     debug << "WaveformUtil::GetThresholdCrossingBeforePeak: Start of lookback window not before peak." << newline;
   } else if (static_cast<size_t>(peakSample) >= waveform.size()) {
     debug << "WaveformUtil::GetThresholdCrossingBeforePeak: Peak not before end of waveform." << newline;
-  } else if (waveform.at(peakSample) > voltageThreshold) {
-    debug << "WaveformUtil: Peak not above threshold.\n";
   }
 
   // Start at the peak and scan backwards


### PR DESCRIPTION
Commit 0ae95141812443d22d54737a302090684b0c4c9f :

> Previously, line 69-74...
> ```c++
>    // Reached the begining of the waveform
>    // returned an invalid value
>    if (i == back_window) {
>      thresholdCrossing = INVALID;  // Invalid value for bad waveforms
>      break;
>    }
>``` 
> ...was not doing anything, since we loop until `i > back_window`.
> Hence when we don't cross threshold, `GetThresholdCrossingBeforePeak` returned `thresholdCrossing = 0`.
> This causes `CalculateTimeCFD` to return an unrealistic number -- often some small negative value that is outside the trigger window.
>
> Instead, initiate `thresholdCrossing` as `INVALID`, and let it return `INVALID` if threshold is not crossed.

Commit 42842ab3ab09545c2bfb9bf051a7f8e6e4aba629 : 

> Error catching, although this shouldn't happen -- we should never interpolate "backwards".

Commit e30ca73e61581eea183e03363c9ef13b3d7e311b : 

> If the peak is not above threshold, return `INVALID`.
> Previously it returned `peakSample` since it meets the `break` condition immediately.