### PR TITLE
Prevent the double counting of photons in Cherenkov/Scint/Reemission counters

### DIFF
--- a/src/core/include/RAT/TrackInfo.hh
+++ b/src/core/include/RAT/TrackInfo.hh
@@ -24,6 +24,10 @@ class TrackInfo : public G4VUserTrackInformation {
   // Ok, I'm tired of getter/setter C++ bondage crap.  Just expose the
   // interface already.
 
+  // G4 does not guaranttee that preUserTrackingAction is only called once on each track. Track this status to prevent
+  // double counting
+  bool preUserTrackingActionDone = false;
+
   /** Centroid of steps, weighted by energy loss. */
   CentroidCalculator energyCentroid;
   /** Centroid of optical photon creation vertices. */

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -303,6 +303,7 @@ void Gsim::PreUserTrackingAction(const G4Track *aTrack) {
     // grumble, grumble, C++ const keyword, grumble
     const_cast<G4Track *>(aTrack)->SetUserInformation(new TrackInfo);
   }
+  TrackInfo *trackInfo = dynamic_cast<TrackInfo *>(aTrack->GetUserInformation());
 
   // For very large, complex tracks, it is not sufficient to
   // discard the track if we do not want it.  We must prevent
@@ -322,10 +323,12 @@ void Gsim::PreUserTrackingAction(const G4Track *aTrack) {
     fpTrackingManager->SetStoreTrajectory(false);
   }
 
-  if (aTrack->GetDefinition()->GetParticleName() == "opticalphoton") {
+  if (aTrack->GetDefinition()->GetParticleName() == "opticalphoton" &&
+      !trackInfo->preUserTrackingActionDone  // this is needed because it is _not_ guaranteed that G4 only calls this
+                                             // function once per track.
+  ) {
     G4Event *event = G4EventManager::GetEventManager()->GetNonconstCurrentEvent();
     EventInfo *eventInfo = dynamic_cast<EventInfo *>(event->GetUserInformation());
-    TrackInfo *trackInfo = dynamic_cast<TrackInfo *>(aTrack->GetUserInformation());
 
     std::string creatorProcessName;
     const G4VProcess *creatorProcess = aTrack->GetCreatorProcess();
@@ -345,6 +348,7 @@ void Gsim::PreUserTrackingAction(const G4Track *aTrack) {
       eventInfo->numCerenkovPhoton++;
     }
   }
+  trackInfo->preUserTrackingActionDone = true;
 }
 
 void Gsim::PostUserTrackingAction(const G4Track *aTrack) {


### PR DESCRIPTION
This was noticed by @JohannMartyn -- thanks for the report! An assumption was previously made in `Gsim` that G4PreTrackUserAction will only be called once per track upon the track's creation. This turns out not be true -- the method can be called again when Geant4 propagates particles across volume boundaries occasionally. More importantly, the method is _guaranteed_ to be called again when a photon leaves the PMT Optical model, whenever it is transmitted or reflected. This means that photons are double counted towards the cher/scint/reemission when they are transmitted / reflected by PMTs, causing discrepancies in number of photons by RATPAC2 compared to other simulation softwares such as WCSim. 

This patch adds a check on the TrackInfo object, and ensures that a photon is only counted once per event even if PreTrackAction is called multiple times. I've tested this in the Validation geometry using `electron.mac`, the average number of cherenkov photons dropped from ~860 to around 720 for a 2.5MeV electron.

Since this number might be relevant in important optical calibrations, there may be potential implications on analysis results. Perhaps @llebanowski , @tannerbk et. al can comment on anything we need to pay attention to before merging this.