### PR TITLE
Convert MIMIR direction fitting from theta-phi to uvw

### DIFF
--- a/ratdb/FIT_MIMIR.ratdb
+++ b/ratdb/FIT_MIMIR.ratdb
@@ -36,15 +36,13 @@
 //
 // Can either be given as an array of integers representing each component's status, or a single integer representing the status of all comoponents. 
 "position_time_status": 1, // x, y, z, t
-"direction_status": 0, // theta, phi
+"direction_status": 0, // u, v, w
 "energy_status": 0, //...
 
 // bounds:
-// for each component (x, y, z, t, theta, phi, energy), the lower and upper bounds can be specified.
+// for each component (x, y, z, t, u, v, w, energy), the lower and upper bounds can be specified.
 // if omitted, the component is set to the following defaults:
-// x, y, z, t: [-numerical_limit, +numerical_limit]
-// theta: [0, pi]
-// phi: [-pi, pi]
+// x, y, z, u, v, w, t: [-numerical_limit, +numerical_limit]
 // energy: [0, +numerical_limit]
 }
 
@@ -65,15 +63,13 @@
 //
 // Can either be given as an array of integers representing each component's status, or a single integer representing the status of all comoponents. 
 "position_time_status": 2, // x, y, z, t
-"direction_status": 1, // theta, phi
+"direction_status": 1, // u, v, w
 "energy_status": 0, //...
 
 // bounds:
-// for each component (x, y, z, t, theta, phi, energy), the lower and upper bounds can be specified.
+// for each component (x, y, z, t, u, v, w, energy), the lower and upper bounds can be specified.
 // if omitted, the component is set to the following defaults:
-// x, y, z, t: [-numerical_limit, +numerical_limit]
-// theta: [0, pi]
-// phi: [-pi, pi]
+// x, y, z, u, v, w, t: [-numerical_limit, +numerical_limit]
 // energy: [0, +numerical_limit]
 }
 

