### PR TITLE
Fix container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,15 +13,3 @@ Dockerfile*
 data/**/*.MD
 data/**/*.jpeg
 
-### CMake ###
-CMakeLists.txt.user
-CMakeCache.txt
-CMakeFiles
-CMakeScripts
-Testing
-Makefile
-cmake_install.cmake
-install_manifest.txt
-compile_commands.json
-CTestTestfile.cmake
-_deps

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -2,24 +2,28 @@ name: Build Docker Image
 
 on:
   schedule:
-    - cron: '0 4 * * *' # Everyday at 4am UTC
+    - cron: '0 4 * * *' # Every day at 4am UTC
   push:
     branches: [ main ]
     tags: 
-      - "v*.*.*"
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
 jobs:
   docker:
     runs-on: ubuntu-latest
-    # Don't let forks build containers
+    # Only run on the main repo, not forks
     if: github.repository == 'rat-pac/ratpac-two'
     permissions: 
       packages: write
       contents: read
       attestations: write
       id-token: write
+
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -27,34 +31,32 @@ jobs:
           images: |
             ratpac/ratpac-two
             ghcr.io/${{ github.repository }}
-          # generate Docker tags based on the following events/attributes
-          # Using default, which should generate tags for branchs and `nightly`
-          # tags: |
-          #   type=schedule
-          #   type=ref,event=branch
-          #   type=ref,event=workflow_dispatch
-          #   type=semver,pattern={{raw}}
-          #   type=sha
-      -
-        name: Login to Docker Hub
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=workflow_dispatch
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     
-      - 
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push
-        id: push
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
+          context: .
           file: containers/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -5,10 +5,10 @@ SHELL ["/bin/bash", "-c"]
 
 USER ratuser
 
+COPY --chown=ratuser:ratuser . /ratpac-setup/ratpac
+WORKDIR /ratpac-setup/ratpac
+RUN source /ratpac-setup/env.sh && make -j$(nproc)
 WORKDIR /ratpac-setup
-
-RUN ./setup.sh --only ratpac -j$(nproc)
-RUN cd ratpac && cmake --install build && cd ..
 
 RUN sed -i '1s/^/#!\/bin\/bash\n/' /ratpac-setup/env.sh
 RUN printf '\nexec "$@"\n' >> /ratpac-setup/env.sh


### PR DESCRIPTION
- Make sure that the Github CI works with the new tag syntax (from `vX.Y.Z` to `X.Y.Z`)
- Use the build context version of RP2 for building the container, instead of always pulling the latest git commit from `main`.