### PR TITLE
Prevent procset parameters from being overwritten by ratdb values

### DIFF
--- a/doc/programmers_guide/programmer_processors.rst
+++ b/doc/programmers_guide/programmer_processors.rst
@@ -75,6 +75,22 @@ Next you need to decide what parameters your processor will accept at runtime.  
 
 Only overload the methods you need.
 
+Each `/rat/procset` command applies to the processor created by the most recent `/rat/proc` command. This allows a macro to create several instances of the same processor with different values. If your ``BeginOfRun`` also loads a default value from RATDB for one of these parameters, check whether the parameter was set by the user with ``WasParamSet`` so the RATDB default does not overwrite the user's choice. The ``BeginOfRun`` definition from above then becomes::
+
+  void NoiseProc::BeginOfRun(DS::Run *run) {
+    DBLinkPtr lnoise = DB::Get()->GetLink("NOISEPROC");
+
+    if (!WasParamSet("flag")) fNoiseFlag = lnoise->GetI("noise_flag");
+    if (!WasParamSet("rate")) fDefaultNoiseRate = lnoise->GetD("default_noise_rate");
+    ...
+
+    DS::PMTInfo *pmtinfo = run->GetPMTInfo();
+    UpdatePMTModels(pmtinfo);
+    ...
+  }
+
+Note that ``WasParamSet`` accepts the parameter name used by the `/rat/procset` command (and in ``SetI``/``SetF``/``SetD``/``SetS``), while the RATDB table may use a different name.
+
 Finally, the ``EndOfRun`` method is invoked once after all of the events have been processed, and can be used to clean-up variables or print summary statistics.
 
 ---------------------------

--- a/src/cmd/src/ProcBlockManager.cc
+++ b/src/cmd/src/ProcBlockManager.cc
@@ -213,6 +213,7 @@ void ProcBlockManager::DoProcSetCmd(std::string cmdstring) {
       default:
         Log::Die("DoProcSetCmd: Invalid value in /rat/procset " + cmdstring);
     }
