### PR TITLE
Add warning to log when total charge threshold is exceeded

### DIFF
--- a/src/daq/include/RAT/WaveformAnalyzerBase.hh
+++ b/src/daq/include/RAT/WaveformAnalyzerBase.hh
@@ -127,7 +127,8 @@ class WaveformAnalyzerBase : public Processor {
   double fMinTotalCharge = std::numeric_limits<double>::lowest();
   double fMaxTotalCharge = std::numeric_limits<double>::max();
 
-  // Whether the out-of-range charge message has already been printed for the current event. Reset in Event().
+  // Whether the out-of-range charge message has already been printed at info level for the current event.
+  // Reset in Event().
   bool fChargeRangeReported = false;
 };
 

--- a/src/daq/include/RAT/WaveformAnalyzerBase.hh
+++ b/src/daq/include/RAT/WaveformAnalyzerBase.hh
@@ -126,6 +126,9 @@ class WaveformAnalyzerBase : public Processor {
   // Charge thresholds: skip analysis if digitized total charge is outside [fMinTotalCharge, fMaxTotalCharge] (pC).
   double fMinTotalCharge = std::numeric_limits<double>::lowest();
   double fMaxTotalCharge = std::numeric_limits<double>::max();
+
+  // Whether the out-of-range charge message has already been printed for the current event. Reset in Event().
+  bool fChargeRangeReported = false;
 };
 
 }  // namespace RAT

--- a/src/daq/src/WaveformAnalyzerBase.cc
+++ b/src/daq/src/WaveformAnalyzerBase.cc
@@ -31,7 +31,11 @@ void WaveformAnalyzerBase::RunAnalysis(DS::DigitPMT* digitpmt, int pmtID, DS::Di
   digitpmt->GetOrCreateWaveformAnalysisResult(GetAnalyzerName());
 
   double totalCharge = digitpmt->GetDigitizedTotalCharge();
-  if (totalCharge < fMinTotalCharge || totalCharge > fMaxTotalCharge) return;
+  if (totalCharge < fMinTotalCharge || totalCharge > fMaxTotalCharge) {
+    warn << "Total charge " << totalCharge << " is outside of the allowed range [" << fMinTotalCharge << ", "
+         << fMaxTotalCharge << "]. Skipping waveform analysis for PMT " << pmtID << "." << newline;
+    return;
+  }
 
   fVoltageRes = dsdigit->GetVoltageResolution();
   fTimeStep = dsdigit->GetTimeStepNS();

--- a/src/daq/src/WaveformAnalyzerBase.cc
+++ b/src/daq/src/WaveformAnalyzerBase.cc
@@ -32,8 +32,12 @@ void WaveformAnalyzerBase::RunAnalysis(DS::DigitPMT* digitpmt, int pmtID, DS::Di
 
   double totalCharge = digitpmt->GetDigitizedTotalCharge();
   if (totalCharge < fMinTotalCharge || totalCharge > fMaxTotalCharge) {
-    warn << "Total charge " << totalCharge << " is outside of the allowed range [" << fMinTotalCharge << ", "
-         << fMaxTotalCharge << "]. Skipping waveform analysis for PMT " << pmtID << "." << newline;
+    if (!fChargeRangeReported) {
+      info << "Total charge " << totalCharge << " is outside of the allowed range [" << fMinTotalCharge << ", "
+           << fMaxTotalCharge << "]. Skipping waveform analysis for PMT " << pmtID
+           << ". Further out-of-range PMTs in this event will not be reported." << newline;
+      fChargeRangeReported = true;
+    }
     return;
   }
 
@@ -45,6 +49,7 @@ void WaveformAnalyzerBase::RunAnalysis(DS::DigitPMT* digitpmt, int pmtID, DS::Di
 }
 
 Processor::Result WaveformAnalyzerBase::Event(DS::Root* ds, DS::EV* ev) {
+  fChargeRangeReported = false;
   if (!ev->DigitizerExists()) {
     warn << "Running waveform analysis, but no digitzer information." << newline;
     return Processor::Result::OK;

--- a/src/daq/src/WaveformAnalyzerBase.cc
+++ b/src/daq/src/WaveformAnalyzerBase.cc
@@ -1,5 +1,7 @@
 #include "RAT/WaveformAnalyzerBase.hh"
 
+#include <sstream>
+
 #include "RAT/DS/DigitPMT.hh"
 #include "RAT/DS/RunStore.hh"
 
@@ -32,11 +34,15 @@ void WaveformAnalyzerBase::RunAnalysis(DS::DigitPMT* digitpmt, int pmtID, DS::Di
 
   double totalCharge = digitpmt->GetDigitizedTotalCharge();
   if (totalCharge < fMinTotalCharge || totalCharge > fMaxTotalCharge) {
+    // Only the first out-of-range PMT of an event is announced at info level, the rest are demoted to debug.
+    std::ostringstream msg;
+    msg << "Total charge " << totalCharge << " is outside of the allowed range [" << fMinTotalCharge << ", "
+        << fMaxTotalCharge << "]. Skipping waveform analysis for PMT " << pmtID << ".";
     if (!fChargeRangeReported) {
-      info << "Total charge " << totalCharge << " is outside of the allowed range [" << fMinTotalCharge << ", "
-           << fMaxTotalCharge << "]. Skipping waveform analysis for PMT " << pmtID
-           << ". Further out-of-range PMTs in this event will not be reported." << newline;
+      info << msg.str() << " Further out-of-range PMTs in this event will only be reported at debug level." << newline;
       fChargeRangeReported = true;
+    } else {
+      debug << msg.str() << newline;
     }
     return;
   }


### PR DESCRIPTION
Add warning to log when a waveform analyzer doesn't reconstruct due to the total charge on a PMT exceeding the set threshold.