### PR TITLE
Fit valid flag for waveform analyzers

### DIFF
--- a/doc/users_guide/outputs.rst
+++ b/doc/users_guide/outputs.rst
@@ -180,6 +180,7 @@ If ``include_digitizerfits`` is set then we additionally add the following infor
 ``fit_time_+{fitter_name}``             vector<double>       The time extracted from each PMT waveform fit.
 ``fit_charge_+{fitter_name}``           vector<double>       The charge extracted from each PMT waveform fit.
 ``fit_FOM_+{fitter_name}_+{fom_name}``  vector<double>       The figure of merit extracted from each PMT waveform fit.
+``fit_valid_+{fitter_name}``            vector<bool>         Per-PMT flag (parallel to ``digitPMTID``) indicating whether the named fitter produced a valid result for that PMT. ``false`` when the fitter did not run on that PMT or its analysis reported no extracted PEs.
 ======================================  ===================  ===================
 
 If ``include_nestedtubehits`` is set then we additionally add the following information to the ``output`` branch of the ntuple. These "nested tubes" are intended for use with liquid-O style fiber optics detectors. These are filled from the ``DS::MCNestedTube`` branch.

--- a/doc/users_guide/waveform_analysis.rst
+++ b/doc/users_guide/waveform_analysis.rst
@@ -276,6 +276,8 @@ Key features of the ``WaveformAnalysisResult`` include:
 
 **Time Offset Handling**: The class supports time offset corrections to account for cable delays or trigger timing, which can be applied when retrieving results without affecting the stored raw timing.
 
+**Fit Validity Flag**: Each ``WaveformAnalysisResult`` carries a ``fit_valid`` flag, accessed via ``getFitValid()`` and ``setFitValid()``. ``AddPE()`` automatically sets it to ``true``, so any analyzer that extracts at least one PE produces a valid result. Analyzers that may legitimately produce empty results should explicitly initialize the flag to ``false`` so downstream consumers — such as fitters reading hits through ``FitterInputHandler::IsHitValid()`` — can skip PMTs without a usable analysis. For backward compatibility, results read from older ROOT files (schema version <3) are reported as valid whenever the times array is non-empty.
+
 The ``WaveformAnalysisResult`` objects are accessed from the ``DigitPMT`` using the method name as a key::
 
     DS::WaveformAnalysisResult* lognormal_result = digitpmt->GetOrCreateWaveformAnalysisResult("Lognormal");

--- a/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
+++ b/src/ds/include/RAT/DS/WaveformAnalysisResult.hh
@@ -36,6 +36,7 @@ class WaveformAnalysisResult : public TObject {
       std::vector<Double_t>& fom_array = figures_of_merit[kv.first];
       fom_array.insert(fom_array.begin() + insertion_index, kv.second);
     }
+    fit_valid = true;
     return insertion_index;
   }
   virtual void setTimeOffset(Double_t _offset) { time_offset = _offset; }
@@ -47,7 +48,13 @@ class WaveformAnalysisResult : public TObject {
 
   virtual const std::vector<Double_t>& getTimes() { return times; }
   virtual const std::vector<Double_t>& getCharges() { return charges; }
-  ClassDef(WaveformAnalysisResult, 2);
+
+  virtual void setFitValid(Bool_t v) { fit_valid = v; }
+  // The `|| !times.empty()` clause keeps older ROOT files readable: pre-v3 results
+  // serialize fit_valid as default-false, but a non-empty PE vector still implies validity.
+  virtual Bool_t getFitValid() const { return fit_valid || !times.empty(); }
+
+  ClassDef(WaveformAnalysisResult, 3);
 
  protected:
   // All arrays are parallel arrays. It is assumed that they are sorted in time
@@ -55,6 +62,7 @@ class WaveformAnalysisResult : public TObject {
   std::vector<Double_t> charges;
   std::map<std::string, std::vector<Double_t>> figures_of_merit;
   Double_t time_offset;
+  Bool_t fit_valid = false;
 };
 
 }  // namespace DS

--- a/src/fit/include/RAT/FitterInputHandler.hh
+++ b/src/fit/include/RAT/FitterInputHandler.hh
@@ -372,6 +372,22 @@ class FitterInputHandler {
     }
   }
 
+  /**
+   * @brief Check whether the configured waveform analyzer produced a valid result for a PMT.
+   *
+   * In kWaveformAnalysis mode, returns the analyzer's fit_valid flag — false for empty results
+   * (e.g. RAVEN finding no threshold crossings) so callers can skip them safely. In kPMT and
+   * kDigitPMT modes the hit list itself is the validity filter, so this always returns true.
+   *
+   * @param id PMT ID.
+   */
+  bool IsHitValid(Int_t id) const {
+    if (mode != Mode::kWaveformAnalysis) return true;
+    if (!ev) return false;
+    DS::DigitPMT* digitpmt = ev->GetOrCreateDigitPMT(id);
+    return digitpmt->GetOrCreateWaveformAnalysisResult(wfm_ana_name)->getFitValid();
+  }
+
  protected:
   DS::EV* ev = nullptr;
   std::vector<Int_t> hitPMTChannels;

