### PR TITLE
Add triggerSumPeak to SplitEVDAQProc and OutNtupleProc

### DIFF
--- a/doc/users_guide/outputs.rst
+++ b/doc/users_guide/outputs.rst
@@ -136,6 +136,7 @@ The data-structure for the ``output`` tree is as follows. First, the "default" v
 ``nhits``                    int                  The total number of PMTs that detected light in the detector event.
 ``triggerTime``              double               The trigger time of the detector event, relative to the start of the simulation.
 ``timestamp``                double               The UTC time of the detector event.
+``triggerSumPeak``           double               The peak value of the trigger sum in units of hits (0 if not produced by the DAQ processor).
 ``timeSinceLastTrigger_us``  double               The time since the last triggered event, in microseconds. 
 ``event_cleaning_word``      ulong64              The list of event cleaning cuts that failed.
 ===========================  ===================  ===================

--- a/doc/users_guide/outputs.rst
+++ b/doc/users_guide/outputs.rst
@@ -136,7 +136,7 @@ The data-structure for the ``output`` tree is as follows. First, the "default" v
 ``nhits``                    int                  The total number of PMTs that detected light in the detector event.
 ``triggerTime``              double               The trigger time of the detector event, relative to the start of the simulation.
 ``timestamp``                double               The UTC time of the detector event.
-``triggerSumPeak``           double               The peak value of the trigger sum in units of hits (0 if not produced by the DAQ processor).
+``triggerPeak``              double               The peak value of the trigger sum in units of hits (0 if not produced by the DAQ processor).
 ``timeSinceLastTrigger_us``  double               The time since the last triggered event, in microseconds. 
 ``event_cleaning_word``      ulong64              The list of event cleaning cuts that failed.
 ===========================  ===================  ===================

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -139,6 +139,16 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
     ev->SetUTC(mc->GetUTC());
     ev->SetDeltaT(tt - lastTrigger);
     lastTrigger = tt;
