### PR TITLE
Set placeholder FOM values when fit direction center processor fails 

### DIFF
--- a/src/fit/include/RAT/FitDirectionCenterProc.hh
+++ b/src/fit/include/RAT/FitDirectionCenterProc.hh
@@ -44,6 +44,8 @@ class FitDirectionCenterProc : public Processor {
   virtual Processor::Result Event(DS::Root *ds, DS::EV *ev);
 
  protected:
+  void SetPlaceholderFOM(DS::FitResult *fit);
+
   std::vector<int> fPMTtype;  // Types of PMT to use in reconstruction.  If empty, uses all PMT types.
   int fVerbose = 0;  // Save FOMs in FitResult.  1 saves num_PMT.  2 also saves time_resid_low and time_resid_up.
   std::string fFitterName = "fitdirectioncenter";  // Default fitter name.  User can specify.

--- a/src/fit/src/FitDirectionCenterProc.cc
+++ b/src/fit/src/FitDirectionCenterProc.cc
@@ -15,7 +15,7 @@
 namespace RAT {
 
 // Helper to set placeholder figures of merit for failed fits
-void FitDirectionCenterProc::SetPlaceholderFOM(DS::FitResult* fit) {
+void FitDirectionCenterProc::SetPlaceholderFOM(DS::FitResult *fit) {
   fit->SetIntFigureOfMerit("num_PMT", 0);
   fit->SetDoubleFigureOfMerit("time_resid_low", NAN);
   fit->SetDoubleFigureOfMerit("time_resid_up", NAN);
@@ -312,4 +312,3 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
 }
 
 }  // namespace RAT
-

--- a/src/fit/src/FitDirectionCenterProc.cc
+++ b/src/fit/src/FitDirectionCenterProc.cc
@@ -16,9 +16,13 @@ namespace RAT {
 
 // Helper to set placeholder figures of merit for failed fits
 void FitDirectionCenterProc::SetPlaceholderFOM(DS::FitResult *fit) {
-  fit->SetIntFigureOfMerit("num_PMT", 0);
-  fit->SetDoubleFigureOfMerit("time_resid_low", NAN);
-  fit->SetDoubleFigureOfMerit("time_resid_up", NAN);
+  if (fVerbose >= 1) {
+    fit->SetIntFigureOfMerit("num_PMT", 0);
+  }
+  if (fVerbose >= 2) {
+    fit->SetDoubleFigureOfMerit("time_resid_low", NAN);
+    fit->SetDoubleFigureOfMerit("time_resid_up", NAN);
+  }
 }
 
 void FitDirectionCenterProc::BeginOfRun(DS::Run *run) {

--- a/src/fit/src/FitDirectionCenterProc.cc
+++ b/src/fit/src/FitDirectionCenterProc.cc
@@ -14,6 +14,13 @@
 
 namespace RAT {
 
+// Helper to set placeholder figures of merit for failed fits
+void FitDirectionCenterProc::SetPlaceholderFOM(DS::FitResult* fit) {
+  fit->SetIntFigureOfMerit("num_PMT", 0);
+  fit->SetDoubleFigureOfMerit("time_resid_low", NAN);
+  fit->SetDoubleFigureOfMerit("time_resid_up", NAN);
+}
+
 void FitDirectionCenterProc::BeginOfRun(DS::Run *run) {
   DB *db = DB::Get();
   DBLinkPtr table = db->GetLink("Fitter", "FitDirectionCenter");
@@ -103,6 +110,7 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
 
   int numPMTs = inputHandler.GetNHits();
   if (numPMTs <= 0) {
+    SetPlaceholderFOM(fitDC);
     fitDC->SetValidDirection(false);
     ev->AddFitResult(fitDC);
     return Processor::FAIL;
@@ -118,7 +126,10 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
   // Get reconstructed position from a fit result
   if (fPosMethod != "fixed") {
     std::vector<RAT::DS::FitResult *> fits = ev->GetFitResults();
-    if (fits.size() == 0) Log::Die("FitDirectionCenterProc: No position specified (fixed or reconstructed).");
+    if (fits.size() == 0) {
+      SetPlaceholderFOM(fitDC);
+      Log::Die("FitDirectionCenterProc: No position specified (fixed or reconstructed).");
+    }
 
     RAT::DS::FitResult *fit;
     if (fPosFitter.empty()) {       // If fitter not specified
@@ -132,8 +143,10 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
           break;
         }
       }
-      if (!foundPosFitter)
+      if (!foundPosFitter) {
+        SetPlaceholderFOM(fitDC);
         Log::Die("FitDirectionCenterProc: Position fitter \'" + fPosFitter + "\' not found.  Check name.");
+      }
     }
 
     if (fit->GetEnablePosition()) {
@@ -141,6 +154,7 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
       validPos = fit->GetValidPosition();
       if (!validPos) fitDC->SetValidDirection(false);
     } else {
+      SetPlaceholderFOM(fitDC);
       fitDC->SetValidDirection(false);
       ev->AddFitResult(fitDC);
       return Processor::FAIL;
@@ -154,8 +168,10 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
   bool applyDrive = (!fDirFitter.empty() && fDrive != 0.0);
   if (applyDrive) {
     std::vector<RAT::DS::FitResult *> fits = ev->GetFitResults();
-    if (fits.size() == 0)
+    if (fits.size() == 0) {
+      SetPlaceholderFOM(fitDC);
       Log::Die("FitDirectionCenterProc: No reconstructed direction available for drive correction.");
+    }
 
     RAT::DS::FitResult *fit;
     bool foundDirFitter = false;
@@ -166,8 +182,10 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
         break;
       }
     }
-    if (!foundDirFitter)
+    if (!foundDirFitter) {
+      SetPlaceholderFOM(fitDC);
       Log::Die("FitDirectionCenterProc: Direction fitter \'" + fDirFitter + "\' not found.  Check that it was run.");
+    }
 
     TVector3 eventDir;
     bool validDir = true;
@@ -176,6 +194,7 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
       validDir = fit->GetValidDirection();
       if (!validDir) fitDC->SetValidDirection(false);
     } else {
+      SetPlaceholderFOM(fitDC);
       fitDC->SetValidDirection(false);
       ev->AddFitResult(fitDC);
       return Processor::FAIL;
@@ -188,8 +207,10 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
     fitDC->SetPosition(eventPos);
 
   } else if (fDrive != 0.0 && fDirFitter.empty()) {
+    SetPlaceholderFOM(fitDC);
     Log::Die("FitDirectionCenterProc: No direction fitter specified while drive value is specified.");
   } else if (fDrive == 0.0 && !fDirFitter.empty()) {
+    SetPlaceholderFOM(fitDC);
     Log::Die("FitDirectionCenterProc: No drive value specified while direction fitter \'" + fPosFitter +
              "\' is specified.");
   }
@@ -218,6 +239,7 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
       pmtTimes.push_back(timeResidual);
     }
     if (pmtTimes.empty()) {  // No PMTs selected
+      SetPlaceholderFOM(fitDC);
       fitDC->SetValidDirection(false);
       ev->AddFitResult(fitDC);
       return Processor::FAIL;
@@ -266,6 +288,7 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
   }
 
   if (numDir == 0) {
+    SetPlaceholderFOM(fitDC);
     fitDC->SetValidDirection(false);
     ev->AddFitResult(fitDC);
     return Processor::FAIL;
@@ -289,3 +312,4 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
 }
 
 }  // namespace RAT
+

--- a/src/fit/src/FitDirectionCenterProc.cc
+++ b/src/fit/src/FitDirectionCenterProc.cc
@@ -127,7 +127,6 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
   if (fPosMethod != "fixed") {
     std::vector<RAT::DS::FitResult *> fits = ev->GetFitResults();
     if (fits.size() == 0) {
-      SetPlaceholderFOM(fitDC);
       Log::Die("FitDirectionCenterProc: No position specified (fixed or reconstructed).");
     }
 
@@ -144,7 +143,6 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
         }
       }
       if (!foundPosFitter) {
-        SetPlaceholderFOM(fitDC);
         Log::Die("FitDirectionCenterProc: Position fitter \'" + fPosFitter + "\' not found.  Check name.");
       }
     }
@@ -169,7 +167,6 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
   if (applyDrive) {
     std::vector<RAT::DS::FitResult *> fits = ev->GetFitResults();
     if (fits.size() == 0) {
-      SetPlaceholderFOM(fitDC);
       Log::Die("FitDirectionCenterProc: No reconstructed direction available for drive correction.");
     }
 
@@ -183,7 +180,6 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
       }
     }
     if (!foundDirFitter) {
-      SetPlaceholderFOM(fitDC);
       Log::Die("FitDirectionCenterProc: Direction fitter \'" + fDirFitter + "\' not found.  Check that it was run.");
     }
 
@@ -207,10 +203,8 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
     fitDC->SetPosition(eventPos);
 
   } else if (fDrive != 0.0 && fDirFitter.empty()) {
-    SetPlaceholderFOM(fitDC);
     Log::Die("FitDirectionCenterProc: No direction fitter specified while drive value is specified.");
   } else if (fDrive == 0.0 && !fDirFitter.empty()) {
-    SetPlaceholderFOM(fitDC);
     Log::Die("FitDirectionCenterProc: No drive value specified while direction fitter \'" + fPosFitter +
              "\' is specified.");
   }


### PR DESCRIPTION
Ensures that the `FitDirectionCenterProc` always sets placeholder figure of merit values even when the fitter fails or returns early without producing a valid fit. Previously, failure cases did not set any FOMs, which could cause indexing or consistency issues when reading the output files downstream.