### PR TITLE
bugfix(io): Prevent OutNtupleProc segfault on multiple beamOn commands

### DIFF
--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -52,7 +52,7 @@ class OutNtupleProc : public Processor {
   virtual void AssignAdditionalMetaAddresses(){};
   virtual void FillEvent(DS::Root *, DS::EV *){};
   virtual void FillNoTriggerEvent(DS::Root *){};
-  virtual void FillMeta() {};
+  virtual void FillMeta(){};
 
   // Exposed members for external tools
   DS::Run *runBranch;

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -48,11 +48,11 @@ class OutNtupleProc : public Processor {
   virtual void EndOfRun(DS::Run *run) override;
 
   // Extensible functions
-  virtual void AssignAdditionalAddresses(){};
-  virtual void AssignAdditionalMetaAddresses(){};
-  virtual void FillEvent(DS::Root *, DS::EV *){};
-  virtual void FillNoTriggerEvent(DS::Root *){};
-  virtual void FillMeta(){};
+  virtual void AssignAdditionalAddresses() {};
+  virtual void AssignAdditionalMetaAddresses() {};
+  virtual void FillEvent(DS::Root *, DS::EV *) {};
+  virtual void FillNoTriggerEvent(DS::Root *) {};
+  virtual void FillMeta() {};
 
   // Exposed members for external tools
   DS::Run *runBranch;
@@ -77,6 +77,7 @@ class OutNtupleProc : public Processor {
   std::map<std::string, std::vector<std::string>> event_fitter_FOMs;
 
  protected:
+  bool has_run_completed;
   std::string defaultFilename;
   TFile *outputFile;
   TTree *outputTree;

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -48,10 +48,10 @@ class OutNtupleProc : public Processor {
   virtual void EndOfRun(DS::Run *run) override;
 
   // Extensible functions
-  virtual void AssignAdditionalAddresses() {};
-  virtual void AssignAdditionalMetaAddresses() {};
-  virtual void FillEvent(DS::Root *, DS::EV *) {};
-  virtual void FillNoTriggerEvent(DS::Root *) {};
+  virtual void AssignAdditionalAddresses(){};
+  virtual void AssignAdditionalMetaAddresses(){};
+  virtual void FillEvent(DS::Root *, DS::EV *){};
+  virtual void FillNoTriggerEvent(DS::Root *){};
   virtual void FillMeta() {};
 
   // Exposed members for external tools

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -30,6 +30,7 @@
 namespace RAT {
 
 OutNtupleProc::OutNtupleProc() : Processor("outntuple") {
+  has_run_completed = false;
   outputFile = nullptr;
   outputTree = nullptr;
   metaTree = nullptr;
@@ -290,6 +291,11 @@ bool OutNtupleProc::OpenFile(std::string filename) {
 }
 
 Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
+  if (has_run_completed) {
+    Log::Die(
+        "Multiple /run/beamOn commands are not supported while OutNtupleProc is active. Please use a single beamOn "
+        "command.");
+  }
   if (!this->outputFile) {
     if (!OpenFile(this->defaultFilename.c_str())) {
       Log::Die("No output file specified");
@@ -726,6 +732,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
 }
 
 void OutNtupleProc::EndOfRun(DS::Run *run) {
+  has_run_completed = true;
   if (outputFile) {
     outputFile->cd();
 


### PR DESCRIPTION
Simulation crashes with a segmentation violation if multiple `/run/beamOn` commands are issued in a single macro while the `outntuple` processor is active.

**Root Cause:**
During run teardown, `OutNtupleProc::EndOfRun()` closes and deletes `outputFile`, but fails to nullify the pointer. Upon a subsequent `/run/beamOn`, the next `DSEvent()` call bypasses file recreation (`if (!this->outputFile)` evaluates false) and invokes `outputTree->Fill()` on a dangling pointer, resulting in a segfault. 

**Immediate Bugfix (this PR)**
Explicitly forbid multiple runs to prevent silent data loss from file overwriting. 
* Implement a `file_closed` boolean flagged during `EndOfRun()`. 
* If `DSEvent()` is called while `file_closed == true`, invoke `Log::Die()` with an error instructing the user cannot use ntuple with multiple beamon commands.

**Future work: Implement Full Multi-Run Support**
Refactor the ntuple IO architecture to safely accumulate data across runs. Very roughly this would require:
1. Explicitly nullify `outputFile`, `outputTree`, `metaTree`, and `waveformTree` in `EndOfRun()`.
2. Modify `OpenFile()` to use `"UPDATE"` mode instead of `"RECREATE"` for subsequent runs.
3. Add a `runId` branch to the `output` tree. This is strictly required so downstream analysis can perform relational joins to the correct run context in the `meta` tree.
4. existence checks in `OpenFile()` (e.g., `f->Get("output")`) to fetch and append to existing trees rather than instantiating new `TTree` cycles in the ROOT directory.