### PR TITLE
Remove absorption from PMT glass models

### DIFF
--- a/ratdb/MATERIALS.ratdb
+++ b/ratdb/MATERIALS.ratdb
@@ -14,7 +14,6 @@
 "pressure": 0.01,
 }
 
-
 {
 "name": "MATERIAL",
 "index": "air",
@@ -25,7 +24,6 @@
 "elemprop": [0.7, 0.3, ],
 "nmaterials": 0,
 }
-
 
 {
 "name": "MATERIAL",
@@ -38,7 +36,6 @@
 "elemprop": [0.1119, 0.8881],
 }
 
-
 {
 "name": "MATERIAL",
 "index": "aluminum",
@@ -49,7 +46,6 @@
 "elements": ["Aluminum"],
 "elemprop": [1.0],
 }
-
 
 {
 "name": "MATERIAL",
@@ -62,7 +58,6 @@
 "elemprop": [1.0],
 }
 
-
 {
 "name": "MATERIAL",
 "index": "brass",
@@ -74,7 +69,6 @@
 "elemprop": [0.66, 0.34],
 }
 
-
 {
 "name": "MATERIAL",
 "index": "brass_360", // C36000 "Free Machining" Brass
@@ -85,7 +79,6 @@
 "elements": ["Copper", "Zinc", "Lead", "Iron"],
 "elemprop": [0.615, 0.355, 0.0265, 0.0035],
 }
-
 
 {
 "name": "MATERIAL",
@@ -317,11 +310,26 @@
 "elemprop": [0.52925, 0.47075],
 }
 
+
 // ------------------- PMT materials ----------------
