### PR TITLE
Update MIMIR registration mechanism

### DIFF
--- a/src/fit/mimir/include/mimir/Common.hh
+++ b/src/fit/mimir/include/mimir/Common.hh
@@ -2,7 +2,7 @@
 
 #include <RAT/DB.hh>
 
-namespace RAT::Mimir {
+namespace Mimir {
 constexpr int INVALID = -9999;
 
 inline RAT::DBLinkPtr GetConfig(const std::string& type_name, const std::string& index = "") {
@@ -15,4 +15,4 @@ inline std::string GetConfigRepr(RAT::DBLinkPtr db_link) {
   return result.str();
 }
 
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/include/mimir/Cost.hh
+++ b/src/fit/mimir/include/mimir/Cost.hh
@@ -3,7 +3,7 @@
 #include <mimir/Common.hh>
 #include <mimir/ParamSet.hh>
 
-namespace RAT::Mimir {
+namespace Mimir {
 
 class Cost {
  public:
@@ -46,4 +46,4 @@ class Cost {
   std::string name;
 };
 
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/include/mimir/FitStep.hh
+++ b/src/fit/mimir/include/mimir/FitStep.hh
@@ -1,11 +1,11 @@
 #pragma once
+#include <mimir/Cost.hh>
 #include <mimir/FitStrategy.hh>
-#include <mimir/PMTTypeTimeResidualPDF.hh>
-#include <mimir/RootOptimizer.hh>
+#include <mimir/Optimizer.hh>
 
 #include "mimir/ParamSet.hh"
 
-namespace RAT::Mimir {
+namespace Mimir {
 
 class FitStep : public FitStrategy {
  public:
@@ -32,4 +32,4 @@ class FitStep : public FitStrategy {
                   std::vector<double>& ub);
 };
 
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/include/mimir/FitStrategy.hh
+++ b/src/fit/mimir/include/mimir/FitStrategy.hh
@@ -5,7 +5,7 @@
 
 #include "mimir/ParamSet.hh"
 
-namespace RAT::Mimir {
+namespace Mimir {
 class FitStrategy {
  public:
   FitStrategy() = default;
@@ -58,4 +58,4 @@ class FitStrategy {
   std::string name;
 };
 
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/include/mimir/Optimizer.hh
+++ b/src/fit/mimir/include/mimir/Optimizer.hh
@@ -4,7 +4,7 @@
 #include <mimir/Cost.hh>
 #include <mimir/ParamSet.hh>
 
-namespace RAT::Mimir {
+namespace Mimir {
 
 class Optimizer {
  public:
@@ -33,4 +33,4 @@ class Optimizer {
   std::string name;
 };
 
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/include/mimir/PMTTypeTimeResidualPDF.hh
+++ b/src/fit/mimir/include/mimir/PMTTypeTimeResidualPDF.hh
@@ -5,7 +5,7 @@
 #include <mimir/Cost.hh>
 #include <mimir/Factory.hh>
 
-namespace RAT::Mimir {
+namespace Mimir {
 class PMTTypeTimeResidualPDF : public Cost {
  public:
   bool Configure(RAT::DBLinkPtr db_link) override;
@@ -19,5 +19,4 @@ class PMTTypeTimeResidualPDF : public Cost {
   std::map<int, double> type_weights;
   RAT::DS::PMTInfo* pmt_info;
 };
-MIMIR_REGISTER_TYPE(Cost, PMTTypeTimeResidualPDF, "PMTTypeTimeResidualPDF")
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/include/mimir/ParamSet.hh
+++ b/src/fit/mimir/include/mimir/ParamSet.hh
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-namespace RAT::Mimir {
+namespace Mimir {
 enum class ParamStatus { INACTIVE = 0, ACTIVE = 1, FIXED = 2 };
 
 struct ParamComponent {
@@ -67,4 +67,4 @@ struct ParamSet {
   ParamSet from_active_vector(const std::vector<double>& values) const;
 };
 
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/include/mimir/RootOptimizer.hh
+++ b/src/fit/mimir/include/mimir/RootOptimizer.hh
@@ -3,7 +3,7 @@
 
 #include <mimir/Factory.hh>
 #include <mimir/Optimizer.hh>
-namespace RAT::Mimir {
+namespace Mimir {
 
 class RootOptimizer : public Optimizer {
  public:
@@ -13,5 +13,4 @@ class RootOptimizer : public Optimizer {
  protected:
   std::unique_ptr<ROOT::Math::Minimizer> fMinimizer = nullptr;
 };
-MIMIR_REGISTER_TYPE(Optimizer, RootOptimizer, "RootOptimizer")
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/src/FitStep.cc
+++ b/src/fit/mimir/src/FitStep.cc
@@ -1,7 +1,7 @@
 #include <mimir/Factory.hh>
 #include <mimir/FitStep.hh>
 
-namespace RAT::Mimir {
+namespace Mimir {
 
 bool FitStep::Configure(RAT::DBLinkPtr db_link) {
   std::string optimizer_name = db_link->GetS("optimizer_name");
@@ -84,6 +84,5 @@ void FitStep::Execute(ParamSet& params) {
   params.energy.set_upper_bounds(energy_ub);
   optimizer->Minimize(cost_function.get(), params);
 }
-MIMIR_REGISTER_TYPE(FitStrategy, FitStep, "FitStep");
-
-}  // namespace RAT::Mimir
+}  // namespace Mimir
+MIMIR_REGISTER_TYPE(Mimir::FitStrategy, Mimir::FitStep, "FitStep");

--- a/src/fit/mimir/src/PMTTypeTimeResidualPDF.cc
+++ b/src/fit/mimir/src/PMTTypeTimeResidualPDF.cc
@@ -7,7 +7,7 @@
 
 #include "Math/Interpolator.h"
 
-namespace RAT::Mimir {
+namespace Mimir {
 bool PMTTypeTimeResidualPDF::Configure(RAT::DBLinkPtr db_link) {
   std::vector<double> binning = db_link->GetDArray("binning");
   std::vector<int> pmt_types = db_link->GetIArray("pmt_types");
@@ -28,8 +28,8 @@ bool PMTTypeTimeResidualPDF::Configure(RAT::DBLinkPtr db_link) {
     std::vector<double> nll_vals;
     for (const auto& val : histvals) {
       if (val <= 0) {
-        Log::Die("mimir::PMTTypeTimeResidualPDF: PDF histogram for PMT type " + std::to_string(pmt_type) +
-                 " has zero or negative bin content, cannot take log.");
+        RAT::Log::Die("mimir::PMTTypeTimeResidualPDF: PDF histogram for PMT type " + std::to_string(pmt_type) +
+                      " has zero or negative bin content, cannot take log.");
       }
       nll_vals.push_back(-std::log(val / norm));
     }
@@ -90,4 +90,5 @@ double PMTTypeTimeResidualPDF::clamped_spline(const ROOT::Math::Interpolator& sp
   }
 }
 
-}  // namespace RAT::Mimir
+}  // namespace Mimir
+MIMIR_REGISTER_TYPE(Mimir::Cost, Mimir::PMTTypeTimeResidualPDF, "PMTTypeTimeResidualPDF")

--- a/src/fit/mimir/src/ParamSet.cc
+++ b/src/fit/mimir/src/ParamSet.cc
@@ -2,7 +2,7 @@
 #include <mimir/ParamSet.hh>
 #include <sstream>
 
-namespace RAT::Mimir {
+namespace Mimir {
 
 std::vector<double> ParamField::active_values() const {
   std::vector<double> values;
@@ -174,4 +174,4 @@ void ParamSet::set_active_fit_valid(bool valid) {
     }
   }
 }
-}  // namespace RAT::Mimir
+}  // namespace Mimir

--- a/src/fit/mimir/src/RootOptimizer.cc
+++ b/src/fit/mimir/src/RootOptimizer.cc
@@ -7,7 +7,7 @@
 
 #include "Minuit2/Minuit2Minimizer.h"
 
-namespace RAT::Mimir {
+namespace Mimir {
 
 bool RootOptimizer::Configure(RAT::DBLinkPtr db_link) {
   std::string minimizer_type = db_link->GetS("minimizer_type");
@@ -17,10 +17,10 @@ bool RootOptimizer::Configure(RAT::DBLinkPtr db_link) {
   fMinimizer->SetMaxIterations(db_link->GetI("max_iterations"));
   fMinimizer->SetTolerance(db_link->GetD("tolerance"));
   fMinimizer->SetPrintLevel(db_link->GetI("print_level"));
-  info << "Mimir::RootOptimizer: Setting up the following optimizer: " << newline;
+  RAT::info << "Mimir::RootOptimizer: Setting up the following optimizer: " << newline;
   std::stringstream minimizer_info;
   fMinimizer->Options().Print(minimizer_info);
-  info << minimizer_info.str() << newline;
+  RAT::info << minimizer_info.str() << newline;
   return true;
 }
 
@@ -58,5 +58,5 @@ void RootOptimizer::MinimizeImpl(std::function<double(const ParamSet&)> cost, Pa
   params = params.from_active_vector(result);
   params.set_active_fit_valid(fMinimizer->Status() == 0);
 }
-
-}  // namespace RAT::Mimir
+}  // namespace Mimir
+MIMIR_REGISTER_TYPE(Mimir::Optimizer, Mimir::RootOptimizer, "RootOptimizer")


### PR DESCRIPTION
- changing Mimir's working space from RAT::Mimir to just Mimir so that downstream components can register without referring to RAT::Mimir all the time.
- Make sure all MIMIR registration macros are in cpp files to avoid multiple TUs registering the same components multiple times.
- Improve registration macro so that the registration can happen with namespaced components (e.g. `EOS::MyComponent` vs just MyComponent`. Now registration macro must be called in a plain, namespace-less scope.