### PR TITLE
Enable quenched energy deposited for a specific track or step to be accessed

### DIFF
--- a/src/core/include/RAT/Trajectory.hh
+++ b/src/core/include/RAT/Trajectory.hh
@@ -3,6 +3,7 @@
 
 #include <G4Trajectory.hh>
 #include <RAT/DS/MCTrack.hh>
+#include <RAT/QuenchingCalculator.hh>
 #include <string>
 
 namespace RAT {
@@ -30,6 +31,7 @@ class Trajectory : public G4Trajectory {
   std::string creatorProcessName;
   DS::MCTrack *ratTrack;
   static bool fgDoAppendMuonStepSpecial;
+  QuenchingCalculator *fQuenching;
 };
 
 // GEANT4 uses a custom allocator on subclass, so we need to override it here.

--- a/src/ds/include/RAT/DS/MCTrack.hh
+++ b/src/ds/include/RAT/DS/MCTrack.hh
@@ -94,6 +94,10 @@ class MCTrack : public TObject {
   virtual Double_t GetDepositedEnergy() const { return depositedEnergy; }
   virtual void SetDepositedEnergy(Double_t _depositedEnergy) { depositedEnergy = _depositedEnergy; }
 
+  /** True total quenched energy deposited along the track (MeV). **/
+  virtual Double_t GetScintEdepQuenched() const { return scintEdepQuenched; }
+  virtual void SetScintEdepQuenched(Double_t _scintEdepQuenched) { scintEdepQuenched = _scintEdepQuenched; }
+
   ClassDef(MCTrack, 2);
 
  protected:
@@ -102,6 +106,7 @@ class MCTrack : public TObject {
   Int_t pdgcode;
   Double_t length;
   Double_t depositedEnergy;
+  Double_t scintEdepQuenched;
   std::string particleName;
   std::vector<MCTrackStep> step;
 };

--- a/src/ds/include/RAT/DS/MCTrackStep.hh
+++ b/src/ds/include/RAT/DS/MCTrackStep.hh
@@ -67,6 +67,10 @@ class MCTrackStep : public TObject {
   virtual Double_t GetDepositedEnergy() const { return depositedEnergy; }
   virtual void SetDepositedEnergy(Double_t _depositedEnergy) { depositedEnergy = _depositedEnergy; }
 
+  /** True total quenched energy deposited along the step (MeV). **/
+  virtual Double_t GetScintEdepQuenched() const { return scintEdepQuenched; }
+  virtual void SetScintEdepQuenched(Double_t _scintEdepQuenched) { scintEdepQuenched = _scintEdepQuenched; }
+
   /** Name of physics process acting at endpoint. */
   virtual std::string GetProcess() const { return process; }
   virtual void SetProcess(const std::string &_process) { process = _process; }
@@ -84,6 +88,7 @@ class MCTrackStep : public TObject {
   Double_t properTime;
   Double_t ke;
   Double_t depositedEnergy;
+  Double_t scintEdepQuenched;
   TVector3 endpoint;
   TVector3 mom;
   std::string process;


### PR DESCRIPTION
The motivation was mainly to provide a more granular version of GetTotalScintEdepQuenched from MCSummary. MCSummary only gives the total quenched energy deposited: the quenched energy for each step was not available in the original source code.

Briefly tested with electrons.