### PR TITLE
Concretize nhit logic

### DIFF
--- a/src/ds/include/RAT/DS/EV.hh
+++ b/src/ds/include/RAT/DS/EV.hh
@@ -94,14 +94,33 @@ class EV : public TObject {
 
   // TODO: Implemetation for PMT class
   const std::vector<Int_t> GetAllCleanedPMTIDs() const {
-    std::vector<Int_t> result;
-    return result;
+    throw std::logic_error("EV::GetAllCleanedPMTIDs is not yet implemented.");
   }
 
   /** Number of PMTs which were hit at least once. (Convenience method) */
   virtual Int_t Nhits() const { return GetPMTCount(); }
-  virtual Int_t cleanedNhits() const { return GetAllCleanedPMTIDs().size(); }
-  virtual Int_t cleanedDigitNhits() const { return GetAllCleanedDigitPMTIDs().size(); }
+  virtual Int_t NhitsCleaned() const { return GetAllCleanedPMTIDs().size(); }
+
+  /** For digitPMTs, nhit should only include channels that crossed threshold at least once */
+  virtual Int_t DigitNhits() const {
+    int result = 0;
+    for (std::pair<Int_t, DigitPMT> kv : digitpmt) {
+      if (kv.second.GetNCrossings() > 0) {
+        result++;
+      }
+    }
+    return result;
+  }
+  virtual Int_t DigitNhitsCleaned() const {
+    int result = 0;
+    for (std::pair<Int_t, DigitPMT> kv : digitpmt) {
+      DigitPMT::HCMask hit_cleaning_mask = kv.second.GetHitCleaningMask();
+      if (kv.second.GetNCrossings() > 0 && hit_cleaning_mask == 0) {
+        result++;
+      }
+    }
+    return result;
+  }
 
   /** List of LAPPDs with at least one charge sample in this event. */
   virtual LAPPD *GetLAPPD(Int_t i) { return &lappd[i]; }
@@ -163,7 +182,7 @@ class EV : public TObject {
     return (eventCleaningWord >> bit_position) & 0x1;
   }
 
-  ClassDef(EV, 5);
+  ClassDef(EV, 6);
 
  protected:
   Int_t id;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -607,9 +607,6 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
         digitNCrossings.push_back(digitpmt->GetNCrossings());
         digitTimeOverThreshold.push_back(digitpmt->GetTimeOverThreshold());
         digitReconNPEs.push_back(digitpmt->GetReconNPEs());
-        if (digitpmt->GetNCrossings() > 0) {
-          digitNhits++;
-        }
         digitHitCleaningMask.push_back(digitpmt->GetHitCleaningMask());
         digitVoltageOverThreshold.push_back(digitpmt->GetVoltageOverThreshold());
         digitPeak.push_back(digitpmt->GetPeakVoltage());
@@ -629,10 +626,8 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
           }
         }
       }
-      for (int pmtc : ev->GetAllCleanedDigitPMTIDs()) {
-        RAT::DS::DigitPMT *digitpmt = ev->GetOrCreateDigitPMT(pmtc);
-        digitHitCleanedNhits++;
-      }
+      digitNhits = ev->DigitNhits();
+      digitHitCleanedNhits = ev->DigitNhitsCleaned();
     }
     if (options.digitizerwaveforms) {
       DS::Digit digitizer = ev->GetDigitizer();


### PR DESCRIPTION
Previously it wasn't clear what is an `nhit` means for digitPMTs. This PR creates two new functions: `DigitNhits` and `DigitNhitsCleaned` in `DS::EV` to clarify that a channel contributes toward nhit if it has `DigitNCrossings() > 0`. This shouldn't impact any files created with zero suppression turned on, but would be useful if zero suppression is turned off.

Thanks to @hbjamin 's discussion on this matter:) This PR potentially supersedes #339 .