### PR TITLE
Throw FatalError from Log::Die instead of std::exit

### DIFF
--- a/src/core/include/RAT/FatalError.hh
+++ b/src/core/include/RAT/FatalError.hh
@@ -1,0 +1,27 @@
+/** @class FatalError
+ *  Exception thrown by Log::Die() and a failed Log::Assert().
+ *
+ *  Throwing (rather than calling std::exit) lets the C++ stack unwind so
+ *  destructors run, and allows a hosting interpreter such as ROOT's Cling
+ *  to catch the error and return to its prompt instead of killing the
+ *  interactive session.  Batch executables should catch this in main() and
+ *  return @c return_code so the process exit code is preserved.
+ */
+
+#ifndef __RAT_FatalError__
+#define __RAT_FatalError__
+
+#include <stdexcept>
+#include <string>
+
+namespace RAT {
+
+class FatalError : public std::runtime_error {
+ public:
+  FatalError(const std::string &message, int return_code = 1) : std::runtime_error(message), return_code(return_code) {}
+  int return_code; /**< Exit code originally passed to Die()/Assert(). */
+};
+
+}  // namespace RAT
+
+#endif

--- a/src/core/include/RAT/Log.hh
+++ b/src/core/include/RAT/Log.hh
@@ -80,6 +80,7 @@ Log::Die("Could not open " + filename + " for input.");
 #include <TObjString.h>
 #include <TObject.h>
 
+#include <RAT/FatalError.hh>
 #include <RAT/json.hh>
 #include <sstream>
 #include <string>
@@ -126,13 +127,14 @@ class Log {
   /** Set verbosity level for writing to log file. */
   static void SetLogLevel(Level level);
 
-  /** Write @p message to @p warn stream and immediately terminate,
-      sending @p return_code back to OS. */
+  /** Write @p message to @p warn stream and throw a FatalError carrying
+      @p return_code.  Batch executables catch this in main() and return
+      @p return_code to the OS; an interpreter such as ROOT's Cling catches it
+      and returns to its prompt. */
   [[noreturn]] static void Die(std::string message, int return_code = 1);
 
-  /** Write @p message to @p warn stream and immediately terminate if @condition
-      is not true.  @p return_code is returned to the OS to signal job failure
-   */
+  /** Write @p message to @p warn stream and throw a FatalError if @p condition
+      is not true.  @p return_code is propagated to signal job failure. */
   static void Assert(bool condition, std::string message, int return_code = 1);
 
   /** Return reference to string containing entire log from this session */

--- a/src/core/src/Log.cc
+++ b/src/core/src/Log.cc
@@ -89,14 +89,11 @@ void Log::SetLogLevel(Level level) {
 
 void Log::Die(std::string message, int return_code) {
   warn << message << newline;
-  std::exit(return_code);
+  throw FatalError(message, return_code);
 }
 
 void Log::Assert(bool condition, std::string message, int return_code) {
-  if (!condition) {
-    warn << message << newline;
-    std::exit(return_code);
-  }
+  if (!condition) Die(message, return_code);
 }
 
 void Log::SetupIO() {

--- a/tools/ntuple/ntuple.cpp
+++ b/tools/ntuple/ntuple.cpp
@@ -4,13 +4,14 @@
 #include <RAT/AnyParse.hh>
 #include <RAT/DB.hh>
 #include <RAT/DBTable.hh>
+#include <RAT/FatalError.hh>
 #include <RAT/Log.hh>
 #include <RAT/OutNtupleProc.hh>
 #include <fstream>
 #include <iostream>
 #include <string>
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv) try {
   auto parser = new RAT::AnyParse(argc, argv);
   parser->SetHelpLine("[options] inputfile.root");
   parser->AddArgument("verbose", false, "v", 0, "Verbosity", RAT::ParseInt);
@@ -54,4 +55,8 @@ int main(int argc, char **argv) {
       proc.DSEvent(ds);
     }
   }
+  return 0;
+} catch (const RAT::FatalError &e) {
+  // Message has already been logged by Log::Die(); just propagate the code.
+  return e.return_code;
 }

--- a/tools/rat/rat.cpp
+++ b/tools/rat/rat.cpp
@@ -1,11 +1,18 @@
 #include <RAT/AnyParse.hh>
+#include <RAT/FatalError.hh>
 #include <RAT/Rat.hh>
 
 int main(int argc, char **argv) {
-  auto parser = new RAT::AnyParse(argc, argv);
-  // Additional experiment arguments
-  auto experiment = RAT::Rat(parser, argc, argv);
-  // Run experiment
-  experiment.Begin();
-  experiment.Report();
+  try {
+    auto parser = new RAT::AnyParse(argc, argv);
+    // Additional experiment arguments
+    auto experiment = RAT::Rat(parser, argc, argv);
+    // Run experiment
+    experiment.Begin();
+    experiment.Report();
+  } catch (const RAT::FatalError &e) {
+    // Message has already been logged by Log::Die(); just propagate the code.
+    return e.return_code;
+  }
+  return 0;
 }

--- a/tools/ratdb2json/ratdb2json.cpp
+++ b/tools/ratdb2json/ratdb2json.cpp
@@ -1,11 +1,12 @@
 #include <RAT/AnyParse.hh>
 #include <RAT/DB.hh>
 #include <RAT/DBTable.hh>
+#include <RAT/FatalError.hh>
 #include <fstream>
 #include <iostream>
 #include <string>
 
-int main(int argc, char **argv) {
+int main(int argc, char **argv) try {
   auto parser = new RAT::AnyParse(argc, argv);
   parser->SetHelpLine("[options] inputfile.ratdb");
   parser->AddArgument("output", "", "o", 1, "Output json file", RAT::ParseString);
@@ -41,4 +42,8 @@ int main(int argc, char **argv) {
     json::Writer writer(std::cout);
     writer.putValue(jsontable);
   }
+  return 0;
+} catch (const RAT::FatalError &e) {
+  // Message has already been logged by Log::Die(); just propagate the code.
+  return e.return_code;
 }


### PR DESCRIPTION
Log::Die() and a failed Log::Assert() now throw a RAT::FatalError carrying the return code rather than calling std::exit(). This allows the ROOT interpreter to stay alive when `Log::Die` is triggered.