### PR TITLE
Update chargebalance classifier

### DIFF
--- a/doc/users_guide/reconstruction.rst
+++ b/doc/users_guide/reconstruction.rst
@@ -197,10 +197,27 @@ MiniSim
 
 What does this do? Do we need this in RAT?
 
+.. _chargeblanace:
+
 ClassifyChargeBalance
 =====================
 
-Document this!
+The ``classifychargebalance`` processor calculates the standard deviation divided by
+the mean of the charges on hit PMT channels.
+
+Command:
+::
+
+    /rat/proc classifychargebalance
+
+Parameters: None
+
+Classifier information in data structure
+''''''''''''''''''''''''''''''''''''''''''
+* name - ``chargebalance``
+* figures of merit - None
+
+----------------------
 
 FitTensor
 =========
@@ -449,4 +466,3 @@ Evaluates a 1D CosAlpha PDF as a negative log likelihood.
 ``hist_<pmttype>``             ``double[]``                Histogram content for each type of PMT, with ``binning`` as the bin centers.
 ``tresid_range``               ``double[2]``               Range of time residuals to use for evaluating the PDF.
 ============================   ==========================  ===================
-

--- a/src/fit/include/RAT/ClassifyChargeBalance.hh
+++ b/src/fit/include/RAT/ClassifyChargeBalance.hh
@@ -1,6 +1,7 @@
 #ifndef __RAT_ClassifyChargeBalance__
 #define __RAT_ClassifyChargeBalance__
 
+#include <RAT/FitterInputHandler.hh>
 #include <RAT/Processor.hh>
 #include <string>
 
@@ -13,13 +14,14 @@ class EV;
 
 class ClassifyChargeBalance : public Processor {
  public:
-  ClassifyChargeBalance();
+  ClassifyChargeBalance() : Processor("classifychargebalance"), inputHandler(){};
   virtual ~ClassifyChargeBalance() {}
 
   virtual Processor::Result Event(DS::Root *ds, DS::EV *ev);
 
  protected:
-  std::vector<std::string> fLabels;
+  std::vector<std::string> fLabels = {"chargebalance"};
+  FitterInputHandler inputHandler;
 };
 
 }  // namespace RAT

--- a/src/fit/src/ClassifyChargeBalance.cc
+++ b/src/fit/src/ClassifyChargeBalance.cc
@@ -7,24 +7,37 @@
 
 namespace RAT {
 
-ClassifyChargeBalance::ClassifyChargeBalance() : Processor("classifychargebalance") { fLabels = {"chargebalance"}; }
-
 Processor::Result ClassifyChargeBalance::Event(DS::Root *ds, DS::EV *ev) {
-  int hitcount = ev->GetPMTCount();
+  inputHandler.RegisterEvent(ev);
+
+  DS::Classifier *classification = new DS::Classifier("ChargeBalance", fLabels);
+
+  // Initialize ALL parameters with placeholder values
+  classification->SetClassificationResult("chargebalance", NAN);
+
+  double hitcount = static_cast<double>(inputHandler.GetNHits());
+  if (hitcount <= 1) {
+    ev->AddClassifierResult(classification);
+    return Processor::FAIL;
+  }
+
   double qsumsquare = 0;
   double qsum = 0;
-  for (int pmtc : ev->GetAllPMTIDs()) {
-    DS::PMT *pmt = ev->GetOrCreatePMT(pmtc);
-    double charge = pmt->GetCharge();
+  for (int pmtid : inputHandler.GetAllHitPMTIDs()) {
+    double charge = inputHandler.GetCharge(pmtid);
     qsumsquare += pow(charge, 2);
     qsum += charge;
   }
-  double qbalance = sqrt(qsumsquare / pow(qsum, 2) - 1 / hitcount);
+  if (qsum == 0.0) {
+    ev->AddClassifierResult(classification);
+    return Processor::FAIL;
+  }
 
-  DS::Classifier *classification = new DS::Classifier("ChargeBalance", fLabels);
+  double qbalance = hitcount * sqrt(1.0 / (hitcount - 1.0) * (qsumsquare / pow(qsum, 2) - 1.0 / hitcount));
+
   classification->SetClassificationResult("chargebalance", qbalance);
-  ev->AddClassifierResult(classification);
 
+  ev->AddClassifierResult(classification);
   return Processor::OK;
 }
 


### PR DESCRIPTION
Update the chargebalance event classifier:
1. use FitterIntputHandler
2. minimize Nhit dependence by incorporating missing coefficients*
3. provide some documentation

*the existing calculation is the standard _error_ divided by the mean of all charges.  this PR changes it to the standard _deviation_ divided by the mean.  The original calculation can be easily recovered by multiplying by sqrt((N-1)/N^2).  

Example for a 1.55-MeV electron at the center of the Eos detector filled with a 1% WbLS target (using PR #357 ):

<img width="521" height="320" alt="Screenshot 2025-12-10 11 37 19" src="https://github.com/user-attachments/assets/4003a7f5-713f-4986-a087-f9715ac08d29" />
