### PR TITLE
Support FOM lookup by both base and full fitter name in OutNtuple

### DIFF
--- a/doc/users_guide/outputs.rst
+++ b/doc/users_guide/outputs.rst
@@ -46,9 +46,17 @@ Parameters:
     /rat/procset include_digitizerwaveforms 1
     /rat/procset include_digitizerhits 1
     /rat/procset include_digitizerfits 1
+    /rat/procset waveform_fitters ["Lognormal","Gaussian","Sinc","LucyDDM","RAVEN"]
+    /rat/procset waveform_fitter_FOM_FITTERNAME ["FOM1","FOM2"]
+    /rat/procset event_fitters ["quadfitter","fitcentroid","fitdirectioncenter","mimir"]
+    /rat/procset event_fitter_FOM_FITTERNAME ["FOM1","FOM2"]
 
-* filename (required, string) Sets output filename.  File will be deleted if it already exists.
-* include_* (optional, int) Sets whether the ntuple structure will be extended to include more variables, as detailed below. By default the following, based on the entries in IO.ratdb, the following are set to 0 by default: ``include_tracking``, ``include_mcparticles``, and ``include_digitizerwaveforms`` and the rest are set to 1 by default (i.e., the associated variables aare included in the ntuple file, as detailed below).
+* ``filename`` (required, string) Sets output filename.  File will be deleted if it already exists.
+* ``include_*`` (optional, int) Sets whether the ntuple structure will be extended to include more variables, as detailed below. By default the following, based on the entries in IO.ratdb, the following are set to 0 by default: ``include_tracking``, ``include_mcparticles``, and ``include_digitizerwaveforms`` and the rest are set to 1 by default (i.e., the associated variables aare included in the ntuple file, as detailed below).
+* ``waveform_fitters`` (optional, vector<string>) Waveform analysis algorithm results to include in the ntuple. See below for naming of the specific variables.
+* ``waveform_fitter_FOM_FITTERNAME`` (optional, vector<string>) The figure of merit to include for each waveform fitter. See below for naming of the specific variables.
+* ``event_fitters`` (optional, vector<string>) Event reconstruction algorithm results to include in the ntuple. See below for naming of the specific variables.
+* ``event_fitter_FOM_FITTERNAME`` (optional, vector<string>) The figure of merit to include for each event fitter. See below for naming of the specific variables. FOM can be specified by the base name of the reconstruction algorithm (e.g., ``event_fitter_FOM_quadfitter``) or by the specific instances of each algorithm (e.g. ``event_fitter_FOM_fitdirectioncenter__0_quad``).
 
 Similarly to the outroot file, one can pass the filename using the "-o" flag by running the macro as::
 
@@ -258,6 +266,27 @@ If ``include_digitizerwaveforms`` is set then we create a new branch in the ntup
 ``inWindowPulseCharges``       vector<double>       The list of MCPE charges that fall inside the waveform window.
 ``waveform``                   vector<ushort>       The digitized waveform, per PMT.
 =============================  ===================  ===================
+
+
+If ``event_fitters`` specify that event reconstruction algorithm results should be included in the ntuple, then we add the following variables to the ``output`` branch of the ntuple. These are filled from the ``DS::EventFitResult`` branch. All fitter instances are labeled by the "full name" of the fitter instance, which is the name of the fitter type + the instance name of the fitter separated by double underscores (e.g., ``quadfitter__instance1``). The variables are as follows:
+
+===================================   ===================  ===================
+**Name**                              **Type**             **Description**
+===================================   ===================  ===================
+``x_fitter__FULLNAME``                double               X coordinate of the reconstructed event vertex.
+``y_fitter__FULLNAME``                double               Y coordinate of the reconstructed event vertex.
+``z_fitter__FULLNAME``                double               Z coordinate of the reconstructed event vertex.
+``u_fitter__FULLNAME``                double               X component of the reconstructed event direction.
+``v_fitter__FULLNAME``                double               Y component of the reconstructed event direction.
+``w_fitter__FULLNAME``                double               Z component of the reconstructed event direction.
+``energy_fitter__FULLNAME``           double               Reconstructed event energy.
+``time_fitter__FULLNAME``             double               Reconstructed event time.
+``validposition_fitter__FULLNAME``    bool                 Whether the reconstructed event position is valid.
+``validdirection_fitter__FULLNAME``   bool                 Whether the reconstructed event direction is valid.
+``validenergy_fitter__FULLNAME``      bool                 Whether the reconstructed event energy is valid.
+``validtime_fitter__FULLNAME``        bool                 Whether the reconstructed event time is valid.
+``FOMNAME_fitter__FULLNAME``          double               The figure of merit for the event fit.
+===================================   ===================  ===================
 
 .. _outnet:
 

