### PR TITLE
Ratdb snapshot

### DIFF
--- a/doc/users_guide/outputs.rst
+++ b/doc/users_guide/outputs.rst
@@ -21,6 +21,15 @@ Parameters:
 
 * filename (required, string) Sets output filename.  File will be deleted if it already exists.
 
+The output file is meant to be a full representation of the RAT data structure, and can be re-introduced back into RAT for further processing via the InROOT processor. The file contains several objects:
+
+* ``log``: The RAT log messages as emitted during the processing of this file.
+* ``macro``: Content of the RAT macro used to generate this file.
+* `db`: A JSON representation of the state of the RATDB database at the time of processing this file. The recorded RATDB state is scoped to the run that these events are processed with.
+* `obj`: A directory of arbitrary objects that were added by a processor.
+* `runT`: A TTree object containing a DS::Run object for the run processed.
+* `T`: A TTree obejct containing DS::Root object for each event processed.
+
 .. _outntuple:
 
 outntuple

--- a/src/db/include/RAT/DB.hh
+++ b/src/db/include/RAT/DB.hh
@@ -87,6 +87,7 @@ double rindex = lmedia->GetD("index_of_refraction");
 #include <RAT/HTTPDownloader.hh>
 #include <RAT/Log.hh>
 #include <deque>
+#include <limits>
 #include <list>
 #include <map>
 #include <set>
