### PR TITLE
SplitEVDAQ: Add max_hit_duration

### DIFF
--- a/doc/users_guide/daq.rst
+++ b/doc/users_guide/daq.rst
@@ -71,9 +71,10 @@ Parameters:
     /rat/procset pmt_lockout "value"
     /rat/procset lookback "value"
     /rat/procset max_hit_time "value"
+    /rat/procset max_hit_duration "value"
     /rat/procset trigger_on_noise "0"|"1"
     /rat/procset digitizer_name "digitizer"
-    /rat/procset digitize
+    /rat/procset digitize "true"|"false"
 
 The digitization settings can also be configured through the ``DAQ.ratdb`` table.
 

--- a/ratdb/DAQ.ratdb
+++ b/ratdb/DAQ.ratdb
@@ -17,7 +17,8 @@
 "trigger_lockout": 0.0,
 "trigger_resolution": 0.05, // in ns
 "lookback": 200.0,
-"max_hit_time": 1000000.0,
+"max_hit_time": 0.0, // ns.  <= 0 means no max time
+"max_hit_duration": 1000000.0, // ns.  <= 0 means no max duration
 "trigger_on_noise": 1,
 "digitizer_name": "V1730",
 "digitize": true, // Run digitization of PMT waveforms

--- a/src/daq/include/RAT/SplitEVDAQProc.hh
+++ b/src/daq/include/RAT/SplitEVDAQProc.hh
@@ -28,6 +28,7 @@ class SplitEVDAQProc : public Processor {
   double fTriggerResolution;
   double fLookback;
   double fMaxHitTime;
+  double fMaxHitDuration;
   bool fDigitize;
 
   int fTriggerOnNoise;

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -26,6 +26,7 @@ void SplitEVDAQProc::BeginOfRun(DS::Run *run) {
   fTriggerResolution = ldaq->GetD("trigger_resolution");
   fLookback = ldaq->GetD("lookback");
   fMaxHitTime = ldaq->GetD("max_hit_time");
+  fMaxHitDuration = ldaq->GetD("max_hit_duration");
   fTriggerOnNoise = ldaq->GetI("trigger_on_noise");
   fDigitizerType = ldaq->GetS("digitizer_name");
   fDigitize = ldaq->GetZ("digitize");
@@ -65,7 +66,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
       // Do we want to trigger on noise hits?
       if (!fTriggerOnNoise && photon->IsDarkHit()) continue;
       double time = photon->GetFrontEndTime();
-      if (time > fMaxHitTime) continue;
+      if (fMaxHitTime > 0 && time > fMaxHitTime) continue;
       if (time > (lastTrigger + fPmtLockout)) {
         trigPulses.push_back(time);
         lastTrigger = time;
@@ -78,7 +79,8 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
   start = floor(start / fTriggerResolution) * fTriggerResolution;
   double end = *std::max_element(trigPulses.begin(), trigPulses.end());
   end = (floor(end / fTriggerResolution) + 1) * fTriggerResolution;
-  std::sort(trigPulses.begin(), trigPulses.end());
+
+  if (fMaxHitDuration > 0 && end - start > fMaxHitDuration) end = start + fMaxHitDuration;
 
   // Turns hits into a histogram of trigger pulse leading edges
   //        _
@@ -89,6 +91,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
 
   std::vector<double> triggerTrain(nbins);
   for (auto v : trigPulses) {
+    if (v > end) continue;
     int select = int((v - start) / bw);
     triggerTrain[select] += 1.0;
   }
@@ -136,7 +139,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
     ev->SetUTC(mc->GetUTC());
     ev->SetDeltaT(tt - lastTrigger);
     lastTrigger = tt;
-    double totalEVCharge = 0;  // What does total charge get used for?
+    double totalEVCharge = 0;
     for (int imcpmt = 0; imcpmt < mc->GetMCPMTCount(); imcpmt++) {
       DS::MCPMT *mcpmt = mc->GetMCPMT(imcpmt);
       int pmtID = mcpmt->GetID();
@@ -196,6 +199,8 @@ void SplitEVDAQProc::SetD(std::string param, double value) {
     fLookback = value;
   else if (param == "max_hit_time")
     fMaxHitTime = value;
+  else if (param == "max_hit_duration")
+    fMaxHitDuration = value;
   else
     throw ParamUnknown(param);
 }

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -80,7 +80,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
   double end = *std::max_element(trigPulses.begin(), trigPulses.end());
   end = (floor(end / fTriggerResolution) + 1) * fTriggerResolution;
 
-  if (fMaxHitDuration > 0 && end - start > fMaxHitDuration) end = start + fMaxHitDuration;
+  if (fMaxHitDuration > 0 && (end - start) > fMaxHitDuration) end = start + fMaxHitDuration;
 
   // Turns hits into a histogram of trigger pulse leading edges
   //        _


### PR DESCRIPTION
The proposed `max_hit_duration` is very similar to `max_hit_time`.  The difference is that it does not start its time window at the beginning of a simulated event, but at the first hit.  This subtle difference will produce no change for most simulations, but can be important for delayed events with preceding events that do not produce hits.  One example is the beta decay of `Cs137` in `decay0`, where the beta may not enter the detector target while the delayed gamma may.  When using `max_hit_time`, the hits from the gamma are too late to be considered for a trigger.  