### PR TITLE
Fix typo in stainless_steel and add two more

### DIFF
--- a/ratdb/MATERIALS.ratdb
+++ b/ratdb/MATERIALS.ratdb
@@ -105,7 +105,7 @@
 "density": 7.87,
 "nelements": 3,
 "nmaterials": 0,
-"elements": ["Iron", "Chromium","Nitrogen"],
+"elements": ["Iron", "Chromium","Nickel"],
 "elemprop": [0.71, 0.19, 0.1],
 }
 

--- a/ratdb/MATERIALS.ratdb
+++ b/ratdb/MATERIALS.ratdb
@@ -111,7 +111,7 @@
 
 {
 "name": "MATERIAL",
-"index": "stainless_steel_304H",
+"index": "stainless_steel_304H",  // 304 and 304H
 "run_range" : [0, 0],
 // Taken from https://www.sandmeyersteel.com/304H.html
 // Taking median amount of some elements. Iron makes up the remainder.
@@ -125,6 +125,44 @@
 "elemprop":[
   0.0008, 0.0200,  0.0075,  0.1900, 0.0925,
   0.00045, 0.00030, 0.0010, 0.68745
+],
+}
+
+{
+"name": "MATERIAL",
+"index": "stainless_steel_304L",
+"run_range" : [0, 0],
+// Taken from https://www.sandmeyersteel.com/alloy-304-304l/
+// Taking median amount of some elements. Iron makes up the remainder.
+"density": 7.90,
+"nelements": 9,
+"nmaterials": 0,
+"elements": [
+  "Carbon",     "Manganese", "Silicon",  "Chromium", "Nickel",
+  "Phosphorus", "Sulphur",   "Nitrogen", "Iron"
+],
+"elemprop":[
+  0.00030, 0.0200,  0.0075, 0.1900, 0.1000,
+  0.00045, 0.00030, 0.0010, 0.68045
+],
+}
+
+{
+"name": "MATERIAL",
+"index": "stainless_steel_316",
+"run_range" : [0, 0],
+// Taken from https://www.sandmeyersteel.com/alloy-316-316l/
+// Taking median amount of some elements. Iron makes up the remainder.
+"density": 7.90,
+"nelements": 10,
+"nmaterials": 0,
+"elements": [
+  "Carbon",     "Manganese",  "Silicon", "Chromium", "Nickel",
+  "Molybdenum", "Phosphorus", "Sulphur", "Nitrogen", "Iron"
+],
+"elemprop":[
+  0.0008, 0.0200,  0.0075, 0.1700, 0.1200,
+  0.0250, 0.00045, 0.0003, 0.001,  0.65495
 ],
 }
 

--- a/ratdb/OPTICS.ratdb
+++ b/ratdb/OPTICS.ratdb
@@ -131,6 +131,48 @@
 // Assuming austenitic stainless (832MV on Figure) and assuming constant reflectivity below 200nm (limit of plot) to 140nm (arbitrary wavelength)
 // then assuming a linear decrease to zero by 120nm.
 "name": "OPTICS",
+"index": "stainless_steel_304L",
+"run_range" : [0, 0],
+"surface": 1,
+"finish": "ground",
+"model": "glisur",
+"type": "dielectric_metal",
+"polish": 0.1,
+"REFLECTIVITY_option": "wavelength",
+"REFLECTIVITY_value1": [60.0, 120.0, 140.0,   200.0,  300.0,  400.0,   600.0,  800.0,  ],
+"REFLECTIVITY_value2": [0.0, 0.0, 0.35, 0.35, 0.45, 0.55,  0.65, 0.67, ],
+"ABSLENGTH_option": "wavelength",
+"ABSLENGTH_value1": [60.0,  800.0, ],
+"ABSLENGTH_value2": [1.0, 1.0, ],
+"PROPERTY_LIST": ["REFLECTIVITY", "ABSLENGTH", ]
+}
+
+{
+// Reflectance data taken from Figure 1 of Karlsson and Ribbing, J. Appl. Phys. Vol 53. No. 9 Sept. 1982
+// Assuming austenitic stainless (832MV on Figure) and assuming constant reflectivity below 200nm (limit of plot) to 140nm (arbitrary wavelength)
+// then assuming a linear decrease to zero by 120nm.
+"name": "OPTICS",
+"index": "stainless_steel_316",
+"run_range" : [0, 0],
+"surface": 1,
+"finish": "ground",
+"model": "glisur",
+"type": "dielectric_metal",
+"polish": 0.1,
+"REFLECTIVITY_option": "wavelength",
+"REFLECTIVITY_value1": [60.0, 120.0, 140.0,   200.0,  300.0,  400.0,   600.0,  800.0,  ],
+"REFLECTIVITY_value2": [0.0, 0.0, 0.35, 0.35, 0.45, 0.55,  0.65, 0.67, ],
+"ABSLENGTH_option": "wavelength",
+"ABSLENGTH_value1": [60.0,  800.0, ],
+"ABSLENGTH_value2": [1.0, 1.0, ],
+"PROPERTY_LIST": ["REFLECTIVITY", "ABSLENGTH", ]
+}
+
+{
+// Reflectance data taken from Figure 1 of Karlsson and Ribbing, J. Appl. Phys. Vol 53. No. 9 Sept. 1982
+// Assuming austenitic stainless (832MV on Figure) and assuming constant reflectivity below 200nm (limit of plot) to 140nm (arbitrary wavelength)
+// then assuming a linear decrease to zero by 120nm.
+"name": "OPTICS",
 "index": "stainless_steel_316L",
 "run_range" : [0, 0],
 "surface": 1,


### PR DESCRIPTION
Adds two more common stainless steels and fixes an apparent typo in the "stainless_steel" definition, which could have a broad impact on users.