### PR TITLE
Add new hit cleaned waveform analysis mode for fitters to use

### DIFF
--- a/ratdb/FITTER.ratdb
+++ b/ratdb/FITTER.ratdb
@@ -1,8 +1,9 @@
 {
 "name": "FIT_COMMON",
 "index": "",
-"mode": 0, // 0 = use DS::PMT; 1 = use DS::DigitPMT DigitTime/Charge; 2 = use WaveformAnalysisResult
-"waveform_analyzer": "Lognormal", // only required if mode = 2
+"mode": 0, // 0 = use DS::PMT; 1 = use DS::DigitPMT DigitTime/Charge; 2 = use WaveformAnalysisResult: 3 = use hit cleaned WaveformAnalysisResult
+"waveform_analyzer": "Lognormal", // only required if mode = 2 or 3
+"hit_cleaning_bit": 1, // only required if mode = 3
 "vertex_seed": "quadfitter",
 "direction_seed": "fitdirectioncenter",
 "energy_seed": "DOESNOTEXIST"


### PR DESCRIPTION
- Fitter mode 3 is now `kHitCleanedWaveformAnalysis`. This mode uses the hit cleaning mask from the `DigitPMT` class to remove waveforms that don't pass the hit cleaning cut of bit `hit_cleaning_bit` from the fitter analysis
- Made the default `hit_cleaning_bit` bit 1 in the hit cleaning mask, which is from `NegPosAmpRatioCut` 



