### PR TITLE
feat: Created 'include_opticalproperties' parameter that saves inputted optical parameters to TGraph format in output file

### DIFF
--- a/doc/users_guide/outputs.rst
+++ b/doc/users_guide/outputs.rst
@@ -46,6 +46,7 @@ Parameters:
     /rat/procset include_digitizerwaveforms 1
     /rat/procset include_digitizerhits 1
     /rat/procset include_digitizerfits 
+    /rat/procset include_opticalproperties 1
 
 * filename (required, string) Sets output filename.  File will be deleted if it already exists.
 * include_* (optional, int) Sets whether the ntuple structure will be extended to include more variables, as detailed below. By default the following, based on the entries in IO.ratdb, the following are set to 0 by default: ``include_tracking``, ``include_mcparticles``, and ``include_digitizerwaveforms`` and the rest are set to 1 by default (i.e., the associated variables aare included in the ntuple file, as detailed below).
@@ -257,6 +258,18 @@ If ``include_digitizerwaveforms`` is set then we create a new branch in the ntup
 ``inWindowPulseCharges``       vector<double>       The list of MCPE charges that fall inside the waveform window.
 ``waveform``                   vector<ushort>       The digitized waveform, per PMT.
 =============================  ===================  ===================
+
+If ``include_opticalproperties`` is set then we create a new TDirectory in the ntuple called ``opticalProperies`` that stores the inputted optical properties as TGraphs. Every material is saved, such as refractive indices, absorption length, reflectivity and scintillation spectra. The format of the TGraphs is shown below, and is in the format ``<MATERIAL>_<OPTICALPROPERTY>``:
+
+=============================  ===================  ===================
+**Name**                       **Type**             **Description**
+=============================  ===================  ===================
+``water_RINDEX``               TGraph               RINDEX as a function of wavelength [nm]
+``water_ABSLENGTH``            TGraph               ABSLENGTH as a function of wavelength [nm]
+``tybek_REFLECTIVITY``         TGraph               REFLECTIVITY as a function of wavelength [nm]
+``wbls_SCINTILLATION``         TGraph               SCINTILLATION spectrum as a function of wavelength [nm]
+=============================  ===================  ===================
+
 
 .. _outnet:
 

--- a/src/ds/include/RAT/DS/Optical.hh
+++ b/src/ds/include/RAT/DS/Optical.hh
@@ -1,0 +1,88 @@
+
+/**
+ * @class DS::Optical
+ * Data Structure: Monte Carlo information
+ *
+ * @author Sean Hughes <sgshugh0@liverpool.ac.uk>
+ *
+ * Contains the information relating to printing out optical properties as meta data
+ *
+ */
+
+#ifndef __RAT_DS_Optical__
+#define __RAT_DS_Optical__
+
+#include <TAxis.h>
+#include <TGraph.h>
+#include <TObject.h>
+#include <TTimeStamp.h>
+
+#include <RAT/DB.hh>
+
+namespace RAT {
+namespace DS {
+
+class Optical : public TObject {
+ public:
+  Optical() : TObject() {}
+  virtual ~Optical() {}
+
+  /**
+   * function that produces optical properties as TGraphs from existing ratdb tables.
+   * Takes from all optics ratdb tables
+   */
+  std::pair<std::vector<TString>, std::vector<TGraph*>> GetOpticalProperty() {
+    GetOPTICS();
+    return std::make_pair(opticalProperties_names, opticalProperties);
+  }
+
+  void GetOPTICS() {
+    DBLinkGroup mats = DB::Get()->GetLinkGroup("OPTICS");
+    std::vector<std::string> opticalNames = {"ABSLENGTH",         "RINDEX",         "REFLECTIVITY", "SCINTILLATION",
+                                             "SCINTILLATION_WLS", "REEMISSION_PROB"};
+
+    std::string value1 = "_value1";
+    std::string value2 = "_value2";
+
+    // Load everything in OPTICS
+    for (std::string opticalName : opticalNames) {
+      for (DBLinkGroup::iterator iv = mats.begin(); iv != mats.end(); iv++) {
+        std::string name = iv->first;
+        DBLinkPtr table = iv->second;
+        try {
+          std::vector<double> abslength_wavelength = table->GetDArray((opticalName + value1));
+          std::vector<double> abslength_value = table->GetDArray((opticalName + value2));
+        } catch (DBNotFoundError& e) {
+          std::cout << "Optics failed to get " << opticalName << " on: " << name << std::endl;
+          continue;
+        }
+
+        std::cout << "Loading " << opticalName << " optics: " << name << std::endl;
+
+        std::vector<double> abslength_wavelength = table->GetDArray((opticalName + value1));
+        std::vector<double> abslength_value = table->GetDArray((opticalName + value2));
+
+        TGraph* new_gr = new TGraph(abslength_value.size());
+
+        for (size_t i = 0; i < abslength_wavelength.size(); ++i) {
+          new_gr->SetPoint(i, abslength_wavelength.at(i), abslength_value.at(i));
+        }
+        new_gr->GetXaxis()->SetTitle("Wavelength [nm]");
+        new_gr->GetYaxis()->SetTitle(opticalName.c_str());
+        opticalProperties.push_back(new_gr);
+        opticalProperties_names.push_back((name + "_" + opticalName));
+      }
+    }
+  }
+
+ private:
+  std::string name;
+  std::vector<TString> opticalProperties_names;
+  std::vector<TGraph*> opticalProperties;
+};
+// ClassDef(Optical, 2);
+
+}  // namespace DS
+}  // namespace RAT
+
+#endif

