### PR TITLE
Update to Geant4 v11.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ find_package(ROOT CONFIG REQUIRED COMPONENTS Minuit2 ROOTTPython MathMore)
 endif()
 include(${ROOT_USE_FILE})
 
-find_package(Geant4 REQUIRED)
+find_package(Geant4 11.4 REQUIRED)
 find_package(Geant4 QUIET OPTIONAL_COMPONENTS qt)
 include(${Geant4_USE_FILE})
 include_directories(${Geant4_INCLUDE_DIRS})

--- a/src/core/src/GLG4VisManager.cc
+++ b/src/core/src/GLG4VisManager.cc
@@ -21,7 +21,6 @@
 // Not needing external packages or libraries...
 #include "G4ASCIITree.hh"
 #include "G4DAWNFILE.hh"
-#include "G4HepRepFile.hh"
 #include "G4HitFilterFactories.hh"
 #ifdef G4VIS_USE_QT
 #include "G4OpenGLImmediateQt.hh"
@@ -82,7 +81,6 @@ void GLG4VisManager::RegisterGraphicsSystems() {
   // Graphics Systems not needing external packages or libraries...
   RegisterGraphicsSystem(new G4ASCIITree);
   RegisterGraphicsSystem(new G4DAWNFILE);
-  RegisterGraphicsSystem(new G4HepRepFile);
   RegisterGraphicsSystem(new G4RayTracer);
   RegisterGraphicsSystem(new G4VRML2File);
 #ifdef G4VIS_USE_QT


### PR DESCRIPTION
Note that heprep visualization is removed in this build.

To quote Geant4's [release note](https://geant4.web.cern.ch/download/release-notes/notes-v11.4.0.html):
```
Removed HepRepFile and Qt3D visualisation drivers, no longer viable to develop and maintain.
```