### PR TITLE
fix: Makefile redirect causes docker builds to fail silently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all:
 	ln -sf $(PWD)/cformat.sh $(shell git rev-parse --git-common-dir)/hooks/pre-commit
 	cmake . -B$(build_directory) -DCMAKE_INSTALL_PREFIX=$(install_directory)
 	cmake --build $(build_directory) -- $(MAKEFLAGS)
-	cmake --install $(build_directory) &> /dev/null
+	cmake --install $(build_directory) | grep -v "Up-to-date"
 
 clean:
 	rm -rf $(build_directory) $(install_directory) ratpac.sh ratpac.csh RatpacConfig.cmake


### PR DESCRIPTION
Finally fixing the fact that you need to press enter after build is complete:)