### PR TITLE
chore: impove build mode support, compile errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,19 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 # add the automatically determined parts of the RPATH
 # which point to directories outside the build tree to the install RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Automatically generate compile_commands.json
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+add_custom_target(
+    copy-compile-commands ALL
+    ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_BINARY_DIR}/compile_commands.json
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+
 ###########################################################
 # Set default build type
-set(default_build_type "Release")
+set(default_build_type "RelWithDebInfo")
 #set(CMAKE_BUILD_TYPE Debug)
 #set(CMAKE_CXX_FLAGS -pg)
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,27 @@
 
 build_directory := build
 install_directory := $(PWD)/install
+BUILDTYPE ?= RelWithDebInfo # default build type
 
 all:
 	ln -sf $(PWD)/cformat.sh $(shell git rev-parse --git-common-dir)/hooks/pre-commit
-	cmake . -B$(build_directory) -DCMAKE_INSTALL_PREFIX=$(install_directory)
+	cmake . -B$(build_directory) -DCMAKE_BUILD_TYPE=$(BUILDTYPE) -DCMAKE_INSTALL_PREFIX=$(install_directory)
 	cmake --build $(build_directory) -- $(MAKEFLAGS)
 	cmake --install $(build_directory) | grep -v "Up-to-date"
+
+# Convenient build-type targets (reuse same build dir)
+.PHONY: debug release relwithdebinfo minsizerel
+debug: BUILDTYPE=Debug
+debug: all
+
+release: BUILDTYPE=Release
+release: all
+
+relwithdebinfo: BUILDTYPE=RelWithDebInfo
+relwithdebinfo: all
+
+minsizerel: BUILDTYPE=MinSizeRel
+minsizerel: all
 
 clean:
 	rm -rf $(build_directory) $(install_directory) ratpac.sh ratpac.csh RatpacConfig.cmake

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ apptainer run [-B /disks/to/mount] ratpac2.sif
 
 ## Installation
 
+### Dependencies
 Installation requires [ROOT 6.25+](https://root.cern.ch),
 [Geant4 11.0+](https://geant4.web.cern.ch/), and [cmake 3.22+](https://cmake.org/)
 
@@ -45,19 +46,25 @@ script](https://github.com/rat-pac/ratpac-setup). Follow the instruction will
 produce a standalone directory that includes all dependencies. You can also
 check this repo for the best-tested minor versions of each dependency.
 
-A convenience Makefile exists to automate the above process, simply type `make`.
 
-Install using cmake:
+### Building from source
 
-``` sh
-    cmake . -Bbuild
-    cmake --build build -- -j$(nproc)
-```
+#### Using the convenience Makefile
+A convenience Makefile exists to automate the above process, simply type `make`. Several targets are available:
 
-If you want to install the code, just add
+- `make` or `make all`: Builds in installs ratpac-two to `install/` directory. Default to the `RelWithDebInfo` build type.
+- `make debug/release/Minsize/relwithdebinfo`: Builds and installs ratpac-two with the specified build type.
+- `make clean`: Removes the `build/` and `install/` directories.
 
-``` sh
-    cmake --build build . --target install -j$(nproc)
+#### Custom Configuration with CMake
+Ratpac-two follows standard CMake conventions. The following is a step-by-step list CMake commands to compile:
+
+```sh
+mkdir build install
+cd build
+cmake .. -DCMAKEINSTALL_PREFIX=../install # Add any additional configuration flags here
+make  # use -jN to parallelize with N threads
+make install
 ```
 
 ## Usage

--- a/doc/users_guide/installation.rst
+++ b/doc/users_guide/installation.rst
@@ -67,3 +67,29 @@ repository.
     # Full container:
     apptainer build ratpac-two.sif docker://ratpac/ratpac-two:main
 
+
+Build from source
+`````````````````
+
+Using the convenience Makefile
+''''''''''''''''''''''''''''''
+
+A convenience Makefile exists to automate the above process, simply type `make`. Several targets are available:
+
+- ``make`` or ``make all``: Builds in installs ratpac-two to ``install/`` directory. Default to the ``RelWithDebInfo`` build type.
+- ``make debug/release/Minsize/relwithdebinfo``: Builds and installs ratpac-two with the specified build type.
+- ``make clean``: Removes the ``build/`` and ``install/`` directories.
+
+Custom Configuration with CMake
+'''''''''''''''''''''''''''''''
+
+Ratpac-two follows standard CMake conventions. The following is a step-by-step list CMake commands to compile:
+
+.. code-block:: bash
+    
+    mkdir build install
+    cd build
+    cmake .. -DCMAKEINSTALL_PREFIX=../install # Add any additional configuration flags here
+    make  # use -jN to parallelize with N threads
+    make install
+

--- a/src/daq/src/PMTWaveformGenerator.cc
+++ b/src/daq/src/PMTWaveformGenerator.cc
@@ -32,7 +32,6 @@ PMTWaveformGenerator::PMTWaveformGenerator(std::string modelName) {
     fPMTPulseShape = "analytic";
   }
 
-  fPMTPulseShape == "";
   if (fPMTPulseType == "analytic") {
     try {
       fPMTPulseShape = lpulse->GetS("pulse_shape");

--- a/src/geo/include/RAT/GeoRevArrayFactory.hh
+++ b/src/geo/include/RAT/GeoRevArrayFactory.hh
@@ -7,7 +7,8 @@ namespace RAT {
 class GeoRevArrayFactory : public GeoSolidArrayFactoryBase {
  public:
   GeoRevArrayFactory() : GeoSolidArrayFactoryBase("revarray"){};
-  virtual G4VPhysicalVolume *Construct(DBLinkPtr table);
+  using GeoSolidArrayFactoryBase::Construct;
+  virtual G4VPhysicalVolume *Construct(DBLinkPtr table) override;
 };
 
 }  // namespace RAT

--- a/src/geo/include/RAT/GeoSolidArrayFactoryBase.hh
+++ b/src/geo/include/RAT/GeoSolidArrayFactoryBase.hh
@@ -9,6 +9,7 @@ class GeoSolidArrayFactoryBase : public GeoFactory {
   GeoSolidArrayFactoryBase(const std::string &name) : GeoFactory(name){};
 
  protected:
+  using GeoFactory::Construct;
   virtual G4VPhysicalVolume *Construct(G4VSolid *BaseSolid, DBLinkPtr table);
   virtual G4VPhysicalVolume *Construct(G4LogicalVolume *logiSolid, DBLinkPtr table);
 };


### PR DESCRIPTION
- Add support for multiple build types. Now `make debug` will build RAT in debug mode, for examle.
- The default build mode has been changed to `RelWithDebInfo` -- this lowers the optimization level slightly (from O3 to O2), but should have no impact for most users.
- Address compile-time warnings that pop up in gcc v15.2