+
+    // Find the peak of the trigger sum (in units of hits) over the same time window used for hits
+    double windowLo = tt - fLookback;
+    double windowHi = tt + fTriggerWindow;
+    int binLo = std::max(0, static_cast<int>(std::ceil((windowLo - start) / bw)));
+    int binHi = std::min(nbins - 1, static_cast<int>(std::floor((windowHi - start) / bw)));
+    double triggerSumPeak = 0.0;
+    for (int i = binLo; i <= binHi; i++) triggerSumPeak = std::max(triggerSumPeak, triggerHistogram[i]);
+    ev->SetTriggerSumPeak(triggerSumPeak);
+
     double totalEVCharge = 0;
     for (int imcpmt = 0; imcpmt < mc->GetMCPMTCount(); imcpmt++) {
       DS::MCPMT *mcpmt = mc->GetMCPMT(imcpmt);
@@ -151,7 +161,7 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
         for (int pidx = 0; pidx < mcpmt->GetMCPhotonCount(); pidx++) {
           DS::MCPhoton *photon = mcpmt->GetMCPhoton(pidx);
           double time = photon->GetFrontEndTime();
-          if ((time > (tt - fLookback)) && (time < (tt + fTriggerWindow))) {
+          if ((time > windowLo) && (time < windowHi)) {
             pmtInEvent = true;
             hitTimes.push_back(time);
             integratedCharge += photon->GetCharge();

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -145,9 +145,9 @@ Processor::Result SplitEVDAQProc::DSEvent(DS::Root *ds) {
     double windowHi = tt + fTriggerWindow;
     int binLo = std::max(0, static_cast<int>(std::ceil((windowLo - start) / bw)));
     int binHi = std::min(nbins - 1, static_cast<int>(std::floor((windowHi - start) / bw)));
-    double triggerSumPeak = 0.0;
-    for (int i = binLo; i <= binHi; i++) triggerSumPeak = std::max(triggerSumPeak, triggerHistogram[i]);
-    ev->SetTriggerSumPeak(triggerSumPeak);
+    double triggerPeak = 0.0;
+    for (int i = binLo; i <= binHi; i++) triggerPeak = std::max(triggerPeak, triggerHistogram[i]);
+    ev->SetTriggerPeak(triggerPeak);
 
     double totalEVCharge = 0;
     for (int imcpmt = 0; imcpmt < mc->GetMCPMTCount(); imcpmt++) {

--- a/src/ds/include/RAT/DS/EV.hh
+++ b/src/ds/include/RAT/DS/EV.hh
@@ -157,6 +157,10 @@ class EV : public TObject {
   Double_t GetTotalCharge() const { return qTotal; }
   void SetTotalCharge(Double_t _qTotal) { qTotal = _qTotal; }
 
+  /** Peak value of the DAQ trigger sum, in units of hits. */
+  Double_t GetTriggerSumPeak() const { return triggerSumPeak; }
+  void SetTriggerSumPeak(Double_t _triggerSumPeak) { triggerSumPeak = _triggerSumPeak; }
+
   /** Fit Results **/
   virtual std::vector<FitResult *> GetFitResults() { return fitResults; }
   virtual void AddFitResult(FitResult *fit) { fitResults.push_back(fit); }
@@ -197,7 +201,7 @@ class EV : public TObject {
     return (eventCleaningWord >> bit_position) & 0x1;
   }
 
-  ClassDef(EV, 6);
+  ClassDef(EV, 7);
 
  protected:
   Int_t id;
@@ -213,6 +217,7 @@ class EV : public TObject {
   std::vector<Classifier *> classifierResults;
   std::vector<Digit> digitizer;  ///< The digitizer information
   uint64_t eventCleaningWord = 0;
+  Double_t triggerSumPeak = 0;
 };
 
 }  // namespace DS

--- a/src/ds/include/RAT/DS/EV.hh
+++ b/src/ds/include/RAT/DS/EV.hh
@@ -158,8 +158,8 @@ class EV : public TObject {
   void SetTotalCharge(Double_t _qTotal) { qTotal = _qTotal; }
 
   /** Peak value of the DAQ trigger sum, in units of hits. */
-  Double_t GetTriggerSumPeak() const { return triggerSumPeak; }
-  void SetTriggerSumPeak(Double_t _triggerSumPeak) { triggerSumPeak = _triggerSumPeak; }
+  Double_t GetTriggerPeak() const { return triggerPeak; }
+  void SetTriggerPeak(Double_t _triggerPeak) { triggerPeak = _triggerPeak; }
 
   /** Fit Results **/
   virtual std::vector<FitResult *> GetFitResults() { return fitResults; }
@@ -217,7 +217,7 @@ class EV : public TObject {
   std::vector<Classifier *> classifierResults;
   std::vector<Digit> digitizer;  ///< The digitizer information
   uint64_t eventCleaningWord = 0;
-  Double_t triggerSumPeak = 0;
+  Double_t triggerPeak = 0;
 };
 
 }  // namespace DS

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -149,6 +149,7 @@ class OutNtupleProc : public Processor {
   double triggerTime;
   ULong64_t timestamp;
   ULong64_t trigger_word;
+  double triggerSumPeak;
   ULong64_t event_cleaning_word;
   double timeSinceLastTrigger_us;
   // MC Summary Information

--- a/src/io/include/RAT/OutNtupleProc.hh
+++ b/src/io/include/RAT/OutNtupleProc.hh
@@ -149,7 +149,7 @@ class OutNtupleProc : public Processor {
   double triggerTime;
   ULong64_t timestamp;
   ULong64_t trigger_word;
-  double triggerSumPeak;
+  double triggerPeak;
   ULong64_t event_cleaning_word;
   double timeSinceLastTrigger_us;
   // MC Summary Information

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -203,6 +203,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   outputTree->Branch("triggerTime", &triggerTime);  // Local trigger time
   outputTree->Branch("timestamp", &timestamp);      // Global trigger time
   outputTree->Branch("trigger_word", &trigger_word);
+  outputTree->Branch("triggerSumPeak", &triggerSumPeak);
   outputTree->Branch("event_cleaning_word", &event_cleaning_word);
   outputTree->Branch("timeSinceLastTrigger_us", &timeSinceLastTrigger_us);
   // MC Information
@@ -591,6 +592,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     triggerTime = ev->GetCalibratedTriggerTime();
     timestamp = TTimeStamp_to_UnixTime(ev->GetUTC()) - TTimeStamp_to_UnixTime(runBranch->GetStartTime()) + triggerTime;
     trigger_word = ev->GetTriggerWord();
+    triggerSumPeak = ev->GetTriggerSumPeak();
     event_cleaning_word = ev->GetEventCleaningWord();
     timeSinceLastTrigger_us = ev->GetDeltaT() / 1000.;
 
@@ -767,6 +769,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     nhits = -1;
     totalcharge = 0;
     triggerTime = 0;
+    triggerSumPeak = 0;
     timeSinceLastTrigger_us = 0;
     if (options.pmthits) {
       hitPMTID.clear();

--- a/src/io/src/OutNtupleProc.cc
+++ b/src/io/src/OutNtupleProc.cc
@@ -203,7 +203,7 @@ bool OutNtupleProc::OpenFile(std::string filename) {
   outputTree->Branch("triggerTime", &triggerTime);  // Local trigger time
   outputTree->Branch("timestamp", &timestamp);      // Global trigger time
   outputTree->Branch("trigger_word", &trigger_word);
-  outputTree->Branch("triggerSumPeak", &triggerSumPeak);
+  outputTree->Branch("triggerPeak", &triggerPeak);
   outputTree->Branch("event_cleaning_word", &event_cleaning_word);
   outputTree->Branch("timeSinceLastTrigger_us", &timeSinceLastTrigger_us);
   // MC Information
@@ -592,7 +592,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     triggerTime = ev->GetCalibratedTriggerTime();
     timestamp = TTimeStamp_to_UnixTime(ev->GetUTC()) - TTimeStamp_to_UnixTime(runBranch->GetStartTime()) + triggerTime;
     trigger_word = ev->GetTriggerWord();
-    triggerSumPeak = ev->GetTriggerSumPeak();
+    triggerPeak = ev->GetTriggerPeak();
     event_cleaning_word = ev->GetEventCleaningWord();
     timeSinceLastTrigger_us = ev->GetDeltaT() / 1000.;
 
@@ -769,7 +769,7 @@ Processor::Result OutNtupleProc::DSEvent(DS::Root *ds) {
     nhits = -1;
     totalcharge = 0;
     triggerTime = 0;
-    triggerSumPeak = 0;
+    triggerPeak = 0;
     timeSinceLastTrigger_us = 0;
     if (options.pmthits) {
       hitPMTID.clear();


### PR DESCRIPTION
This PR calculates the peak value of the trigger sum (in units of NHit) in SplitEVDAQProc and then saves it to the ntuple. This allows the user to set a low threshold and then easily apply a trigger efficiency curve in analysis afterward.

Because this value is calculated per EV, events that don't trigger the detector (or don't use SplitEVDAQProc) are set to 0. Saving some value for untriggered events would mean editing the DS::MC in a way that it currently isn't used.