### PR TITLE
Missing regex header file for the RemoveProcess Function

### DIFF
--- a/src/physics/src/PhysicsList.cc
+++ b/src/physics/src/PhysicsList.cc
@@ -1,6 +1,7 @@
 #include <Shielding.hh>
 #include <stdexcept>
 #include <string>
+#include <regex>
 // Required for G4 > 10.5
 #include <G4EmParameters.hh>
 #include <G4FastSimulationManagerProcess.hh>


### PR DESCRIPTION
add header for regex function that was missing in the file causing it to not complie on some cmake versions.

fixes #349 