--- a/src/fit/mimir/include/mimir/FitStrategy.hh
+++ b/src/fit/mimir/include/mimir/FitStrategy.hh
@@ -29,8 +29,7 @@ class FitStrategy {
     params.position_time.set_values(xyzt);
     if (input_handler->ValidSeedDirection()) {
       TVector3 seed_dir = input_handler->GetSeedDirection();
-      std::vector<double> seed_theta_phi = {seed_dir.Theta(), seed_dir.Phi()};
-      params.direction.set_values(seed_theta_phi);
+      params.direction.set_values({seed_dir.X(), seed_dir.Y(), seed_dir.Z()});
     }
     if (input_handler->ValidSeedEnergy()) {
       params.energy.set_values({input_handler->GetSeedEnergy()});

--- a/src/fit/mimir/include/mimir/ParamSet.hh
+++ b/src/fit/mimir/include/mimir/ParamSet.hh
@@ -1,5 +1,6 @@
 #pragma once
 #include <CLHEP/Units/PhysicalConstants.h>
+#include <TVector3.h>
 
 #include <algorithm>
 #include <limits>
@@ -34,8 +35,11 @@ struct ParamField {
   void set_all_status(ParamStatus status);
   void set_all_fit_valid(bool valid);
   void set_status(std::vector<ParamStatus> status_vector);
+  void set_values(const double* values, size_t n);
   void set_values(std::vector<double> values);
+  void set_lower_bounds(const double* lower_bounds, size_t n);
   void set_lower_bounds(std::vector<double> lower_bounds);
+  void set_upper_bounds(const double* upper_bouonds, size_t n);
   void set_upper_bounds(std::vector<double> upper_bounds);
   bool are_all_used() const {
     return std::all_of(components.begin(), components.end(), [](const ParamComponent& comp) { return comp.is_used(); });
@@ -54,17 +58,21 @@ struct ParamSet {
                                              {.name = "y", .value = 0.0},
                                              {.name = "z", .value = 0.0},
                                              {.name = "t", .value = 0.0}}};
-  ParamField direction = {.components = {
-                              {.name = "theta", .value = CLHEP::pi / 2, .lower_bound = 0, .upper_bound = CLHEP::pi},
-                              {.name = "phi", .value = 0.0, .lower_bound = -CLHEP::pi, .upper_bound = CLHEP::pi},
-                          }};
+  ParamField direction = {
+      .components = {{.name = "u", .value = 0.0}, {.name = "v", .value = 0.0}, {.name = "w", .value = 0.0}}};
   ParamField energy = {.components = {{.name = "energy", .value = 1.0, .lower_bound = 0.0}}};
 
   std::vector<double> to_active_vector() const;
   std::vector<ParamComponent> to_active_components() const;
   void update_active(const std::vector<double>& values);
+  void update_active(const double* values, size_t n);
   void set_active_fit_valid(bool valid);
   ParamSet from_active_vector(const std::vector<double>& values) const;
+
+  TVector3 GetPosition() const;
+  TVector3 GetDirection() const;
+  double GetTime() const;
+  double GetEnergy() const;
 };
 
 }  // namespace Mimir

--- a/src/fit/mimir/src/FitMimirProc.cc
+++ b/src/fit/mimir/src/FitMimirProc.cc
@@ -42,18 +42,18 @@ Processor::Result FitMimirProc::Event(DS::Root *ds, DS::EV *ev) {
     ratds_result->SetPosition(TVector3(result.position_time.components[0].value,
                                        result.position_time.components[1].value,
                                        result.position_time.components[2].value));
-    ratds_result->SetTime(result.position_time.components[3].value);
-    ratds_result->SetValidPosition(result.position_time.are_all_fit_valid());
-    ratds_result->SetValidTime(result.position_time.are_all_fit_valid());
+    ratds_result->SetPosition(result.GetPosition());
+    ratds_result->SetTime(result.GetTime());
+    bool valid_xyzt = result.position_time.are_all_fit_valid();
+    ratds_result->SetValidPosition(valid_xyzt);
+    ratds_result->SetValidTime(valid_xyzt);
   }
   if (result.direction.are_all_used()) {
-    TVector3 direction;
-    direction.SetMagThetaPhi(1.0, result.direction.components[0].value, result.direction.components[1].value);
-    ratds_result->SetDirection(direction);
+    ratds_result->SetDirection(result.GetDirection());
     ratds_result->SetValidDirection(result.direction.are_all_fit_valid());
   }
   if (result.energy.are_all_used()) {
-    ratds_result->SetEnergy(result.energy.components[0].value);
+    ratds_result->SetEnergy(result.GetEnergy());
     ratds_result->SetValidEnergy(result.energy.are_all_fit_valid());
   }
   ev->AddFitResult(ratds_result);

--- a/src/fit/mimir/src/FitStep.cc
+++ b/src/fit/mimir/src/FitStep.cc
@@ -11,7 +11,7 @@ bool FitStep::Configure(RAT::DBLinkPtr db_link) {
   std::string cost_index = db_link->GetS("cost_config");
   cost_function = Factory<Cost>::GetInstance().make_and_configure(cost_name, cost_index);
   position_time_status.resize(4, ParamStatus::INACTIVE);
-  direction_status.resize(2, ParamStatus::INACTIVE);
+  direction_status.resize(3, ParamStatus::INACTIVE);
   energy_status.resize(1, ParamStatus::INACTIVE);
   set_status(db_link, "position_time_status", position_time_status);
   set_status(db_link, "direction_status", direction_status);
@@ -19,12 +19,12 @@ bool FitStep::Configure(RAT::DBLinkPtr db_link) {
 
   position_time_lb.resize(4, std::numeric_limits<double>::lowest());
   position_time_ub.resize(4, std::numeric_limits<double>::max());
-  direction_lb = {0, -CLHEP::pi};
-  direction_ub = {CLHEP::pi, CLHEP::pi};
+  direction_lb.resize(3, std::numeric_limits<double>::lowest());
+  direction_ub.resize(3, std::numeric_limits<double>::max());
   energy_lb = {0.0};
   energy_ub = {std::numeric_limits<double>::max()};
   set_bounds(db_link, {"x", "y", "z", "t"}, position_time_lb, position_time_ub);
-  set_bounds(db_link, {"theta", "phi"}, direction_lb, direction_ub);
+  set_bounds(db_link, {"u", "v", "w"}, direction_lb, direction_ub);
   set_bounds(db_link, {"energy"}, energy_lb, energy_ub);
   return true;
 }

--- a/src/fit/mimir/src/PMTTypeCosAlphaPDF.cc
+++ b/src/fit/mimir/src/PMTTypeCosAlphaPDF.cc
@@ -61,16 +61,13 @@ double PMTTypeCosAlphaPDF::operator()(const ParamSet& params) const {
         "times.");
   }
   if (!params.direction.are_all_active()) {
-    RAT::Log::Die("mimir::PMTTypeCosAlphaPDF: theta_phi must have 2 active components (theta, phi).");
+    RAT::Log::Die("mimir::PMTTypeCosAlphaPDF: not all direction comoponents are active.");
   }
-  std::vector<double> theta_phi = params.direction.active_values();
-  TVector3 vertex_direction;
-  vertex_direction.SetMagThetaPhi(1.0, theta_phi.at(0), theta_phi.at(1));
+  TVector3 vertex_direction = params.GetDirection();
   if (!params.position_time.are_all_used())
     RAT::Log::Die("mimir::PMTTypeCosAlphaPDF: position_time must have a valid position vertex (x, y, z, t).");
-  std::vector<double> xyzt = params.position_time.used_values();
-  TVector3 vertex_position(xyzt.at(0), xyzt.at(1), xyzt.at(2));
-  double vertex_time = xyzt.at(3);
+  TVector3 vertex_position = params.GetPosition();
+  double vertex_time = params.GetTime();
 
   double result = 0.0;
   for (size_t ihit = 0; ihit < hit_pmtids.size(); ++ihit) {

--- a/src/fit/mimir/src/ParamSet.cc
+++ b/src/fit/mimir/src/ParamSet.cc
@@ -80,37 +80,44 @@ void ParamField::set_status(std::vector<ParamStatus> status_vector) {
   }
 }
 
-void ParamField::set_values(std::vector<double> values) {
-  if (values.size() != components.size()) {
+void ParamField::set_values(std::vector<double> values) { set_values(values.data(), values.size()); }
+
+void ParamField::set_values(const double* values, size_t n) {
+  if (n != components.size()) {
     std::stringstream msg;
-    msg << "Mismatch in number of values provided. Expected " << components.size() << ", but got " << values.size();
+    msg << "Mismatch in number of values provided. Expected " << components.size() << ", but got " << n;
     RAT::Log::Die(msg.str());
   }
-  for (size_t i = 0; i < components.size() && i < values.size(); ++i) {
+  for (size_t i = 0; i < components.size() && i < n; ++i) {
     components[i].value = values[i];
   }
 }
 
 void ParamField::set_lower_bounds(std::vector<double> lower_bounds) {
-  if (lower_bounds.size() != components.size()) {
+  set_lower_bounds(lower_bounds.data(), lower_bounds.size());
+}
+
+void ParamField::set_lower_bounds(const double* lower_bounds, size_t n) {
+  if (n != components.size()) {
     std::stringstream msg;
-    msg << "Mismatch in number of bounds provided. Expected " << components.size() << ", but got "
-        << lower_bounds.size();
+    msg << "Mismatch in number of bounds provided. Expected " << components.size() << ", but got " << n;
     RAT::Log::Die(msg.str());
   }
-  for (size_t i = 0; i < components.size() && i < lower_bounds.size(); ++i) {
+  for (size_t i = 0; i < components.size() && i < n; ++i) {
     components[i].lower_bound = lower_bounds[i];
   }
 }
 
 void ParamField::set_upper_bounds(std::vector<double> upper_bounds) {
-  if (upper_bounds.size() != components.size()) {
+  set_upper_bounds(upper_bounds.data(), upper_bounds.size());
+}
+void ParamField::set_upper_bounds(const double* upper_bounds, size_t n) {
+  if (n != components.size()) {
     std::stringstream msg;
-    msg << "Mismatch in number of bounds provided. Expected " << components.size() << ", but got "
-        << upper_bounds.size();
+    msg << "Mismatch in number of bounds provided. Expected " << components.size() << ", but got " << n;
     RAT::Log::Die(msg.str());
   }
-  for (size_t i = 0; i < components.size() && i < upper_bounds.size(); ++i) {
+  for (size_t i = 0; i < components.size() && i < n; ++i) {
     components[i].upper_bound = upper_bounds[i];
   }
 }
@@ -137,13 +144,14 @@ std::vector<ParamComponent> ParamSet::to_active_components() const {
   return active_components;
 }
 
-void ParamSet::update_active(const std::vector<double>& values) {
+void ParamSet::update_active(const std::vector<double>& values) { return update_active(values.data(), values.size()); }
+
+void ParamSet::update_active(const double* values, size_t n) {
   size_t index = 0;
   for (ParamField* field : {&position_time, &direction, &energy}) {
-    if (index > values.size()) {
+    if (index > n) {
       std::stringstream msg;
-      msg << "Not enough values provided to from_fit_vector. Expected at least " << index << ", but got "
-          << values.size();
+      msg << "Not enough values provided to from_fit_vector. Expected at least " << index << ", but got " << n;
       RAT::Log::Die(msg.str());
     }
     for (size_t idx_in_field = 0; idx_in_field < field->components.size(); ++idx_in_field) {
@@ -152,9 +160,9 @@ void ParamSet::update_active(const std::vector<double>& values) {
       }
     }
   }
-  if (index != values.size()) {
+  if (index != n) {
     std::stringstream msg;
-    msg << "Too many values provided to from_fit_vector. Expected " << index << ", but got " << values.size();
+    msg << "Too many values provided to from_fit_vector. Expected " << index << ", but got " << n;
     RAT::Log::Die(msg.str());
   }
 }
@@ -174,4 +182,19 @@ void ParamSet::set_active_fit_valid(bool valid) {
     }
   }
 }
+
+TVector3 ParamSet::GetPosition() const {
+  return TVector3(position_time.components[0].value, position_time.components[1].value,
+                  position_time.components[2].value);
+}
+
+TVector3 ParamSet::GetDirection() const {
+  TVector3 result =
+      TVector3(direction.components[0].value, direction.components[1].value, direction.components[2].value);
+  return result.Unit();
+}
+
+double ParamSet::GetTime() const { return position_time.components[3].value; }
+
+double ParamSet::GetEnergy() const { return energy.components[0].value; }
 }  // namespace Mimir

--- a/src/fit/mimir/src/RootOptimizer.cc
+++ b/src/fit/mimir/src/RootOptimizer.cc
@@ -53,10 +53,10 @@ void RootOptimizer::MinimizeImpl(std::function<double(const ParamSet&)> cost, Pa
       fMinimizer->SetVariable(icomp, comp.name, comp.value, comp.step);
     }
   }
-  fMinimizer->Minimize();
+  bool fit_valid = fMinimizer->Minimize();
   std::vector<double> result(fMinimizer->X(), fMinimizer->X() + n_params);
   params = params.from_active_vector(result);
-  params.set_active_fit_valid(fMinimizer->Status() == 0);
+  params.set_active_fit_valid(fit_valid);
 }
 }  // namespace Mimir
 MIMIR_REGISTER_TYPE(Mimir::Optimizer, Mimir::RootOptimizer, "RootOptimizer")


### PR DESCRIPTION
currently MIMIR presents some weird behaviors reconstructing events pointing toward the +/-z direction, due to having poles in those direction. This patch changes the direction parameterization to a Cartesian three-vector. The only changes in downstream configuration is in specifying the bounds of theta phi (now needs to be done in uvw), but this is not done with any configuration currently as far as I am aware.