### PR TITLE
Automatically convert procset params

### DIFF
--- a/src/cmd/src/ProcBlockManager.cc
+++ b/src/cmd/src/ProcBlockManager.cc
@@ -202,10 +202,21 @@ void ProcBlockManager::DoProcSetCmd(std::string cmdstring) {
   try {
     switch (t.Next()) {
       case Tokenizer::TYPE_INTEGER:
-        lastProc->SetI(param, t.AsInt());
+        try {
+          lastProc->SetI(param, t.AsInt());
+        } catch (Processor::ParamUnknown &) {
+          // Check if you can set it as a double
+          lastProc->SetD(param, static_cast<double>(t.AsInt()));
+        }
         break;
       case Tokenizer::TYPE_DOUBLE:
-        lastProc->SetD(param, t.AsDouble());
+        try {
+          lastProc->SetD(param, t.AsDouble());
+        } catch (Processor::ParamUnknown &) {
+          // Check if it is actually an int parameter
+          lastProc->SetI(param, 1);
+          throw Processor::ParamInvalid(param, "is an integer parameter.");
+        }
         break;
       case Tokenizer::TYPE_STRING:
         lastProc->SetS(param, t.Token());

--- a/src/core/src/PythonProc.cc
+++ b/src/core/src/PythonProc.cc
@@ -55,6 +55,8 @@ void PythonProc::SetS(std::string param, std::string value) {
     TPython::Exec(cmd.c_str());
     // Update name of this processor to include Python class
     name = value;
+  } else {
+    throw Processor::ParamUnknown(param);
   }
 }
 

--- a/src/fit/mimir/src/FitMimirProc.cc
+++ b/src/fit/mimir/src/FitMimirProc.cc
@@ -31,6 +31,8 @@ void FitMimirProc::SetS(std::string param, std::string value) {
   if (param == "strategy") {
     DB::ParseTableName(value, strategyName, strategyConfig);
     configured = true;
+  } else {
+    throw Processor::ParamUnknown(param);
   }
 }
 

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -876,36 +876,32 @@ void OutNtupleProc::EndOfRun(DS::Run *run) {
 void OutNtupleProc::SetS(std::string param, std::string value) {
   if (param == "file") {
     this->defaultFilename = value;
+  } else {
+    throw Processor::ParamUnknown(param);
   }
 }
 
 void OutNtupleProc::SetI(std::string param, int value) {
   if (param == "include_tracking") {
     options.tracking = value ? true : false;
-  }
-  if (param == "include_mcparticles") {
+  } else if (param == "include_mcparticles") {
     options.mcparticles = value ? true : false;
-  }
-  if (param == "include_pmthits") {
+  } else if (param == "include_pmthits") {
     options.pmthits = value ? true : false;
-  }
-  if (param == "include_nestedtubehits") {
+  } else if (param == "include_nestedtubehits") {
     options.nthits = value ? true : false;
-  }
-  if (param == "include_untriggered_events") {
+  } else if (param == "include_untriggered_events") {
     options.untriggered = value ? true : false;
-  }
-  if (param == "include_mchits") {
+  } else if (param == "include_mchits") {
     options.mchits = value ? true : false;
-  }
-  if (param == "include_digitizerwaveforms") {
+  } else if (param == "include_digitizerwaveforms") {
     options.digitizerwaveforms = value ? true : false;
-  }
-  if (param == "include_digitizerhits") {
+  } else if (param == "include_digitizerhits") {
     options.digitizerhits = value ? true : false;
-  }
-  if (param == "include_digitizerfits") {
+  } else if (param == "include_digitizerfits") {
     options.digitizerfits = value ? true : false;
+  } else {
+    throw Processor::ParamUnknown(param);
   }
 }
 

--- a/src/io/src/OutROOTProc.cc
+++ b/src/io/src/OutROOTProc.cc
@@ -115,6 +115,8 @@ void OutROOTProc::SetS(std::string param, std::string value) {
     if (!OpenFile(value, false)) Log::Die("outroot: Cannot open file " + value);
   } else if (param == "updatefile") {
     if (!OpenFile(value, true)) Log::Die("outroot: Cannot open file " + value);
+  } else {
+    throw Processor::ParamUnknown(param);
   }
 }
 
@@ -130,6 +132,8 @@ void OutROOTProc::SetI(std::string param, int value) {
       savetree = false;
       info << "outroot: Not writing event tree!\n";
     }
+  } else {
+    throw Processor::ParamUnknown(param);
   }
 }
 


### PR DESCRIPTION
When setting a parameter using procset, ratpac decides the type from how you write the value, so 4250 is an int, and 4250.0 is a double. This can cause a parameter unknown error when the parameter is just the wrong type. For example, when using quadfitter, /rat/procset max_radius 4250 fails, but /rat/procset max_radius 4250.0 works.

This pull request changes it to automatically convert the parameter when you input an int for a double, and to throw an error when you input a double for an int.

Also, a few processors did not throw a parameter unknown error when given an unknown parameter, so that has been added. Note that this means an existing macro with an unknown parameter for these processors will now fail instead of doing nothing with the parameter.