### PR TITLE
Ensure MCPhotons are sorted by FrontEndTime in ForcedTrigger

### DIFF
--- a/src/daq/src/ForcedTriggerProc.cc
+++ b/src/daq/src/ForcedTriggerProc.cc
@@ -44,6 +44,7 @@ Processor::Result ForcedTriggerProc::DSEvent(DS::Root *ds) {
   // Loop over the mcpmts and fill the pmt branch assuming we've triggered
   for (int imcpmt = 0; imcpmt < mc->GetMCPMTCount(); imcpmt++) {
     DS::MCPMT *mcpmt = mc->GetMCPMT(imcpmt);
+    mcpmt->SortMCPhotons();
     int pmtID = mcpmt->GetID();
     double integratedCharge = 0;
     double time = 0;


### PR DESCRIPTION
MC Photons are added by their hit time (without PMT TTS). Without additional sorting by FrontEndTime, `DS::PMT` classes may not necessarily register the earliest photo electron in the event window. This leads to over-sampling of the late pulsing peak, as late pulses may have an early hit time.