--- a/src/ds/include/RAT/DS/Run.hh
+++ b/src/ds/include/RAT/DS/Run.hh
@@ -13,6 +13,7 @@
 
 #include <RAT/DS/ChannelStatus.hh>
 #include <RAT/DS/NestedTubeInfo.hh>
+#include <RAT/DS/Optical.hh>
 #include <RAT/DS/PMTInfo.hh>
 #include <vector>
 
@@ -35,6 +36,9 @@ class Run : public TObject {
   /** Run start time */
   virtual TTimeStamp GetStartTime() const { return startTime; }
   virtual void SetStartTime(const TTimeStamp &_startTime) { startTime = _startTime; }
+
+  /** Get optical information **/
+  virtual Optical *GetOpticalInfo() { return &opticalinfo; }
 
   /** PMT information */
   virtual PMTInfo *GetPMTInfo() {
@@ -80,6 +84,7 @@ class Run : public TObject {
   TTimeStamp startTime;
   std::vector<NestedTubeInfo> nestedtubeinfo;
   std::vector<PMTInfo> pmtinfo;  // ah.. why is this a vector?
+  Optical opticalinfo;
   ChannelStatus ch_status;
 };
 

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -47,16 +47,17 @@ class OutNtupleProc : public Processor {
   virtual void EndOfRun(DS::Run *run) override;
 
   // Extensible functions
-  virtual void AssignAdditionalAddresses(){};
-  virtual void AssignAdditionalMetaAddresses(){};
-  virtual void FillEvent(DS::Root *, DS::EV *){};
-  virtual void FillNoTriggerEvent(DS::Root *){};
-  virtual void FillMeta(){};
+  virtual void AssignAdditionalAddresses() {};
+  virtual void AssignAdditionalMetaAddresses() {};
+  virtual void FillEvent(DS::Root *, DS::EV *) {};
+  virtual void FillNoTriggerEvent(DS::Root *) {};
+  virtual void FillMeta() {};
 
   // Exposed members for external tools
   DS::Run *runBranch;
   // Fill Functions
   struct NtupleOptions {
+    bool opticalproperties;
     bool tracking;
     bool mcparticles;
     bool pmthits;
@@ -119,6 +120,9 @@ class OutNtupleProc : public Processor {
   std::string calibName;
   ULong64_t calibTime;
   Double_t calibX, calibY, calibZ, calibU, calibV, calibW;
+  // Optical properties
+  std::vector<TGraph *> opticalProperties;
+  std::vector<TString> opticalProperties_names;
   // Digitizer waveforms
   int waveform_pmtid;
   std::vector<Double_t> inWindowPulseTimes;


### PR DESCRIPTION
* Adds new parameter "include_opticalproperties"
* Parameter will create new opticalProperties TDirectory in ntuple
* ntuple contains all inputted optical parameters from the ratdb tables. All are saved as TGraphss