@@ -268,10 +269,18 @@ class DB : public DBFieldCallback {
   void SetArrayIndex(const std::string &tblname, const std::string &index, const std::string &fieldname, size_t idx,
                      const T &val);
 
-  /** Dump all tables in the db to a JSON file.
+  /** Sentinel for DumpContentsToJson's run argument: use the current default
+   *  run (GetDefaultRun()), as rat would when no run is given by hand. */
+  static constexpr int kUseDefaultRun = std::numeric_limits<int>::min();
+
+  /** Dump the effective database as seen at @p run: exactly one table per
+   *  (name, index), with each field holding the value that run would read out
+   *  (user plane overrides run plane overrides default plane). Tables are
+   *  emitted on the default plane so they resolve for any run on read-back.
+   *  When @p run is left at the default, GetDefaultRun() is used.
    * @todo: Currently doesn't support server tables
    * */
-  void DumpContentsToJson(std::ostream &stream);
+  void DumpContentsToJson(std::ostream &stream, int run = kUseDefaultRun);
 
   /************************DBLink interface********************/
   // This is the low level interface that DBLinks use.

--- a/src/db/src/DB.cc
+++ b/src/db/src/DB.cc
@@ -466,24 +466,46 @@ std::vector<DBTable *> DB::ReadRATDBFile(const std::string &filename) {
   return contents;
 }
 
-void DB::DumpContentsToJson(std::ostream &stream) {
+void DB::DumpContentsToJson(std::ostream &stream, int run) {
+  // Default: dump the DB as seen at the current default run, like rat would
+  // when no run is given by hand.
+  if (run == kUseDefaultRun) run = GetDefaultRun();
+
   json::Writer writer(stream);
   stream << "[\n";
-  const DBTableSet &tables = GetAllTables();
+
+  // Collect the unique (name, index) identities present in the DB.
+  std::set<std::pair<std::string, std::string>> ids;
+  for (const auto &table : GetAllTables()) ids.insert({table.first.name, table.first.index});
+
   bool first = true;
-  for (auto table : tables) {
+  for (const auto &id : ids) {
+    const std::string &name = id.first;
+    const std::string &index = id.second;
+
+    // Merge the planes in increasing precedence so each field ends up holding
+    // the value `run` would read out: default < run-specific < user
+    // (mirrors DBLink::Get).
+    json::Value merged(json::TOBJECT);
+    DBTable *planes[] = {GetDefaultTable(name, index), GetRunTable(name, index, run), GetUserTable(name, index)};
+    bool found = false;
+    for (DBTable *tbl : planes) {
+      if (tbl == nullptr) continue;
+      found = true;
+      json::Value src = tbl->GetCompleteJSON();
+      for (const std::string &field : src.getMembers()) merged.setMember(field, src.getMember(field));
+    }
+    if (!found) continue;
+
+    // Stamp canonical identity and collapse onto the default plane so the
+    // table resolves for any run when the dump is reloaded.
+    merged.setMember("name", json::Value(name));
+    merged.setMember("index", json::Value(index));
+    merged.setMember("run_range", json::Value(std::vector<int>{0, 0}));
+
     if (!first) stream << ",\n";
     first = false;
-    // include key information in table if it is not already in there
-    table.second->Set("name", table.second->GetName());
-    table.second->Set("index", table.second->GetIndex());
-    if (table.second->UsesRunList()) {
-      table.second->Set("run_list", table.second->GetValidRuns());
-    } else {
-      std::vector<int> run_range = {table.second->GetRunBegin(), table.second->GetRunEnd()};
-      table.second->Set("run_range", run_range);
-    }
-    writer.putValue(table.second->GetCompleteJSON(), "");
+    writer.putValue(merged, "");
   }
   stream << "\n]\n";
 }

--- a/src/db/src/DBTable.cc
+++ b/src/db/src/DBTable.cc
@@ -98,19 +98,26 @@ DBTable::FieldType DBTable::GetFieldType(std::string name) const {
         return DBTable::STRING;
       case json::TARRAY:
         if (val.getArraySize() > 0) {
-          switch (val[0].getType()) {
-            case json::TINTEGER:
-            case json::TUINTEGER:
-              return DBTable::INTEGER_ARRAY;
-            case json::TBOOL:
-              return DBTable::BOOLEAN_ARRAY;
-            case json::TREAL:
-              return DBTable::DOUBLE_ARRAY;
-            case json::TSTRING:
-              return DBTable::STRING_ARRAY;
-            default:
-              return DBTable::JSON;
+          DBTable::FieldType result = DBTable::JSON;
+          for (size_t i = 0; i < val.getArraySize(); i++) {
+            json::Value curr_val = val[i];
+            switch (curr_val.getType()) {
+              case json::TINTEGER:
+              case json::TUINTEGER:
+                result = DBTable::INTEGER_ARRAY;
+                break;
+              case json::TBOOL:
+                if (result != DBTable::INTEGER_ARRAY) result = DBTable::BOOLEAN_ARRAY;
+                break;
+              case json::TREAL:
+                return DBTable::DOUBLE_ARRAY;
+              case json::TSTRING:
+                return DBTable::STRING_ARRAY;
+              default:
+                return DBTable::JSON;
+            }
           }
+          return result;
         }
         return DBTable::EMPTY_ARRAY;
       default:

--- a/src/db/src/json.cc
+++ b/src/db/src/json.cc
@@ -529,10 +529,28 @@ void Writer::writeValue(const Value &value, const std::string &depth) {
     case TUINTEGER:
       out << value.data.uinteger;
       break;
-    case TREAL:
-      out.precision(std::numeric_limits<double>::digits10);
-      out << value.data.real;
+    case TREAL: {
+      std::ostringstream realbuf;
+      realbuf.precision(std::numeric_limits<double>::digits10);
+      realbuf << value.data.real;
+      std::string realstr = realbuf.str();
+
+      // A whole-valued double prints as e.g. "1", which the parser reads back
+      // as an integer -- changing the RATDB field's type on round-trip. Test
+      // what the emitted text actually parses to, and if it is no longer a
+      // real, re-emit with a fixed decimal point to preserve the type.
+      Reader check(realstr);
+      Value parsed;
+      if (!check.getValue(parsed) || parsed.getType() != TREAL) {
+        std::ostringstream fixedbuf;
+        fixedbuf.setf(std::ios::fixed, std::ios::floatfield);
+        fixedbuf.precision(1);
+        fixedbuf << value.data.real;
+        realstr = fixedbuf.str();
+      }
+      out << realstr;
       break;
+    }
     case TSTRING:
       out << '"' << escapeString(*(value.data.string)) << '"';
       break;

--- a/src/geo/src/DetectorConstruction.cc
+++ b/src/geo/src/DetectorConstruction.cc
@@ -33,44 +33,54 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
   DB *db = DB::Get();
   DBLinkPtr ldetector = db->GetLink("DETECTOR");
   std::string experiment = "";
-
-  // Load experiment RATDB files before doing anything else
+  bool is_snapshot = false;
   try {
-    experiment = ldetector->GetS("experiment");
+    is_snapshot = (db->GetLink("DB")->GetZ("is_snapshot"));
   } catch (DBNotFoundError &e) {
-    info << "No experiment-specific tables loaded." << newline;
   }
-  info << "Loading experiment-specific RATDB files for: " << experiment << newline;
-  // Attempt to load literal experiments (absolute paths and/or experiments defined in local directory).
-  int result = db->LoadAll(experiment);
-  if (result == 2) {
-    info << "Found experiment files in " << experiment << newline;
+  if (is_snapshot) {
+    info << "DB snapshot detected; skipping RATDB loading. This should only happen when running analysis on existing "
+            "sim files!"
+         << newline;
   } else {
-    for (auto dir : Rat::ratdb_directories) {
-      std::string experimentDirectoryString = dir + "/" + experiment;
-      int result = db->LoadAll(experimentDirectoryString);
-      if (result == 2) {
-        info << "Found experiment files in " << experimentDirectoryString << newline;
-        break;
+    // Load experiment RATDB files before doing anything else
+    try {
+      experiment = ldetector->GetS("experiment");
+    } catch (DBNotFoundError &e) {
+      info << "No experiment-specific tables loaded." << newline;
+    }
+    info << "Loading experiment-specific RATDB files for: " << experiment << newline;
+    // Attempt to load literal experiments (absolute paths and/or experiments defined in local directory).
+    int result = db->LoadAll(experiment);
+    if (result == 2) {
+      info << "Found experiment files in " << experiment << newline;
+    } else {
+      for (auto dir : Rat::ratdb_directories) {
+        std::string experimentDirectoryString = dir + "/" + experiment;
+        int result = db->LoadAll(experimentDirectoryString);
+        if (result == 2) {
+          info << "Found experiment files in " << experimentDirectoryString << newline;
+          break;
+        }
       }
     }
-  }
 
-  try {
-    std::string detector_factory = ldetector->GetS("detector_factory");
-    info << "Loading detector factory " << detector_factory << newline;
-    DetectorFactory::DefineWithFactory(detector_factory, ldetector);
-  } catch (DBNotFoundError &e) {
-    info << "DetectorConstruction: could not access " << e.table << "[" << e.index << "]." << e.field << newline;
     try {
-      std::string geo_file = ldetector->GetS("geo_file");
-      info << "Loading detector geometry from " << geo_file << newline;
-      if (db->Load(geo_file) == 0) {
-        Log::Die("DetectorConstruction: Could not open detector geometry");
+      std::string detector_factory = ldetector->GetS("detector_factory");
+      info << "Loading detector factory " << detector_factory << newline;
+      DetectorFactory::DefineWithFactory(detector_factory, ldetector);
+    } catch (DBNotFoundError &e) {
+      info << "DetectorConstruction: could not access " << e.table << "[" << e.index << "]." << e.field << newline;
+      try {
+        std::string geo_file = ldetector->GetS("geo_file");
+        info << "Loading detector geometry from " << geo_file << newline;
+        if (db->Load(geo_file) == 0) {
+          Log::Die("DetectorConstruction: Could not open detector geometry");
+        }
+      } catch (DBNotFoundError &_e) {
+        info << "DetectorConstruction: could not access " << _e.table << "[" << _e.index << "]." << _e.field << newline;
+        Log::Die("DetectorConstruction: Could not open geo_file or detector_factory");
       }
-    } catch (DBNotFoundError &_e) {
-      info << "DetectorConstruction: could not access " << _e.table << "[" << _e.index << "]." << _e.field << newline;
-      Log::Die("DetectorConstruction: Could not open geo_file or detector_factory");
     }
   }
 

--- a/src/io/include/RAT/DSReader.hh
+++ b/src/io/include/RAT/DSReader.hh
@@ -5,6 +5,7 @@
 #include <TObject.h>
 #include <TTree.h>
 
+#include <RAT/DB.hh>
 #include <RAT/DS/Root.hh>
 #include <string>
 
@@ -15,6 +16,21 @@ class DSReader : public TObject {
  public:
   DSReader(const char *filename);
   virtual ~DSReader();
+
+  // Reconstruct the global RAT::DB from the snapshot embedded in this file by
+  // the outroot processor (the "ratdb" object). This restores the exact set of
+  // tables used to build the geometry during production -- no $RATSHARE or geo
+  // file needed. It is called automatically by the constructor so the DB is
+  // ready before event looping begins, but is exposed so it can be re-run.
+  // Returns the singleton DB instance.
+  RAT::DB *LoadDB();
+
+  // Construct and close the Geant4 detector geometry from the DB loaded by
+  // LoadDB(), mirroring `rat`'s /run/initialize. This wraps RAT's G4 machinery
+  // (DetectorConstruction, RunManager, PhysicsList) so no Geant4 types leak
+  // into ROOT. Call once, after construction, before using the geometry (e.g.
+  // the light-path calculator). Requires the libRATPAC library to be loaded.
+  void BuildGeometry();
 
   void Add(const char *filename);
   void SetBranchStatus(const char *bname, bool status = 1) { T.SetBranchStatus(bname, status); };

--- a/src/io/src/DSReader.cc
+++ b/src/io/src/DSReader.cc
@@ -1,13 +1,83 @@
+#include <TFile.h>
+#include <TObjString.h>
+
+#include <G4RunManager.hh>
+#include <G4StateManager.hh>
+#include <RAT/DB.hh>
+#include <RAT/DBJsonLoader.hh>
+#include <RAT/DBTable.hh>
 #include <RAT/DS/RootFactory.hh>
 #include <RAT/DSReader.hh>
+#include <RAT/DetectorConstruction.hh>
 #include <RAT/Log.hh>
+#include <RAT/PhysicsList.hh>
+#include <RAT/json.hh>
 #include <iostream>
 
 namespace RAT {
 
 #undef DEBUG
 
+DB *DSReader::LoadDB() {
+  DB *db = DB::Get();
+  db->Set("DB", "is_snapshot", true);
+
+  // The outroot processor stores the resolved DB as a JSON-array TObjString
+  // named "ratdb" in each output file (see OutROOTProc). Pull it from the
+  // first file of the chain.
+  if (total > 0) T.LoadTree(0);
+  TFile *file = T.GetCurrentFile();
+  if (file == nullptr) {
+    warn << "DSReader::LoadDB: no input file available; DB left untouched." << newline;
+    return db;
+  }
+
+  TObjString *snapshot = dynamic_cast<TObjString *>(file->Get("ratdb"));
+  if (snapshot == nullptr) {
+    warn << "DSReader::LoadDB: '" << file->GetName()
+         << "' has no embedded RATDB snapshot ('ratdb'); was it written by an older RAT?" << newline;
+    return db;
+  }
+
+  // DumpContentsToJson writes a JSON array of table objects, so unpack the
+  // array and feed each element through the normal RATDB load path.
+  json::Reader reader(snapshot->GetString().Data());
+  json::Value doc;
+  int nTables = 0;
+  if (reader.getValue(doc) && doc.getType() == json::TARRAY) {
+    for (size_t i = 0; i < doc.getArraySize(); i++) {
+      json::Value entry = doc.getIndex(i);
+      db->LoadTable(DBJsonLoader::convertTable(entry));
+      ++nTables;
+    }
+  } else {
+    warn << "DSReader::LoadDB: unexpected RATDB snapshot format in '" << file->GetName() << "'." << newline;
+  }
+
+  info << "DSReader::LoadDB: loaded " << nTables << " RATDB tables from " << file->GetName() << newline;
+  return db;
+}
+
+void DSReader::BuildGeometry() {
+  // The geometry tables come from the DB; LoadDB() runs in the constructor.
+  G4RunManager *runManager = G4RunManager::GetRunManager();
+  if (runManager != nullptr) {
+    warn << "DSReader::BuildGeometry: a G4RunManager already exists; geometry left untouched." << newline;
+    return;
+  }
+
+  // Mirror rat's /run/initialize: a run manager needs both a physics list and
+  // a detector construction before Initialize() builds and closes the geometry.
+  runManager = new G4RunManager;
+  runManager->SetUserInitialization(new PhysicsList());
+  runManager->SetUserInitialization(DetectorConstruction::GetDetectorConstruction());
+  runManager->Initialize();
+
+  info << "DSReader::BuildGeometry: detector geometry constructed and closed." << newline;
+}
+
 DSReader::DSReader(const char *filename) : T("T"), runT("runT") {
+  RAT::Log::Init("/dev/null");
   T.Add(filename);
 
   next = 0;
@@ -20,6 +90,9 @@ DSReader::DSReader(const char *filename) : T("T"), runT("runT") {
 
   ds = new DS::Root();
   T.SetBranchAddress("ds", &ds);
+
+  // Reconstruct the DB from this file's snapshot before any event looping.
+  LoadDB();
 }
 
 DSReader::~DSReader() { delete ds; }

--- a/src/io/src/OutROOTProc.cc
+++ b/src/io/src/OutROOTProc.cc
@@ -70,8 +70,12 @@ OutROOTProc::~OutROOTProc() {
     TObjString *macro = new TObjString(Log::GetMacro().c_str());
     macro->Write("macro");
 
-    TMap *dbtrace = Log::GetDBTraceMap();
-    dbtrace->Write("db", TObject::kSingleKey);
+    // Snapshot the full resolved RATDB so the geometry/materials can be
+    // reconstructed from this file alone (see DSReader::LoadDB).
+    std::ostringstream ratdb_dump;
+    DB::Get()->DumpContentsToJson(ratdb_dump);
+    TObjString *ratdb = new TObjString(ratdb_dump.str().c_str());
+    ratdb->Write("ratdb");
 
     // Save any objects that processors have logged
     f->mkdir("obj");


### PR DESCRIPTION
Create a full snapshot of RATDB in the outroot files. This allows the full runtime condition to be reconstructed. 

Stacked on top of #404 .