--- a/src/ds/include/RAT/DS/FitResult.hh
+++ b/src/ds/include/RAT/DS/FitResult.hh
@@ -33,6 +33,14 @@ class FitResult : public TObject {
     if (tag.empty()) return fitter_name;
     return fitter_name + "__" + tag;
   }
+  // Extract the base fitter name from a full name (strips the "__tag" suffix if present)
+  static std::string GetFitterNameFromFullName(const std::string &full_name) {
+    size_t sep = full_name.find("__");
+    if (sep != std::string::npos) {
+      return full_name.substr(0, sep);
+    }
+    return full_name;
+  }
 
   // Fitted Position
   virtual const TVector3 &GetPosition() const { return fit_position; }

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -20,6 +20,7 @@
 #include <RAT/OutNtupleProc.hh>
 #include <iostream>
 #include <numeric>
+#include <set>
 #include <sstream>
 #include <stlplus/string_utilities.hpp>
 #include <string>
@@ -80,11 +81,25 @@ OutNtupleProc::OutNtupleProc() : Processor("outntuple") {
   event_fitters = table->GetSArray("event_fitters");
   for (const std::string &full_name : event_fitters) {
     if (event_fitter_FOMs.find(full_name) != event_fitter_FOMs.end()) continue;
-    try {
-      event_fitter_FOMs[full_name] = table->GetSArray("event_fitter_FOM_" + full_name);
-    } catch (DBNotFoundError &e) {
-      event_fitter_FOMs[full_name].clear();
+    std::set<std::string> fom_set;
+    // Load FOMs declared under the base fitter name (applies to all tagged variants)
+    std::string fitter_name = DS::FitResult::GetFitterNameFromFullName(full_name);
+    if (fitter_name != full_name) {
+      try {
+        for (const std::string &fom : table->GetSArray("event_fitter_FOM_" + fitter_name)) {
+          fom_set.insert(fom);
+        }
+      } catch (DBNotFoundError &e) {
+      }
     }
+    // Load FOMs declared under the full name and merge
+    try {
+      for (const std::string &fom : table->GetSArray("event_fitter_FOM_" + full_name)) {
+        fom_set.insert(fom);
+      }
+    } catch (DBNotFoundError &e) {
+    }
+    event_fitter_FOMs[full_name] = std::vector<std::string>(fom_set.begin(), fom_set.end());
   }
 }
 

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -83,21 +83,20 @@ OutNtupleProc::OutNtupleProc() : Processor("outntuple") {
     if (event_fitter_FOMs.find(full_name) != event_fitter_FOMs.end()) continue;
     std::set<std::string> fom_set;
     // Load FOMs declared under the base fitter name (applies to all tagged variants)
-    std::string fitter_name = DS::FitResult::GetFitterNameFromFullName(full_name);
-    if (fitter_name != full_name) {
-      try {
-        for (const std::string &fom : table->GetSArray("event_fitter_FOM_" + fitter_name)) {
-          fom_set.insert(fom);
-        }
-      } catch (DBNotFoundError &e) {
-      }
-    }
-    // Load FOMs declared under the full name and merge
     try {
       for (const std::string &fom : table->GetSArray("event_fitter_FOM_" + full_name)) {
         fom_set.insert(fom);
       }
     } catch (DBNotFoundError &e) {
+      std::string fitter_name = DS::FitResult::GetFitterNameFromFullName(full_name);
+      try {
+        for (const std::string &fom : table->GetSArray("event_fitter_FOM_" + fitter_name)) {
+          fom_set.insert(fom);
+        }
+      } catch (DBNotFoundError &e) {
+        info << "No FOMs found for fitter " << full_name << " or " << fitter_name
+             << ". No FOM will be saved for this fitter." << newline;
+      }
     }
     event_fitter_FOMs[full_name] = std::vector<std::string>(fom_set.begin(), fom_set.end());
   }


### PR DESCRIPTION
Add GetFitterNameFromFullName helper to FitResult and use it in OutNtupleProc to merge FOMs declared under the base fitter name (e.g. fitter) with those declared under the full tagged name (e.g. `fitter__tag`), so tagged fitter variants inherit shared FOMs.