### PR TITLE
Correctly place toroidal PMTs in cylindrical envelopes

### DIFF
--- a/src/geo/src/pmt/ToroidalPMTConstruction.cc
+++ b/src/geo/src/pmt/ToroidalPMTConstruction.cc
@@ -26,6 +26,7 @@ ToroidalPMTConstruction::ToroidalPMTConstruction(DBLinkPtr table, G4LogicalVolum
 
   // Setup PMT parameters
   fParams.faceGap = 0.1 * CLHEP::mm;
+  fParams.minEnvelopeRadius = 0.0;
   fParams.zEdge = table->GetDArray("z_edge");
   fParams.rhoEdge = table->GetDArray("rho_edge");
   fParams.zOrigin = table->GetDArray("z_origin");
@@ -272,7 +273,7 @@ G4LogicalVolume *ToroidalPMTConstruction::BuildVolume(const std::string &prefix)
     central_gap_log->SetVisAttributes(G4VisAttributes::GetInvisible());
   }
 
-  log_pmt = body_log;
+  log_pmt = fParams.useEnvelope ? envelope_log : body_log;
 
   // if using envelope place waveguide now
   if (fParams.useEnvelope && fWaveguideFactory) {


### PR DESCRIPTION
**Breaking changes!!**

This PR addresses a bug in the Toroidal PMT construction routine. By design each toroidal PMT is supposed to be constructed in a cylindrical "envelope", whose radius and height is just enough to fully enclose the PMT. The envelop cylinder is then supposed to be placed in the geometry once per PMT.

However, currently in code, while the PMT body is constructed in the envelope, it is the PMT body that gets placed in the main geo, not the envelop itself. This results in the fact that the any surface defined between the PMT body and the envelope (namely, the reflective metallic surface at the back of the PMT) is not simulated.  Additionally, it is a lot more expensive to construct and propagate photons without the geometry, since TorusStack is expensive to construct and not very friendly toward G4 voxelization. Applying this patch speeds up geometry construction dramatically. In geometries with O(10k) pmts, the geometry construction speeds up from ~10minutes to seconds.

However, this patch changes the PMT light yield in a somewhat significant way. Transitioning from a version of RAT without this patch will likely require recalibration of the detector optics.

resolves #120 .