### PR TITLE
Write classifiers into Ntuple

### DIFF
--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -557,7 +557,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     for (auto clf : classifierVector) {
       std::string name = clf->GetClassifierName();
       for (auto const &label : clf->classificationLabels) {
-        classifiervalues[label + "_" + name] = new double(clf->GetClassificationResult(label));
+        classifiervalues[name + "_" + label] = new double(clf->GetClassificationResult(label));
       }
     }
     // Write classifier values into TTree

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -492,6 +492,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     trigger_word = ev->GetTriggerWord();
     event_cleaning_word = ev->GetEventCleaningWord();
     timeSinceLastTrigger_us = ev->GetDeltaT() / 1000.;
+
     auto fitVector = ev->GetFitResults();
     std::map<std::string, double *> fitvalues;
     std::map<std::string, bool *> fitvalids;
@@ -550,6 +551,20 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     for (auto const &[label, value] : doubleFOMs) {
       this->SetBranchValue(label, value);
     }
+
+    auto classifierVector = ev->GetClassifierResults();
+    std::map<std::string, double *> classifiervalues;
+    for (auto clf : classifierVector) {
+      std::string name = clf->GetClassifierName();
+      for (auto const &label : clf->classificationLabels) {
+        classifiervalues[label + "_" + name] = new double(clf->GetClassificationResult(label));
+      }
+    }
+    // Write classifier values into TTree
+    for (auto const &[label, value] : classifiervalues) {
+      this->SetBranchValue(label, value);
+    }
+
     nhits = ev->GetPMTCount();
     if (options.pmthits) {
       hitPMTID.clear();


### PR DESCRIPTION
Event classifier parameters will be written in the ntuple after event reconstruction parameters.  
The implementation is identical aside from one suggestion: recon results are named like "parameter_fitter" while classifier results may be more conveniently named in reverse, "classifier_parameters", so that however many parameters are produced by however many classifiers, they are not all listed as a single group in the ntuple, but grouped by classifier.  