### PR TITLE
feat: Add macro command to remove a process from the physics list

### DIFF
--- a/doc/users_guide/physics_processes.rst
+++ b/doc/users_guide/physics_processes.rst
@@ -7,7 +7,24 @@ The standard RAT simulation includes many standard GEANT4 physics processes.
 Physics Lists
 `````````````
 
-Add documentation for the Physics List!
+Add more documentation for the Physics List!
+
+Commands that related to the physics list are listed under ``/rat/physics``.
+You can find out what they do in ``src/cmd/src/PhysicsListMessenger.cc``.
+Descriptions to these commands will be added here soon. 
+
+
+Remove a process from the physics list
+''''''''''''''''''''''''''''''''''''''
+If you want to remove a process from the current physics list (e.g. if you
+would like to stop simulating muon decays), you can modify the physics list in
+your main macro file (e.g. run.mac) as follows:
+
+    /rat/physics/removeProcess mu+ Decay
+    /rat/physics/removeProcess mu- Decay
+
+Where the first argument is the G4 name of the particle, and the second is the
+name of the process you would like to remove. 
 
 -------------------
 

--- a/macros/examples/the_big_rat_macro.mac
+++ b/macros/examples/the_big_rat_macro.mac
@@ -34,6 +34,11 @@
 # to our output file.
 /tracking/storeTrajectory 1
 
+# Remove any physics processes that we don't want. For example, to disable
+# muon decays:
+# /rat/physics/removeProcess mu+ Decay
+# /rat/physics/removeProcess mu- Decay
+
 # Turn on the simulation of the PMT dark-noise
 /rat/proc noise
 

--- a/src/cmd/include/RAT/PhysicsListMessenger.hh
+++ b/src/cmd/include/RAT/PhysicsListMessenger.hh
@@ -34,6 +34,7 @@ class PhysicsListMessenger : public G4UImessenger {
   G4UIcmdWithABool *fEnableCerenkov;
   G4UIcommand *fSetStepFunctionLightIons;
   G4UIcommand *fSetStepFunctionMuHad;
+  G4UIcommand *fRemoveProcess;
 };
 
 }  // namespace RAT

--- a/src/cmd/src/PhysicsListMessenger.cc
+++ b/src/cmd/src/PhysicsListMessenger.cc
@@ -56,6 +56,15 @@ PhysicsListMessenger::PhysicsListMessenger(PhysicsList *physicsList) : fPhysicsL
   G4UIparameter *unitMuHad = new G4UIparameter("unit", 's', true);
   unitMuHad->SetDefaultValue("mm");
   fSetStepFunctionMuHad->SetParameter(unitMuHad);
+
+  fRemoveProcess = new G4UIcommand("/rat/physics/removeProcess", this);
+  fRemoveProcess->SetGuidance("Remove a physics process by name");
+  fRemoveProcess->SetGuidance("  particleName: name of the particle from which to remove the process");
+  fRemoveProcess->SetGuidance("  processName: name of process to remove");
+  G4UIparameter *particleName = new G4UIparameter("particleName", 's', false);
+  G4UIparameter *processName = new G4UIparameter("processName", 's', false);
+  fRemoveProcess->SetParameter(particleName);
+  fRemoveProcess->SetParameter(processName);
 }
 
 PhysicsListMessenger::~PhysicsListMessenger() {
@@ -64,6 +73,7 @@ PhysicsListMessenger::~PhysicsListMessenger() {
   delete fEnableCerenkov;
   delete fSetStepFunctionLightIons;
   delete fSetStepFunctionMuHad;
+  delete fRemoveProcess;
 }
 
 G4String PhysicsListMessenger::GetCurrentValue(G4UIcommand *command) {
@@ -81,8 +91,8 @@ G4String PhysicsListMessenger::GetCurrentValue(G4UIcommand *command) {
 }
 
 void PhysicsListMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
-  info << "PhysicsListMessenger: Setting WLS model to " << newValue << newline;
   if (command == fSetOpWLSCmd) {
+    info << "PhysicsListMessenger: Setting WLS model to " << newValue << newline;
     fPhysicsList->SetOpWLSModel(std::string(newValue.data()));
   } else if (command == fSetCerenkovMaxNumPhotonsPerStep) {
     fPhysicsList->SetCerenkovMaxNumPhotonsPerStep(std::stoi(newValue));
@@ -99,6 +109,11 @@ void PhysicsListMessenger::SetNewValue(G4UIcommand *command, G4String newValue) 
     } else if (command == fSetStepFunctionMuHad) {
       fPhysicsList->SetStepFunctionMuHad(v1, v2);
     }
+  } else if (command == fRemoveProcess) {
+    G4String particleName, processName;
+    std::istringstream is(newValue);
+    is >> particleName >> processName;
+    fPhysicsList->RemoveProcess(particleName, processName);
   } else {
     Log::Die(dformat("PhysicsListMessenger::SetCurrentValue: Unknown command %s", command->GetCommandPath().data()));
   }

--- a/src/physics/include/RAT/PhysicsList.hh
+++ b/src/physics/include/RAT/PhysicsList.hh
@@ -50,6 +50,9 @@ class PhysicsList : public Shielding {
     this->finalRangeMuHad = v2;
   }
 
+  // Remove a process from a particle's process list
+  void RemoveProcess(G4String particleName, G4String processName);
+
  private:
   // Construct and register optical processes
   void ConstructOpticalProcesses();

--- a/src/physics/src/PhysicsList.cc
+++ b/src/physics/src/PhysicsList.cc
@@ -67,6 +67,26 @@ void PhysicsList::ConstructProcess() {
   EnableThermalNeutronScattering();
 }
 
+void PhysicsList::RemoveProcess(G4String particleName, G4String processName) {
+  G4ParticleDefinition *particle = G4ParticleTable::GetParticleTable()->FindParticle(particleName);
+  if (!particle) {
+    warn << "PhysicsList::RemoveProcess: couldn't find particle \"" << particleName << "\"" << newline;
+    throw std::runtime_error(std::string("Missing") + " particle " + particleName + " in PhysicsList");
+  }
+  info << "Removing process " << processName << " from particle " << particleName << newline;
+
+  G4ProcessManager *pmanager = particle->GetProcessManager();
+  std::regex process_re(processName);
+  for (int i = 0; i < pmanager->GetProcessListLength(); i++) {
+    G4VProcess *proc = pmanager->GetProcessList()->operator[](i);
+    std::string pname = proc->GetProcessName();
+    if (std::regex_match(pname, process_re)) {
+      info << "Removing process " << pname << " from particle " << particleName << newline;
+      pmanager->RemoveProcess(proc);
+    }
+  }
+}
+
 void PhysicsList::EnableThermalNeutronScattering() {
   // Get the particle definition for neutrons
   G4ParticleDefinition *n_definition = G4Neutron::Definition();


### PR DESCRIPTION
Allow any arbitrary physics process to be removed from the physics list. Example on how to disable muon decays is provided in `the_big_rat_macro.mac` as a comment.

Validated by running a mu+ at-rest simulation in the validation geometry. Triggered events become zero when muon decays are disabled.