--- a/src/fit/include/RAT/FitterInputHandler.hh
+++ b/src/fit/include/RAT/FitterInputHandler.hh
@@ -375,9 +375,8 @@ class FitterInputHandler {
   /**
    * @brief Check whether the configured waveform analyzer produced a valid result for a PMT.
    *
-   * In kWaveformAnalysis mode, returns the analyzer's fit_valid flag — false for empty results
-   * (e.g. RAVEN finding no threshold crossings) so callers can skip them safely. In kPMT and
-   * kDigitPMT modes the hit list itself is the validity filter, so this always returns true.
+   * Only meaningful in kWaveformAnalysis mode; other modes filter via the hit list and
+   * always return true.
    *
    * @param id PMT ID.
    */

--- a/src/fit/mimir/include/mimir/Cost.hh
+++ b/src/fit/mimir/include/mimir/Cost.hh
@@ -21,6 +21,7 @@ class Cost {
   virtual void AddAllHits(const RAT::FitterInputHandler& input_handler) {
     std::vector<int> pmtids = input_handler.GetAllHitPMTIDs();
     for (int pmtid : pmtids) {
+      if (!input_handler.IsHitValid(pmtid)) continue;
       AddHit(pmtid, input_handler);
     }
   }

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -211,8 +211,7 @@ class OutNtupleProc : public Processor {
   std::map<std::string, std::vector<double>> wfmFitTime;
   std::map<std::string, std::vector<double>> wfmFitCharge;
   std::map<std::string, std::map<std::string, std::vector<double>>> wfmFitFOM;
-  // Per-PMT fit validity, parallel to digitPMTID. False when the fitter did not run on a PMT
-  // or its WaveformAnalysisResult reports an invalid fit.
+  // Per-PMT fit validity, parallel to digitPMTID.
   std::map<std::string, std::vector<bool>> wfmFitValid;
   // Tracking
   std::map<std::string, int> processCodeMap;

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -211,6 +211,9 @@ class OutNtupleProc : public Processor {
   std::map<std::string, std::vector<double>> wfmFitTime;
   std::map<std::string, std::vector<double>> wfmFitCharge;
   std::map<std::string, std::map<std::string, std::vector<double>>> wfmFitFOM;
+  // Per-PMT fit validity, parallel to digitPMTID. False when the fitter did not run on a PMT
+  // or its WaveformAnalysisResult reports an invalid fit.
+  std::map<std::string, std::vector<bool>> wfmFitValid;
   // Tracking
   std::map<std::string, int> processCodeMap;
   std::vector<int> processCodeIndex;

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -217,6 +217,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
       outputTree->Branch(TString("fit_pmtid_" + fitter_name), &wfmFitPmtID[fitter_name]);
       outputTree->Branch(TString("fit_time_" + fitter_name), &wfmFitTime[fitter_name]);
       outputTree->Branch(TString("fit_charge_" + fitter_name), &wfmFitCharge[fitter_name]);
+      outputTree->Branch(TString("fit_valid_" + fitter_name), &wfmFitValid[fitter_name]);
       for (const std::string &fom_name : waveform_fitter_FOMs[fitter_name]) {
         outputTree->Branch(TString("fit_FOM_" + fitter_name + "_" + fom_name), &wfmFitFOM[fitter_name][fom_name]);
       }
@@ -613,6 +614,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
           wfmFitPmtID[fitter_name].clear();
           wfmFitTime[fitter_name].clear();
           wfmFitCharge[fitter_name].clear();
+          wfmFitValid[fitter_name].clear();
           for (const std::string &fom_name : waveform_fitter_FOMs[fitter_name]) {
             wfmFitFOM[fitter_name][fom_name].clear();
           }
@@ -632,9 +634,16 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
         digitPeak.push_back(digitpmt->GetPeakVoltage());
         digitLocalTriggerTime.push_back(digitpmt->GetLocalTriggerTime());
         if (options.digitizerfits) {
-          const std::vector<std::string> fitters = digitpmt->GetFitterNames();
-          for (std::string fitter_name : fitters) {
+          const std::vector<std::string> ran_fitter_names = digitpmt->GetFitterNames();
+          std::set<std::string> ran_fitters(ran_fitter_names.begin(), ran_fitter_names.end());
+          for (const std::string &fitter_name : waveform_fitters) {
+            if (!ran_fitters.count(fitter_name)) {
+              // Fitter never ran on this PMT — record invalid, leave per-PE arrays untouched.
+              wfmFitValid[fitter_name].push_back(false);
+              continue;
+            }
             DS::WaveformAnalysisResult *fit_result = digitpmt->GetOrCreateWaveformAnalysisResult(fitter_name);
+            wfmFitValid[fitter_name].push_back(fit_result->getFitValid());
             for (int hitidx = 0; hitidx < fit_result->getNPEs(); hitidx++) {
               wfmFitPmtID[fitter_name].push_back(digitpmt->GetID());
               wfmFitTime[fitter_name].push_back(fit_result->getTime(hitidx));
@@ -719,6 +728,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
           wfmFitPmtID[fitter_name].clear();
           wfmFitTime[fitter_name].clear();
           wfmFitCharge[fitter_name].clear();
+          wfmFitValid[fitter_name].clear();
           for (const std::string &fom_name : waveform_fitter_FOMs[fitter_name]) {
             wfmFitFOM[fitter_name][fom_name].clear();
           }


### PR DESCRIPTION
Add a fit valid flag for waveform analyzers that is false if the analyzer is not run or does not fit a PE to a DigitPMT. Prevents crashes when event reconstruction algorithms are run in waveform analyzer mode.