+// ------ Since quantum efficiency measurements generally include glass absorption, PMT ------------
+// ------ models should not include glass absorption.  Therefore, several window materials ---------
+// ------ below include versions of glass that are effectively without absorption ('_noAbs'). ------
 
 {
 "name": "MATERIAL",
 "index": "quartz",
+"run_range" : [0, 0],
+"density": 2.65,
+"nelements": 2,
+"nmaterials": 0,
+"elements": ["Silicon", "Oxygen",],
+"elemprop": [0.4675, 0.5325],
+}
+
+{
+"name": "MATERIAL",
+"index": "quartz_noAbs",  // version without optical absorption
 "run_range" : [0, 0],
 "density": 2.65,
 "nelements": 2,
@@ -343,6 +351,97 @@
 
 {
 "name": "MATERIAL",
+"index": "glass_noAbs",
+"run_range" : [0, 0],
+"density": 2.2,
+"nelements": 2,
+"nmaterials": 0,
+"elements": ["Silicon", "Oxygen",],
+"elemprop": [0.4675, 0.5325],
+}
+
+{
+"name": "MATERIAL",
+"index": "borosilicate_glass",
+"run_range" : [0, 0],
+"density": 2.23, // g/cm^3, from Wikipedia
+"nelements": 3,
+"nmaterials": 0,
+"elements": ["Boron","Oxygen","Silicon",],
+"elemprop": [0.38889, 0.55873, 0.05238,],
+}
+
+{
+"name": "MATERIAL",
+"index": "borosilicate_glass_noAbs",  // version without optical absorption
+"run_range" : [0, 0],
+"density": 2.23, // g/cm^3, from Wikipedia
+"nelements": 3,
+"nmaterials": 0,
+"elements": ["Boron","Oxygen","Silicon",],
+"elemprop": [0.38889, 0.55873, 0.05238,],
+}
+
+{
+"name": "MATERIAL",
+"index": "hamamatsu_borosilicate_glass",
+"run_range" : [0, 0],
+"density": 2.23, // g/cm^3, from Wikipedia
+"nelements": 7,
+"nmaterials": 0,
+"elements": ["Lithium","Boron","Oxygen","Sodium","Aluminum","Silicon","Barium",],
+"elemprop": [0.001, 0.059, 0.523, 0.042, 0.049, 0.284, 0.042,],
+}
+
+{
+"name": "MATERIAL",
+"index": "hamamatsu_borosilicate_glass_noAbs",  // version without optical absorption
+"run_range" : [0, 0],
+"density": 2.23, // g/cm^3, from Wikipedia
+"nelements": 7,
+"nmaterials": 0,
+"elements": ["Lithium","Boron","Oxygen","Sodium","Aluminum","Silicon","Barium",],
+"elemprop": [0.001, 0.059, 0.523, 0.042, 0.049, 0.284, 0.042,],
+}
+
+{
+"name": "MATERIAL",
+"index": "MgF2",
+"run_range" : [0, 0],
+"density": 3.18,
+"nelements": 2,
+"nmaterials": 0,
+"elements": ["Magnesium","Fluorine"],
+"elemprop": [0.39, 0.61],
+}
+
+{
+"name": "MATERIAL",
+"index": "mirror",
+"run_range" : [0, 0],
+"density": 2.2,
+"nelements": 2,
+"nmaterials": 0,
+"elements": ["Silicon", "Oxygen",],
+"elemprop": [0.4675, 0.5325],
+}
+
+{
+"name": "MATERIAL",
+"index": "pmt_vacuum",
+"run_range" : [0, 0],
+"density": 1.0e-5,
+"nelements": 0,
+"nmaterials": 1,
+"materials": ["air",],
+"matprop": [1.0,],
+"state": "gas",
+"temperature": 273.15,
+"pressure": 0.01,
+}
+
+{
+"name": "MATERIAL",
 "index": "longpass_dichroic_placeholder",
 "run_range" : [0, 0],
 "density": 2.2,
@@ -355,17 +454,6 @@
 {
 "name": "MATERIAL",
 "index": "shortpass_dichroic_placeholder",
-"run_range" : [0, 0],
-"density": 2.2,
-"nelements": 2,
-"nmaterials": 0,
-"elements": ["Silicon", "Oxygen",],
-"elemprop": [0.4675, 0.5325],
-}
-
-{
-"name": "MATERIAL",
-"index": "mirror",
 "run_range" : [0, 0],
 "density": 2.2,
 "nelements": 2,
@@ -429,7 +517,6 @@
 "elemprop": [1.0],
 }
 
-////   The photocathode material for the R5912-HQE
 {
 "name": "MATERIAL",
 "index": "photocathode_R5912_HQE",
@@ -452,7 +539,6 @@
 "elemprop": [1.0],
 }
 
-//// The photocathode material for the R1408.
 {
 "name": "MATERIAL",
 "index": "photocathode_R1408",
@@ -497,7 +583,6 @@
 "elemprop": [1.0],
 }
 
-// E.Keener at Penn, copied from photocathode_R7081HQE
 {
 "name": "MATERIAL",
 "index": "photocathode_R7081",
@@ -531,9 +616,6 @@
 "elemprop": [1.0],
 }
 
-
-
-////   The photocathode material for the ET 9390B
 {
 "name": "MATERIAL",
 "index": "photocathode_et9390b",
@@ -545,57 +627,8 @@
 "elemprop": [1.0],
 }
 
-{
-"name": "MATERIAL",
-"index": "pmt_vacuum",
-"run_range" : [0, 0],
-"density": 1.0e-5,
-"nelements": 0,
-"nmaterials": 1,
-"materials": ["air",],
-"matprop": [1.0,],
-"state": "gas",
-"temperature": 273.15,
-"pressure": 0.01,
-}
 
-//// Approximate Borosilicate glass
-{
-"name": "MATERIAL",
-"index": "borosilicate_glass",
-"run_range" : [0, 0],
-"density": 2.23, // g/cm^3, from Wikipedia
-"nelements": 3,
-"nmaterials": 0,
-"elements": ["Boron","Oxygen","Silicon",],
-"elemprop": [0.38889, 0.55873, 0.05238,],
-}
-
-//// hamamatsu borosilicate glass composition
-{
-"name": "MATERIAL",
-"index": "hamamatsu_borosilicate_glass",
-"run_range" : [0, 0],
-"density": 2.23, // g/cm^3, from Wikipedia
-"nelements": 7,
-"nmaterials": 0,
-"elements": ["Lithium","Boron","Oxygen","Sodium","Aluminum","Silicon","Barium",],
-"elemprop": [0.001, 0.059, 0.523, 0.042, 0.049, 0.284, 0.042,],
-}
-
-{
-"name": "MATERIAL",
-"index": "MgF2",
-"run_range" : [0, 0],
-"density": 3.18,
-"nelements": 2,
-"nmaterials": 0,
-"elements": ["Magnesium","Fluorine"],
-"elemprop": [0.39, 0.61],
-}
-
-
-// --------------- Liquid organic scintillator experiments ------------------
+// --------------- Liquid organic scintillators ------------------
 
 {
 "name": "MATERIAL",
@@ -752,6 +785,7 @@
 "matprop": [0.999425, 0.000575],
 }
 
+
 // --------------------- Plastics ----------------------------
 
 {
@@ -775,8 +809,6 @@
 "elements": ["Carbon", "Fluorine",],
 "elemprop": [0.24018, 0.75982],
 }
-
-
 
 {
 "name": "MATERIAL",
@@ -1054,6 +1086,7 @@
 "formula": "AROMATIC",
 }
 
+
 // ------------------ Gunite ---------------------
 //Place holder for when we get more info
 {
@@ -1066,7 +1099,6 @@
 "elements": ["Silicon","Oxygen","Hydrogen","Calcium","Aluminum","Iron",],
 "elemprop": [0.227915, 0.60541, 0.09972, 0.04986, 0.014245, 0.00285],
 }
-
 
 
 // ------------------ Concrete ---------------------
@@ -1115,8 +1147,8 @@
 "elemprop": [0.337, 0.529, 0.01, 0.044, 0.034, 0.014, 0.002, 0.001, 0.016, 0.013],
 }
 
-// ----------------- Cryogenic scintillator experiments ---------------
 
+// ----------------- Cryogenic scintillators ---------------
 
 {
 "name": "MATERIAL",
@@ -1209,7 +1241,9 @@
 "nmaterials": 0,
 }
 
+
 // ------------------- other detector materials ----------------
+
 {
 "name": "MATERIAL",
 "index": "NaI",

--- a/ratdb/MATERIALS.ratdb
+++ b/ratdb/MATERIALS.ratdb
@@ -312,24 +312,10 @@
 
 
 // ------------------- PMT materials ----------------
-// ------ Since quantum efficiency measurements generally include glass absorption, PMT ------------
-// ------ models should not include glass absorption.  Therefore, several window materials ---------
-// ------ below include versions of glass that are effectively without absorption ('_noAbs'). ------
 
 {
 "name": "MATERIAL",
 "index": "quartz",
-"run_range" : [0, 0],
-"density": 2.65,
-"nelements": 2,
-"nmaterials": 0,
-"elements": ["Silicon", "Oxygen",],
-"elemprop": [0.4675, 0.5325],
-}
-
-{
-"name": "MATERIAL",
-"index": "quartz_noAbs",  // version without optical absorption
 "run_range" : [0, 0],
 "density": 2.65,
 "nelements": 2,
@@ -351,17 +337,6 @@
 
 {
 "name": "MATERIAL",
-"index": "glass_noAbs",
-"run_range" : [0, 0],
-"density": 2.2,
-"nelements": 2,
-"nmaterials": 0,
-"elements": ["Silicon", "Oxygen",],
-"elemprop": [0.4675, 0.5325],
-}
-
-{
-"name": "MATERIAL",
 "index": "borosilicate_glass",
 "run_range" : [0, 0],
 "density": 2.23, // g/cm^3, from Wikipedia
@@ -373,29 +348,7 @@
 
 {
 "name": "MATERIAL",
-"index": "borosilicate_glass_noAbs",  // version without optical absorption
-"run_range" : [0, 0],
-"density": 2.23, // g/cm^3, from Wikipedia
-"nelements": 3,
-"nmaterials": 0,
-"elements": ["Boron","Oxygen","Silicon",],
-"elemprop": [0.38889, 0.55873, 0.05238,],
-}
-
-{
-"name": "MATERIAL",
 "index": "hamamatsu_borosilicate_glass",
-"run_range" : [0, 0],
-"density": 2.23, // g/cm^3, from Wikipedia
-"nelements": 7,
-"nmaterials": 0,
-"elements": ["Lithium","Boron","Oxygen","Sodium","Aluminum","Silicon","Barium",],
-"elemprop": [0.001, 0.059, 0.523, 0.042, 0.049, 0.284, 0.042,],
-}
-
-{
-"name": "MATERIAL",
-"index": "hamamatsu_borosilicate_glass_noAbs",  // version without optical absorption
 "run_range" : [0, 0],
 "density": 2.23, // g/cm^3, from Wikipedia
 "nelements": 7,

--- a/ratdb/OPTICS.ratdb
+++ b/ratdb/OPTICS.ratdb
@@ -234,6 +234,24 @@
 
 {
 "name": "OPTICS",
+"index": "glass",
+"run_range" : [0, 0],
+"surface": 1,
+"finish": "ground",
+"model": "glisur",
+"type": "dielectric_dielectric",
+"polish": 0.9,
+"RINDEX_option": "wavelength",
+"RINDEX_value1": [60.0, 200.0, 300.0, 600.0, 800.0, ],
+"RINDEX_value2": [1.458, 1.458, 1.458, 1.458, 1.458, ],
+"ABSLENGTH_option": "wavelength",
+"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
+"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
+"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+}
+
+{
+"name": "OPTICS",
 "index": "ZnO2",
 "run_range" : [0, 0],
 "surface": 1,
@@ -317,12 +335,11 @@
 "model": "glisur",
 "type": "dielectric_dielectric",
 "polish": 0.9,
-// Refractive index of Sapphire (Al2O3) from https://refractiveindex.info/?shelf=3d&book=crystals&page=sapphire {no data below 200 nm}
 "RINDEX_option": "wavelength",
-"RINDEX_value1": [60.0, 200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 1000.0, ],
-"RINDEX_value2": [1.91, 1.913, 1.845, 1.814, 1.787, 1.774, 1.768, 1.763, 1.760, 1.756, ],
+"RINDEX_value1": [60.0, 200.0, 300.0, 600.0, 800.0, ],
+"RINDEX_value2": [1.76, 1.76, 1.76, 1.76, 1.76, ], //index of refraction looked up online
 "ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 180.0, 200.0, 250.0, 400.0, 1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 7000.0,  ], // values calculated from infromation in CeramTec documentation
+"ABSLENGTH_value1": [60.0, 180.0, 200.0, 250.0, 400.0, 1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 7000.0,  ], //values calculate from infromation from ceramtech documentation
 "ABSLENGTH_value2": [0.1e-3, 0.1e-3, 10.0, 44.81, 52.67, 61.53, 61.53, 61.53, 50.39, 28.03, 0.1e-3, ],
 "PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
 }
@@ -330,7 +347,7 @@
 
 // ------------------- PMT materials ----------------
 // ------ Since quantum efficiency measurements generally include glass -----------------
-// ------ absorption, glass models should not separately account for it. ----------------
+// ------ absorption, PMT glass models should not separately account for it. ------------
 // ------ Furthermore, GLG4PMTOpticalModel does not consider PMT glass absorption. ------
 
 {
@@ -350,24 +367,6 @@
 // Values inherited from "glass" except cutoff set to ~160 nm based on https://www.hamamatsu.com/us/en/support/glossary/w.html
 //"ABSLENGTH_value1": [60.0, 130.0, 160.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
 //"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 1.0e3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
-"PROPERTY_LIST": ["RINDEX", /*"ABSLENGTH",*/ ]
-}
-
-{
-"name": "OPTICS",
-"index": "glass",
-"run_range" : [0, 0],
-"surface": 1,
-"finish": "ground",
-"model": "glisur",
-"type": "dielectric_dielectric",
-"polish": 0.9,
-"RINDEX_option": "wavelength",
-"RINDEX_value1": [60.0, 200.0, 300.0, 600.0, 800.0, ],
-"RINDEX_value2": [1.458, 1.458, 1.458, 1.458, 1.458, ],
-//"ABSLENGTH_option": "wavelength",
-//"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
-//"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
 "PROPERTY_LIST": ["RINDEX", /*"ABSLENGTH",*/ ]
 }
 

--- a/ratdb/OPTICS.ratdb
+++ b/ratdb/OPTICS.ratdb
@@ -322,9 +322,10 @@
 "model": "glisur",
 "type": "dielectric_dielectric",
 "polish": 0.9,
+// Refractive index of Sapphire (Al2O3) from https://refractiveindex.info/?shelf=3d&book=crystals&page=sapphire {no data below 200 nm}
 "RINDEX_option": "wavelength",
-"RINDEX_value1": [60.0, 200.0, 300.0, 600.0, 800.0, ],
-"RINDEX_value2": [1.76, 1.76, 1.76, 1.76, 1.76, ], //index of refraction looked up online
+"RINDEX_value1": [60.0, 200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 1000.0, ],
+"RINDEX_value2": [1.91, 1.913, 1.845, 1.814, 1.787, 1.774, 1.768, 1.763, 1.760, 1.756, ],
 "ABSLENGTH_option": "wavelength",
 "ABSLENGTH_value1": [60.0, 180.0, 200.0, 250.0, 400.0, 1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 7000.0,  ], //values calculate from infromation from ceramtech documentation
 "ABSLENGTH_value2": [0.1e-3, 0.1e-3, 10.0, 44.81, 52.67, 61.53, 61.53, 61.53, 50.39, 28.03, 0.1e-3, ],
@@ -333,6 +334,9 @@
 
 
 // ------------------- PMT materials ----------------
+// ------ Since quantum efficiency measurements generally include glass absorption, PMT ------------
+// ------ models should not include glass absorption.  Therefore, several window materials ---------
+// ------ below include versions of glass that are effectively without absorption ('_noAbs'). ------
 
 {
 "name": "OPTICS",
@@ -356,6 +360,25 @@
 
 {
 "name": "OPTICS",
+"index": "quartz_noAbs",  // fused quartz (no absorption)
+"run_range" : [0, 0],
+"surface": 1,
+"finish": "ground",
+"model": "glisur",
+"type": "dielectric_dielectric",
+"polish": 0.9,
+"RINDEX_option": "wavelength",
+// Refractive index of Fused silica (fused quartz) from https://refractiveindex.info/?shelf=glass&book=fused_silica&page=Malitson
+"RINDEX_value1": [60.0, 117.0, 120.0, 140.0, 160.0, 180.0, 200.0, 220.0, 240.0, 260.0, 280.0, 300.0, 320.0, 340.0, 360.0, 380.0, 400.0, 420.0, 440.0, 460.0, 480.0, 500.0, 520.0, 540.0, 560.0, 580.0, 600.0, 620.0, 640.0, 660.0, 680.0, 700.0, 720.0, 740.0, 760.0, 780.0, 800.0, 820.0, 840.0, 860.0, 880.0, 900.0, 920.0, 940.0, 960.0, 980.0, 1000, ],
+"RINDEX_value2": [5.7982, 5.7982, 2.9406, 1.7966, 1.6479, 1.5853, 1.5505, 1.5285, 1.5133, 1.5024, 1.4942, 1.4878, 1.4827, 1.4787, 1.4753, 1.4725, 1.4701, 1.4681, 1.4663, 1.4648, 1.4635, 1.4623, 1.4613, 1.4603, 1.4595, 1.4587, 1.4580, 1.4574, 1.4568, 1.4563, 1.4558, 1.4553, 1.4549, 1.4544, 1.4540, 1.4537, 1.4533, 1.4530, 1.4527, 1.4523, 1.4520, 1.4518, 1.4515, 1.4512, 1.4509, 1.4507, 1.4504, ],
+"ABSLENGTH_option": "wavelength",
+"ABSLENGTH_value1": [60.0, 800.0, ],
+"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
+"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+}
+
+{
+"name": "OPTICS",
 "index": "glass",
 "run_range" : [0, 0],
 "surface": 1,
@@ -369,6 +392,24 @@
 "ABSLENGTH_option": "wavelength",
 "ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
 "ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
+"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+}
+
+{
+"name": "OPTICS",
+"index": "glass_noAbs",
+"run_range" : [0, 0],
+"surface": 1,
+"finish": "ground",
+"model": "glisur",
+"type": "dielectric_dielectric",
+"polish": 0.9,
+"RINDEX_option": "wavelength",
+"RINDEX_value1": [60.0, 200.0, 300.0, 600.0, 800.0, ],
+"RINDEX_value2": [1.458, 1.458, 1.458, 1.458, 1.458, ],
+"ABSLENGTH_option": "wavelength",
+"ABSLENGTH_value1": [60.0, 800.0, ],
+"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
 "PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
 }
 
@@ -394,6 +435,26 @@
 
 {
 "name": "OPTICS",
+"index": "borosilicate_glass_noAbs",
+"run_range" : [0, 0],
+"surface": 1,
+"finish": "ground",
+"model": "glisur",
+"type": "dielectric_dielectric",
+"polish": 0.9,
+"RINDEX_option": "wavelength",
+// Refractive index of Schott BK7 from https://refractiveindex.info/?shelf=popular_glass&book=BK7&page=SCHOTT
+// There is no data below 300 nm, so the Sellmeier formulas extrapolated below using an exponential fit.
+"RINDEX_value1": [60.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, ],
+"RINDEX_value2": [1.707, 1.662, 1.589, 1.551, 1.531, 1.521, 1.516, 1.513, 1.512, ],
+"ABSLENGTH_option": "wavelength",
+"ABSLENGTH_value1": [60.0, 800.0, ],
+"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
+"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+}
+
+{
+"name": "OPTICS",
 "index": "hamamatsu_borosilicate_glass",
 "run_range" : [0, 0],
 "surface": 1,
@@ -409,6 +470,26 @@
 "ABSLENGTH_option": "wavelength",
 "ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
 "ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
+"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+}
+
+{
+"name": "OPTICS",
+"index": "hamamatsu_borosilicate_glass_noAbs",
+"run_range" : [0, 0],
+"surface": 1,
+"finish": "ground",
+"model": "glisur",
+"type": "dielectric_dielectric",
+"polish": 0.9,
+// Refractive index of Schott BK7 from https://refractiveindex.info/?shelf=popular_glass&book=BK7&page=SCHOTT
+// There is no data below 300 nm, so the Sellmeier formulas extrapolated below using an exponential fit.
+"RINDEX_option": "wavelength",
+"RINDEX_value1": [60.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, ],
+"RINDEX_value2": [1.707, 1.662, 1.589, 1.551, 1.531, 1.521, 1.516, 1.513, 1.512, ],
+"ABSLENGTH_option": "wavelength",
+"ABSLENGTH_value1": [60.0, 800.0, ],
+"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
 "PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
 }
 

--- a/ratdb/OPTICS.ratdb
+++ b/ratdb/OPTICS.ratdb
@@ -196,7 +196,6 @@
 "PROPERTY_LIST": ["REFLECTIVITY", "ABSLENGTH", ]
 }
 
-
 {
 "name": "OPTICS",
 "index": "lightcone",
@@ -214,9 +213,6 @@
 "ABSLENGTH_value2": [1.0e-3, 1.0e-3, ],
 "PROPERTY_LIST": ["REFLECTIVITY", "ABSLENGTH", ]
 }
-
-
-
 
 {
 "name": "OPTICS",
@@ -293,7 +289,6 @@
 "RINDEX_option": "wavelength",
 "RINDEX_value1":[60.0,150.0,200.0,240.0,280.0,320.0,360.0,400.0,440.0,480.0,520.0,560.0,600.0,640.0,680.0,720.0,760.0,800.0,],
 "RINDEX_value2":[38.0,2.61803,1.42983,1.41213,1.40248,1.39657,1.39265,1.3899,1.38789,1.38637,1.38517,1.38421,1.38342,1.38277,1.3822,1.38172,1.38129,1.3809,],
-
 "PROPERTY_LIST": ["RINDEX", /*"ABSLENGTH",*/ ]
 }
 
@@ -327,16 +322,16 @@
 "RINDEX_value1": [60.0, 200.0, 250.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 1000.0, ],
 "RINDEX_value2": [1.91, 1.913, 1.845, 1.814, 1.787, 1.774, 1.768, 1.763, 1.760, 1.756, ],
 "ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 180.0, 200.0, 250.0, 400.0, 1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 7000.0,  ], //values calculate from infromation from ceramtech documentation
+"ABSLENGTH_value1": [60.0, 180.0, 200.0, 250.0, 400.0, 1000.0, 2000.0, 3000.0, 4000.0, 5000.0, 7000.0,  ], // values calculated from infromation in CeramTec documentation
 "ABSLENGTH_value2": [0.1e-3, 0.1e-3, 10.0, 44.81, 52.67, 61.53, 61.53, 61.53, 50.39, 28.03, 0.1e-3, ],
 "PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
 }
 
 
 // ------------------- PMT materials ----------------
-// ------ Since quantum efficiency measurements generally include glass absorption, PMT ------------
-// ------ models should not include glass absorption.  Therefore, several window materials ---------
-// ------ below include versions of glass that are effectively without absorption ('_noAbs'). ------
+// ------ Since quantum efficiency measurements generally include glass -----------------
+// ------ absorption, glass models should not separately account for it. ----------------
+// ------ Furthermore, GLG4PMTOpticalModel does not consider PMT glass absorption. ------
 
 {
 "name": "OPTICS",
@@ -351,30 +346,11 @@
 // Refractive index of Fused silica (fused quartz) from https://refractiveindex.info/?shelf=glass&book=fused_silica&page=Malitson
 "RINDEX_value1": [60.0, 117.0, 120.0, 140.0, 160.0, 180.0, 200.0, 220.0, 240.0, 260.0, 280.0, 300.0, 320.0, 340.0, 360.0, 380.0, 400.0, 420.0, 440.0, 460.0, 480.0, 500.0, 520.0, 540.0, 560.0, 580.0, 600.0, 620.0, 640.0, 660.0, 680.0, 700.0, 720.0, 740.0, 760.0, 780.0, 800.0, 820.0, 840.0, 860.0, 880.0, 900.0, 920.0, 940.0, 960.0, 980.0, 1000, ],
 "RINDEX_value2": [5.7982, 5.7982, 2.9406, 1.7966, 1.6479, 1.5853, 1.5505, 1.5285, 1.5133, 1.5024, 1.4942, 1.4878, 1.4827, 1.4787, 1.4753, 1.4725, 1.4701, 1.4681, 1.4663, 1.4648, 1.4635, 1.4623, 1.4613, 1.4603, 1.4595, 1.4587, 1.4580, 1.4574, 1.4568, 1.4563, 1.4558, 1.4553, 1.4549, 1.4544, 1.4540, 1.4537, 1.4533, 1.4530, 1.4527, 1.4523, 1.4520, 1.4518, 1.4515, 1.4512, 1.4509, 1.4507, 1.4504, ],
-"ABSLENGTH_option": "wavelength",
+//"ABSLENGTH_option": "wavelength",
 // Values inherited from "glass" except cutoff set to ~160 nm based on https://www.hamamatsu.com/us/en/support/glossary/w.html
-"ABSLENGTH_value1": [60.0, 130.0, 160.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
-"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 1.0e3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
-}
-
-{
-"name": "OPTICS",
-"index": "quartz_noAbs",  // fused quartz (no absorption)
-"run_range" : [0, 0],
-"surface": 1,
-"finish": "ground",
-"model": "glisur",
-"type": "dielectric_dielectric",
-"polish": 0.9,
-"RINDEX_option": "wavelength",
-// Refractive index of Fused silica (fused quartz) from https://refractiveindex.info/?shelf=glass&book=fused_silica&page=Malitson
-"RINDEX_value1": [60.0, 117.0, 120.0, 140.0, 160.0, 180.0, 200.0, 220.0, 240.0, 260.0, 280.0, 300.0, 320.0, 340.0, 360.0, 380.0, 400.0, 420.0, 440.0, 460.0, 480.0, 500.0, 520.0, 540.0, 560.0, 580.0, 600.0, 620.0, 640.0, 660.0, 680.0, 700.0, 720.0, 740.0, 760.0, 780.0, 800.0, 820.0, 840.0, 860.0, 880.0, 900.0, 920.0, 940.0, 960.0, 980.0, 1000, ],
-"RINDEX_value2": [5.7982, 5.7982, 2.9406, 1.7966, 1.6479, 1.5853, 1.5505, 1.5285, 1.5133, 1.5024, 1.4942, 1.4878, 1.4827, 1.4787, 1.4753, 1.4725, 1.4701, 1.4681, 1.4663, 1.4648, 1.4635, 1.4623, 1.4613, 1.4603, 1.4595, 1.4587, 1.4580, 1.4574, 1.4568, 1.4563, 1.4558, 1.4553, 1.4549, 1.4544, 1.4540, 1.4537, 1.4533, 1.4530, 1.4527, 1.4523, 1.4520, 1.4518, 1.4515, 1.4512, 1.4509, 1.4507, 1.4504, ],
-"ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 800.0, ],
-"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+//"ABSLENGTH_value1": [60.0, 130.0, 160.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
+//"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 1.0e3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
+"PROPERTY_LIST": ["RINDEX", /*"ABSLENGTH",*/ ]
 }
 
 {
@@ -389,28 +365,10 @@
 "RINDEX_option": "wavelength",
 "RINDEX_value1": [60.0, 200.0, 300.0, 600.0, 800.0, ],
 "RINDEX_value2": [1.458, 1.458, 1.458, 1.458, 1.458, ],
-"ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
-"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
-}
-
-{
-"name": "OPTICS",
-"index": "glass_noAbs",
-"run_range" : [0, 0],
-"surface": 1,
-"finish": "ground",
-"model": "glisur",
-"type": "dielectric_dielectric",
-"polish": 0.9,
-"RINDEX_option": "wavelength",
-"RINDEX_value1": [60.0, 200.0, 300.0, 600.0, 800.0, ],
-"RINDEX_value2": [1.458, 1.458, 1.458, 1.458, 1.458, ],
-"ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 800.0, ],
-"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+//"ABSLENGTH_option": "wavelength",
+//"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
+//"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
+"PROPERTY_LIST": ["RINDEX", /*"ABSLENGTH",*/ ]
 }
 
 {
@@ -427,30 +385,10 @@
 // There is no data below 300 nm, so the Sellmeier formulas extrapolated below using an exponential fit.
 "RINDEX_value1": [60.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, ],
 "RINDEX_value2": [1.707, 1.662, 1.589, 1.551, 1.531, 1.521, 1.516, 1.513, 1.512, ],
-"ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
-"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
-}
-
-{
-"name": "OPTICS",
-"index": "borosilicate_glass_noAbs",
-"run_range" : [0, 0],
-"surface": 1,
-"finish": "ground",
-"model": "glisur",
-"type": "dielectric_dielectric",
-"polish": 0.9,
-"RINDEX_option": "wavelength",
-// Refractive index of Schott BK7 from https://refractiveindex.info/?shelf=popular_glass&book=BK7&page=SCHOTT
-// There is no data below 300 nm, so the Sellmeier formulas extrapolated below using an exponential fit.
-"RINDEX_value1": [60.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, ],
-"RINDEX_value2": [1.707, 1.662, 1.589, 1.551, 1.531, 1.521, 1.516, 1.513, 1.512, ],
-"ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 800.0, ],
-"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+//"ABSLENGTH_option": "wavelength",
+//"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
+//"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
+"PROPERTY_LIST": ["RINDEX", /*"ABSLENGTH",*/ ]
 }
 
 {
@@ -467,30 +405,10 @@
 "RINDEX_option": "wavelength",
 "RINDEX_value1": [60.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, ],
 "RINDEX_value2": [1.707, 1.662, 1.589, 1.551, 1.531, 1.521, 1.516, 1.513, 1.512, ],
-"ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
-"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
-}
-
-{
-"name": "OPTICS",
-"index": "hamamatsu_borosilicate_glass_noAbs",
-"run_range" : [0, 0],
-"surface": 1,
-"finish": "ground",
-"model": "glisur",
-"type": "dielectric_dielectric",
-"polish": 0.9,
-// Refractive index of Schott BK7 from https://refractiveindex.info/?shelf=popular_glass&book=BK7&page=SCHOTT
-// There is no data below 300 nm, so the Sellmeier formulas extrapolated below using an exponential fit.
-"RINDEX_option": "wavelength",
-"RINDEX_value1": [60.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, ],
-"RINDEX_value2": [1.707, 1.662, 1.589, 1.551, 1.531, 1.521, 1.516, 1.513, 1.512, ],
-"ABSLENGTH_option": "wavelength",
-"ABSLENGTH_value1": [60.0, 800.0, ],
-"ABSLENGTH_value2": [1.0e9, 1.0e9, ],
-"PROPERTY_LIST": ["RINDEX", "ABSLENGTH", ]
+//"ABSLENGTH_option": "wavelength",
+//"ABSLENGTH_value1": [60.0, 200.0, 300.0, 330.0, 500.0, 600.0, 770.0, 800.0, ],
+//"ABSLENGTH_value2": [0.1e-3, 0.1e-3, 0.1e-3, 1.0e3, 2.0e3, 1.0e3, 0.5e3, 0.1e-3, ],
+"PROPERTY_LIST": ["RINDEX", /*"ABSLENGTH",*/ ]
 }
 
 {

--- a/ratdb/PMT.ratdb
+++ b/ratdb/PMT.ratdb
@@ -397,7 +397,7 @@
 
 "construction": "lappd",
 
-"glass_material": "glass",
+"glass_material": "borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_lappd",
 

--- a/ratdb/PMT.ratdb
+++ b/ratdb/PMT.ratdb
@@ -6,7 +6,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode",
 "mirror_surface": "mirror",
@@ -31,7 +31,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_r14688",
 "mirror_surface": "mirror",
@@ -56,7 +56,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_R1408",
 "mirror_surface": "mirror",
@@ -82,7 +82,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R1408", 
 "mirror_surface": "mirror",
@@ -116,7 +116,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "quartz_noAbs",
+"glass_material": "quartz",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_R11065",
 "mirror_surface": "mirror",
@@ -141,7 +141,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R11780",
 "mirror_surface": "mirror",
@@ -167,7 +167,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R11780",
 "mirror_surface": "mirror",
@@ -229,7 +229,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081HQE",
 "mirror_surface": "mirror",
@@ -254,7 +254,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081", 
 "mirror_surface": "mirror",
@@ -280,7 +280,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081", 
 "mirror_surface": "mirror",
@@ -315,7 +315,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R1408", //used the 1408 photocathode in SNO+ rat 
 "mirror_surface": "mirror",
@@ -350,7 +350,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "borosilicate_glass_noAbs",
+"glass_material": "borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_et9390b", 
 "mirror_surface": "mirror",
@@ -375,7 +375,7 @@
 "construction": "cubic",
 
 "case_material": "acrylic_white",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_H11934",
 "mirror_surface": "mirror",
@@ -397,7 +397,7 @@
 
 "construction": "lappd",
 
-"glass_material": "glass_noAbs",
+"glass_material": "glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_lappd",
 
@@ -417,7 +417,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081",
 "photocathode_MINrho": 110.0,
@@ -443,7 +443,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R3600",
 "photocathode_MINrho": 230.0,
@@ -470,7 +470,7 @@
 
 // same shape as r3600
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass_noAbs",
+"glass_material": "hamamatsu_borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R12860",
 "photocathode_MINrho": 230.0,

--- a/ratdb/PMT.ratdb
+++ b/ratdb/PMT.ratdb
@@ -6,7 +6,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode",
 "mirror_surface": "mirror",
@@ -31,7 +31,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_r14688",
 "mirror_surface": "mirror",
@@ -56,7 +56,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_R1408",
 "mirror_surface": "mirror",
@@ -82,7 +82,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R1408", 
 "mirror_surface": "mirror",
@@ -116,7 +116,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "quartz",
+"glass_material": "quartz_noAbs",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_R11065",
 "mirror_surface": "mirror",
@@ -141,7 +141,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R11780",
 "mirror_surface": "mirror",
@@ -167,7 +167,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R11780",
 "mirror_surface": "mirror",
@@ -229,7 +229,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081HQE",
 "mirror_surface": "mirror",
@@ -254,7 +254,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081", 
 "mirror_surface": "mirror",
@@ -280,7 +280,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081", 
 "mirror_surface": "mirror",
@@ -315,7 +315,7 @@
 "construction": "revolution",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R1408", //used the 1408 photocathode in SNO+ rat 
 "mirror_surface": "mirror",
@@ -350,7 +350,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "borosilicate_glass",
+"glass_material": "borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum", // dilute air
 "photocathode_surface": "photocathode_et9390b", 
 "mirror_surface": "mirror",
@@ -375,7 +375,7 @@
 "construction": "cubic",
 
 "case_material": "acrylic_white",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_H11934",
 "mirror_surface": "mirror",
@@ -397,7 +397,7 @@
 
 "construction": "lappd",
 
-"glass_material": "glass",
+"glass_material": "glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_lappd",
 
@@ -417,7 +417,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081",
 "photocathode_MINrho": 110.0,
@@ -443,7 +443,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R3600",
 "photocathode_MINrho": 230.0,
@@ -470,7 +470,7 @@
 
 // same shape as r3600
 "dynode_material": "stainless_steel",
-"glass_material": "hamamatsu_borosilicate_glass",
+"glass_material": "hamamatsu_borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R12860",
 "photocathode_MINrho": 230.0,

--- a/ratdb/Validation/PMT.ratdb
+++ b/ratdb/Validation/PMT.ratdb
@@ -6,7 +6,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "borosilicate_glass",
+"glass_material": "borosilicate_glass_noAbs",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081HQE",
 "photocathode_MINrho": 110.0d,

--- a/ratdb/Validation/PMT.ratdb
+++ b/ratdb/Validation/PMT.ratdb
@@ -6,7 +6,7 @@
 "construction": "toroidal",
 
 "dynode_material": "stainless_steel",
-"glass_material": "borosilicate_glass_noAbs",
+"glass_material": "borosilicate_glass",
 "pmt_vacuum_material": "pmt_vacuum",
 "photocathode_surface": "photocathode_R7081HQE",
 "photocathode_MINrho": 110.0d,


### PR DESCRIPTION
This PR adds new versions of the four PMT glasses currently in ratpac2.  The new versions have negligible optical absorption.  This is because quantum efficiency measurements inherently include glass absorption (confirmed with Hamamatsu), and therefore PMT models should not include glass absorption. 
Thus, this PR also updates all PMT models to use the new glasses.  

This PR also improves the refractive index of sapphire.  

The change to glasses could introduce a significant impact when using more green sensitive PMTs, but for the PMT in the Valid.geo, there is no observable impact with Cherenkov light:

No glass absorption:
<img width="520" height="322" alt="image" src="https://github.com/user-attachments/assets/8cdb4d81-1864-428d-a70a-b09457f4b542" />

With glass absorption:
<img width="520" height="320" alt="Screenshot 2026-02-24 15 37 33" src="https://github.com/user-attachments/assets/2476cb17-7028-46b0-a5b9-f13529a7c629" />