+    lastProc->MarkParamSet(param);
   } catch (Processor::ParamUnknown &pu) {
     Log::Die("Parameter unknown: " + pu.param);
   } catch (Processor::ParamInvalid &pi) {

--- a/src/core/include/RAT/Processor.hh
+++ b/src/core/include/RAT/Processor.hh
@@ -29,6 +29,7 @@
 
 #include <RAT/DS/Root.hh>
 #include <RAT/DS/Run.hh>
+#include <set>
 #include <string>
 
 namespace RAT {
@@ -36,6 +37,10 @@ namespace RAT {
 class Processor {
  protected:
   std::string name;
+
+ private:
+  /** Names of the parameters set by the user with /rat/procset. */
+  std::set<std::string> fSetParams;
 
  public:
   /** The short name of this processor. */
@@ -150,6 +155,20 @@ class Processor {
    *  @throws ParamInvalid if value is not allowed for param.
    */
   virtual void SetS(std::string param, std::string value);
+
+  /** Record that a param was set by the user with /rat/procset.
+   *
+   *  @param[in]  param  Name of parameter.
+   */
+  void MarkParamSet(std::string param) { fSetParams.insert(param); }
+
+  /** Check whether a param was set by the user with /rat/procset.
+   *
+   *  @param[in]  param  Name of parameter.
+   *
+   *  @return True if the user set the param. False if not.
+   */
+  bool WasParamSet(std::string param) const { return fSetParams.count(param) > 0; }
 
   /** Process one physics event.
    *

--- a/src/daq/src/AfterPulseProc.cc
+++ b/src/daq/src/AfterPulseProc.cc
@@ -31,8 +31,8 @@ AfterPulseProc::AfterPulseProc() : Processor("afterpulse") {}
 
 void AfterPulseProc::BeginOfRun(DS::Run* run) {
   DBLinkPtr lafterpulse = DB::Get()->GetLink("AFTERPULSEPROC");
-  fDefaultAPFraction = lafterpulse->GetD("afterpulse_fraction");
-  fAPFlag = lafterpulse->GetI("afterpulse_flag");
+  if (!WasParamSet("fraction")) fDefaultAPFraction = lafterpulse->GetD("afterpulse_fraction");
+  if (!WasParamSet("flag")) fAPFlag = lafterpulse->GetI("afterpulse_flag");
   fDefaultAPTime = lafterpulse->GetDArray("afterpulse_time");
   fDefaultAPProb = lafterpulse->GetDArray("afterpulse_prob");
   fDAQ = lafterpulse->GetS("daq");

--- a/src/daq/src/NoiseProc.cc
+++ b/src/daq/src/NoiseProc.cc
@@ -16,12 +16,12 @@ NoiseProc::NoiseProc() : Processor("noise") {}
 void NoiseProc::BeginOfRun(DS::Run *run) {
   DBLinkPtr lnoise = DB::Get()->GetLink("NOISEPROC");
 
-  fNoiseFlag = lnoise->GetI("noise_flag");
-  fDefaultNoiseRate = lnoise->GetD("default_noise_rate");
-  fLookback = lnoise->GetD("noise_lookback");
-  fLookforward = lnoise->GetD("noise_lookforward");
-  fMaxTime = lnoise->GetD("noise_maxtime");
-  fNearHits = lnoise->GetI("noise_nearhits");
+  if (!WasParamSet("flag")) fNoiseFlag = lnoise->GetI("noise_flag");
+  if (!WasParamSet("rate")) fDefaultNoiseRate = lnoise->GetD("default_noise_rate");
+  if (!WasParamSet("lookback")) fLookback = lnoise->GetD("noise_lookback");
+  if (!WasParamSet("lookforward")) fLookforward = lnoise->GetD("noise_lookforward");
+  if (!WasParamSet("maxtime")) fMaxTime = lnoise->GetD("noise_maxtime");
+  if (!WasParamSet("nearhits")) fNearHits = lnoise->GetI("noise_nearhits");
 
   DS::PMTInfo *pmtinfo = run->GetPMTInfo();
   UpdatePMTModels(pmtinfo);

--- a/src/daq/src/SplitEVDAQProc.cc
+++ b/src/daq/src/SplitEVDAQProc.cc
@@ -18,16 +18,16 @@ void SplitEVDAQProc::BeginOfRun(DS::Run *run) {
 
   ldaq = DB::Get()->GetLink("DAQ", "SplitEVDAQ");
   fEventCounter = 0;
-  fPulseWidth = ldaq->GetD("pulse_width");
-  fTriggerThreshold = ldaq->GetD("trigger_threshold");
-  fTriggerWindow = ldaq->GetD("trigger_window");
-  fPmtLockout = ldaq->GetD("pmt_lockout");
-  fTriggerLockout = ldaq->GetD("trigger_lockout");
-  fTriggerResolution = ldaq->GetD("trigger_resolution");
-  fLookback = ldaq->GetD("lookback");
-  fMaxHitTime = ldaq->GetD("max_hit_time");
-  fMaxHitDuration = ldaq->GetD("max_hit_duration");
-  fTriggerOnNoise = ldaq->GetI("trigger_on_noise");
+  if (!WasParamSet("pulse_width")) fPulseWidth = ldaq->GetD("pulse_width");
+  if (!WasParamSet("trigger_threshold")) fTriggerThreshold = ldaq->GetD("trigger_threshold");
+  if (!WasParamSet("trigger_window")) fTriggerWindow = ldaq->GetD("trigger_window");
+  if (!WasParamSet("pmt_lockout")) fPmtLockout = ldaq->GetD("pmt_lockout");
+  if (!WasParamSet("trigger_lockout")) fTriggerLockout = ldaq->GetD("trigger_lockout");
+  if (!WasParamSet("trigger_resolution")) fTriggerResolution = ldaq->GetD("trigger_resolution");
+  if (!WasParamSet("lookback")) fLookback = ldaq->GetD("lookback");
+  if (!WasParamSet("max_hit_time")) fMaxHitTime = ldaq->GetD("max_hit_time");
+  if (!WasParamSet("max_hit_duration")) fMaxHitDuration = ldaq->GetD("max_hit_duration");
+  if (!WasParamSet("trigger_on_noise")) fTriggerOnNoise = ldaq->GetI("trigger_on_noise");
   fDigitizerType = ldaq->GetS("digitizer_name");
   fDigitize = ldaq->GetZ("digitize");
 

--- a/src/fit/mimir/include/RAT/FitMimirProc.hh
+++ b/src/fit/mimir/include/RAT/FitMimirProc.hh
@@ -21,7 +21,6 @@ class FitMimirProc : public Processor {
  protected:
   FitterInputHandler inputHandler;
   std::unique_ptr<Mimir::FitStrategy> strategy;
-  bool configured = false;
   std::string strategyName, strategyConfig;
 };
 

--- a/src/fit/mimir/src/FitMimirProc.cc
+++ b/src/fit/mimir/src/FitMimirProc.cc
@@ -7,7 +7,7 @@ namespace RAT {
 FitMimirProc::FitMimirProc() : Processor("mimir"), inputHandler() {}
 
 void FitMimirProc::BeginOfRun(DS::Run *run) {
-  if (!configured) {
+  if (!WasParamSet("strategy")) {
     info << "FitMimirProc: No strategy configured, using default from RATDB." << newline;
     DBLinkPtr lConfig = DB::Get()->GetLink("FIT_MIMIR", "");
     strategyName = lConfig->GetS("strategy");
@@ -30,7 +30,6 @@ void FitMimirProc::Configure(const std::string &strategyName, const std::string 
 void FitMimirProc::SetS(std::string param, std::string value) {
   if (param == "strategy") {
     DB::ParseTableName(value, strategyName, strategyConfig);
-    configured = true;
   }
 }
 

--- a/src/fit/src/ClassifyTimesProc.cc
+++ b/src/fit/src/ClassifyTimesProc.cc
@@ -18,14 +18,14 @@ void ClassifyTimesProc::BeginOfRun(DS::Run *run) {
   DB *db = DB::Get();
 
   DBLinkPtr table = db->GetLink("Classifier", "ClassifyTimes");
-  fNumerTimeResLow = table->GetD("numer_time_resid_low");
-  fNumerTimeResUp = table->GetD("numer_time_resid_up");
+  if (!WasParamSet("numer_time_resid_low")) fNumerTimeResLow = table->GetD("numer_time_resid_low");
+  if (!WasParamSet("numer_time_resid_up")) fNumerTimeResUp = table->GetD("numer_time_resid_up");
   if (fNumerTimeResLow > fNumerTimeResUp)
     throw ParamInvalid("numer_time_resid_low",
                        "numer_time_resid_low in Classifier table must be <= numer_time_resid_up.");
 
   DBLinkPtr tbl = db->GetLink("FIT_COMMON", "");
-  fLightSpeed = tbl->GetD("light_speed");
+  if (!WasParamSet("light_speed")) fLightSpeed = tbl->GetD("light_speed");
   if (fLightSpeed <= 0 || fLightSpeed > 299.792458)
     throw ParamInvalid("light_speed", "light_speed in FIT_COMMON table must be > 0 and <= 299.792458 mm/ns.");
 

--- a/src/fit/src/FitDirectionCenterProc.cc
+++ b/src/fit/src/FitDirectionCenterProc.cc
@@ -16,7 +16,7 @@ namespace RAT {
 
 void FitDirectionCenterProc::BeginOfRun(DS::Run *run) {
   DBLinkPtr table = DB::Get()->GetLink("FIT_COMMON", "");
-  fLightSpeed = table->GetD("light_speed");
+  if (!WasParamSet("light_speed")) fLightSpeed = table->GetD("light_speed");
   if (fLightSpeed <= 0 || fLightSpeed > 299.792458)
     throw ParamInvalid("light_speed", "light_speed in FIT_COMMON table must be > 0 and <= 299.792458 mm/ns.");
 

--- a/src/fit/src/FitQuadProc.cc
+++ b/src/fit/src/FitQuadProc.cc
@@ -15,16 +15,19 @@ void FitQuadProc::BeginOfRun(DS::Run *run) {
 
   DB *db = DB::Get();
   DBLinkPtr quad_db = db->GetLink("FIT_QUAD");
-  fNumQuadPoints = quad_db->GetI("num_points");
-  fMaxQuadPoints = quad_db->GetI("max_points");
-  fTableCutOff = quad_db->GetI("table_cut_off");
+  if (!WasParamSet("num_points")) fNumQuadPoints = quad_db->GetI("num_points");
+  if (!WasParamSet("max_points")) fMaxQuadPoints = quad_db->GetI("max_points");
+  if (!WasParamSet("table_cut_off")) fTableCutOff = quad_db->GetI("table_cut_off");
   if (fTableCutOff > fNumPointsTbl.size()) {
     Log::Die("Quad::BeginOfRun: cannot set a table_cut_off larger than the size of fNumPointsTbl.");
   }
-  fMaxRadius = quad_db->GetD("max_radius");
-  fMaxX = quad_db->GetD("max_x");
-  fMaxY = quad_db->GetD("max_y");
-  fMaxZ = quad_db->GetD("max_z");
+  // Only use defaults if none were set
+  if (!(WasParamSet("max_radius") || WasParamSet("max_x") || WasParamSet("max_y") || WasParamSet("max_z"))) {
+    fMaxRadius = quad_db->GetD("max_radius");
+    fMaxX = quad_db->GetD("max_x");
+    fMaxY = quad_db->GetD("max_y");
+    fMaxZ = quad_db->GetD("max_z");
+  }
   if (fMaxRadius > 0.0) {
     if (fMaxX > 0.0 || fMaxY > 0.0 || fMaxZ > 0.0)
       Log::Die(
@@ -36,7 +39,7 @@ void FitQuadProc::BeginOfRun(DS::Run *run) {
   }
 
   DBLinkPtr table = db->GetLink("FIT_COMMON", "");
-  fLightSpeed = table->GetD("light_speed");
+  if (!WasParamSet("light_speed")) fLightSpeed = table->GetD("light_speed");
   if (fLightSpeed <= 0.0 || fLightSpeed > 299.792458)
     Log::Die("Quad::BeginOfRun: light_speed in FIT_COMMON table must be > 0 and <= 299.792458 mm/ns.");
 }
@@ -70,18 +73,25 @@ void FitQuadProc::SetD(std::string param, double value) {
       throw ParamInvalid(param, "light_speed must be positive and <= 299.792458 mm/ns.");
     fLightSpeed = value;
   } else if (param == "max_radius") {
-    if (fMaxX > 0.0 || fMaxY > 0.0 || fMaxZ > 0.0)
+    if (WasParamSet("max_x") || WasParamSet("max_y") || WasParamSet("max_z"))
       throw ParamInvalid(param, "cannot set both max_radius and (max_x or max_y or max_z).");
+    if (value <= 0.0) throw ParamInvalid(param, "max_radius must be > 0.");
     fMaxRadius = value;
   } else if (param == "max_x") {
+    if (WasParamSet("max_radius"))
+      throw ParamInvalid(param, "cannot set both max_radius and (max_x or max_y or max_z).");
     if (value <= 0.0) throw ParamInvalid(param, "max_x must be > 0.");
     fMaxX = value;
     fMaxRadius = 0.0;
   } else if (param == "max_y") {
+    if (WasParamSet("max_radius"))
+      throw ParamInvalid(param, "cannot set both max_radius and (max_x or max_y or max_z).");
     if (value <= 0.0) throw ParamInvalid(param, "max_y must be > 0.");
     fMaxY = value;
     fMaxRadius = 0.0;
   } else if (param == "max_z") {
+    if (WasParamSet("max_radius"))
+      throw ParamInvalid(param, "cannot set both max_radius and (max_x or max_y or max_z).");
     if (value <= 0.0) throw ParamInvalid(param, "max_z must be > 0.");
     fMaxZ = value;
     fMaxRadius = 0.0;


### PR DESCRIPTION
Right now, some values that can be set using /rat/procset also have default values in a ratdb table. Because BeginOfRun runs after the macro is read, these default values currently overwrite the user input values.

This PR adds MarkParamSet() and WasParamSet() to track whether the /rat/procset parameter was set by the user, and prevent it from being overwritten.

I've tried to find and update every instance in ratpac-two where this applies. Quad and Mimir had their own methods for checking whether a parameter was set, and I've updated them to use MarkParamSet() and WasParamSet() while trying to keep the same behavior.