### PR TITLE
Add digitHitCleanedPMTID and digitHitCleanedNhits to output ntuple

### DIFF
--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -199,6 +199,8 @@ class OutNtupleProc : public Processor {
   std::vector<int> digitReconNPEs;
   std::vector<int> digitNCrossings;
   std::vector<int> digitPMTID;
+  int digitHitCleanedNhits;
+  std::vector<int> digitHitCleanedPMTID;
   std::vector<uint64_t> digitHitCleaningMask;
   // Information from fit to the waveforms
   std::map<std::string, std::vector<int>> fitPmtID;

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -199,6 +199,7 @@ class OutNtupleProc : public Processor {
   std::vector<int> digitReconNPEs;
   std::vector<int> digitNCrossings;
   std::vector<int> digitPMTID;
+  std::vector<uint64_t> digitHitCleaningMask;
   // Information from fit to the waveforms
   std::map<std::string, std::vector<int>> fitPmtID;
   std::map<std::string, std::vector<double>> fitTime;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -179,6 +179,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
     outputTree->Branch("digitTime", &digitTime);
     outputTree->Branch("digitCharge", &digitCharge);
     outputTree->Branch("digitNCrossings", &digitNCrossings);
+    outputTree->Branch("digitHitCleaningMask", &digitHitCleaningMask);
     outputTree->Branch("digitTimeOverThreshold", &digitTimeOverThreshold);
     outputTree->Branch("digitVoltageOverThreshold", &digitVoltageOverThreshold);
     outputTree->Branch("digitPeak", &digitPeak);
@@ -582,6 +583,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       digitPMTID.clear();
       digitLocalTriggerTime.clear();
       digitReconNPEs.clear();
+      digitHitCleaningMask.clear();
 
       if (options.digitizerfits) {
         for (const std::string &fitter_name : waveform_fitters) {
@@ -606,6 +608,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
         if (digitpmt->GetNCrossings() > 0) {
           digitNhits++;
         }
+        digitHitCleaningMask.push_back(digitpmt->GetHitCleaningMask());
         digitVoltageOverThreshold.push_back(digitpmt->GetVoltageOverThreshold());
         digitPeak.push_back(digitpmt->GetPeakVoltage());
         digitLocalTriggerTime.push_back(digitpmt->GetLocalTriggerTime());
@@ -686,6 +689,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       digitPMTID.clear();
       digitLocalTriggerTime.clear();
       digitReconNPEs.clear();
+      digitHitCleaningMask.clear();
       if (options.digitizerfits) {
         for (const std::string &fitter_name : waveform_fitters) {
           // construct arrays for all fitters

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -179,12 +179,14 @@ bool OutNtupleProc::OpenFile(std::string filename) {
     outputTree->Branch("digitTime", &digitTime);
     outputTree->Branch("digitCharge", &digitCharge);
     outputTree->Branch("digitNCrossings", &digitNCrossings);
-    outputTree->Branch("digitHitCleaningMask", &digitHitCleaningMask);
     outputTree->Branch("digitTimeOverThreshold", &digitTimeOverThreshold);
     outputTree->Branch("digitVoltageOverThreshold", &digitVoltageOverThreshold);
     outputTree->Branch("digitPeak", &digitPeak);
     outputTree->Branch("digitLocalTriggerTime", &digitLocalTriggerTime);
     outputTree->Branch("digitReconNPEs", &digitReconNPEs);
+    outputTree->Branch("digitHitCleanedNhits", &digitHitCleanedNhits);
+    outputTree->Branch("digitHitCleanedPMTID", &digitHitCleanedPMTID);
+    outputTree->Branch("digitHitCleaningMask", &digitHitCleaningMask);
   }
   if (options.digitizerfits) {
     for (const std::string &fitter_name : waveform_fitters) {
@@ -583,6 +585,8 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       digitPMTID.clear();
       digitLocalTriggerTime.clear();
       digitReconNPEs.clear();
+      digitHitCleanedNhits = 0;
+      digitHitCleanedPMTID.clear();
       digitHitCleaningMask.clear();
 
       if (options.digitizerfits) {
@@ -626,6 +630,11 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
             }
           }
         }
+      }
+      for (int pmtc : ev->GetAllCleanedDigitPMTIDs()) {
+        RAT::DS::DigitPMT *digitpmt = ev->GetOrCreateDigitPMT(pmtc);
+        digitHitCleanedPMTID.push_back(digitpmt->GetID());
+        digitHitCleanedNhits++;
       }
     }
     if (options.digitizerwaveforms) {
@@ -689,6 +698,8 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
       digitPMTID.clear();
       digitLocalTriggerTime.clear();
       digitReconNPEs.clear();
+      digitHitCleanedNhits = 0;
+      digitHitCleanedPMTID.clear();
       digitHitCleaningMask.clear();
       if (options.digitizerfits) {
         for (const std::string &fitter_name : waveform_fitters) {


### PR DESCRIPTION
This adds `digitHitCleanedPMTID` and `digitHitCleanedNhits` to the output ntuple file, using the function Sam already created `GetAllCleanedDigtitPMTID()` in `ratpac-two/src/ds/include/RAT/DS/EV.hh` in PR #276, however this function only returns pmtids where all bits in the hit cleaning mask are 0 (pass). 

There should probably be some field we reference like the hex hit cleaning mask `hit_cleaning_mask` in `ratpac-two/ratdb/FITTER.ratdb.` Currently hit cleaning methods are enabled/disabled in `EosSimulations/ratdb/HIT_CLEANING.ratdb`, and their bit position is set in the hit cleaning processor at `EosSimulations/src/data_cleaning/hit_cleaning/src/HitCleaningProc.cc`.
 
Shoud we...
1. Move the hit cleaning processor to `ratpac-two` and add `ratpac-two/ratdb/HIT_CLEANING.ratdb`
2. Reference `ratpac-two/ratdb/FITTER.db` in `ratpac-two/src/ds/include/RAT/DS/EV.hh`
3. Do some obvious solution that eludes me

<img width="1387" height="585" alt="image" src="https://github.com/user-attachments/assets/b0a53a93-d1b6-4512-8909-c69861ea34c8" />
