### PR TITLE
fix issues with the outntuple processor

### DIFF
--- a/ratdb/IO.ratdb
+++ b/ratdb/IO.ratdb
@@ -26,6 +26,8 @@
 
 "waveform_fitters": ["Lognormal", "Gaussian", "Sinc", "LucyDDM"],
 
+"event_fitters": ["quadfitter"],
+
 "waveform_fitter_FOM_Lognormal": ["baseline","chi2ndf"],
 "waveform_fitter_FOM_Gaussian": ["baseline","width","chi2ndf"],
 "waveform_fitter_FOM_Sinc": ["peak"],

--- a/src/fit/include/RAT/FitterInputHandler.hh
+++ b/src/fit/include/RAT/FitterInputHandler.hh
@@ -83,7 +83,7 @@ class FitterInputHandler {
     }
     DS::FitResult* fit_result = FindFitResult(fitter_name);
     if (!ValidSeedPosition(fitter_name)) {
-      warn << "The Requested Seed Position (from " << fitter_name << ") is not valid." << newline;
+      debug << "The Requested Seed Position (from " << fitter_name << ") is not valid." << newline;
       return TVector3(0, 0, 0);
     }
     return fit_result->GetPosition();
@@ -117,7 +117,7 @@ class FitterInputHandler {
     }
     DS::FitResult* fit_result = FindFitResult(fitter_name);
     if (!ValidSeedTime(fitter_name)) {
-      warn << "The Requested Seed Time (from " << fitter_name << ") is not valid." << newline;
+      debug << "The Requested Seed Time (from " << fitter_name << ") is not valid." << newline;
       return 0;
     }
     return fit_result->GetTime();
@@ -150,7 +150,7 @@ class FitterInputHandler {
     }
     DS::FitResult* fit_result = FindFitResult(fitter_name);
     if (!ValidSeedDirection(fitter_name)) {
-      warn << "The Requested Seed Direction (from " << fitter_name << ") is not valid." << newline;
+      debug << "The Requested Seed Direction (from " << fitter_name << ") is not valid." << newline;
       return TVector3(0, 0, 0);
     }
     return fit_result->GetDirection();
@@ -178,7 +178,7 @@ class FitterInputHandler {
     }
     DS::FitResult* fit_result = FindFitResult(fitter_name);
     if (!ValidSeedEnergy(fitter_name)) {
-      warn << "The Requested Seed Energy (from " << fitter_name << ") is not valid." << newline;
+      debug << "The Requested Seed Energy (from " << fitter_name << ") is not valid." << newline;
       return 0;
     }
     return fit_result->GetEnergy();

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -71,6 +71,7 @@ class OutNtupleProc : public Processor {
   NtupleOptions options;
 
   std::vector<std::string> waveform_fitters;
+  std::vector<std::string> event_fitters;
   std::map<std::string, std::vector<std::string>> waveform_fitter_FOMs;
 
  protected:
@@ -181,9 +182,8 @@ class OutNtupleProc : public Processor {
   std::vector<double> mcDirz;
   std::vector<double> mcTime;
   // Reconstruted variables
-  std::vector<int> fitterId;
-  std::vector<double> fitx, fity, fitz;
-  std::vector<double> fitu, fitv, fitw;
+  std::map<std::string, double> fitvalues;
+  std::map<std::string, bool> fitvalids;
   // Store PMT Hit Positions
   std::vector<int> hitPMTID;
   std::vector<double> hitPMTTime;


### PR DESCRIPTION
Add "event_fitters" field to IO.ratdb, which allows the outntuple processor to know in advance what fields to create. This is a fix for issue #327. 

Downgrade a warning message in the fitter input handler, which is very spammy. 

Remove event fitter FOMs from outntuple until someone figures out how to properly add them. 

