### PR TITLE
quad: add fixed position option

### DIFF
--- a/doc/users_guide/reconstruction.rst
+++ b/doc/users_guide/reconstruction.rst
@@ -88,6 +88,11 @@ different settings in a single macro.  An example is given in macros/examples/qu
 ``min_hit_time``            ``double``                  Optional lower cut on PMT hit times in ns
 ``max_hit_time``            ``double``                  Optional upper cut on PMT hit times in ns
 
+``fixed_position``          ``int``                     Option to give a fixed position and determine an event time
+``fixed_x``                 ``double``                  Fixed x coordinate in mm
+``fixed_y``                 ``double``                  Fixed y coordinate in mm
+``fixed_z``                 ``double``                  Fixed z coordinate in mm
+
 Position fit information in data structure
 ''''''''''''''''''''''''''''''''''''''''''
 * name - "quad"

--- a/macros/examples/quadfitter.mac
+++ b/macros/examples/quadfitter.mac
@@ -6,6 +6,11 @@
 /rat/db/set DETECTOR experiment "Validation"
 /rat/db/set DETECTOR geo_file "Validation/Valid.geo"
 
+#/rat/db/set FIT_QUAD fixed_position 1
+#/rat/db/set FIT_QUAD fixed_x 0.0
+#/rat/db/set FIT_QUAD fixed_y 0.0
+#/rat/db/set FIT_QUAD fixed_z 0.0
+
 /run/initialize
 
 /rat/proc splitevdaq

--- a/ratdb/FIT_QUAD.ratdb
+++ b/ratdb/FIT_QUAD.ratdb
@@ -9,4 +9,9 @@
 "max_x": 0.0,          // [mm].  Optional Cartesian alternatives (set max_radius to 0.0).
 "max_y": 0.0,
 "max_z": 0.0,
+
+"fixed_position": 0,   //  If > 0, return a fitted time for the fixed position.
+"fixed_x": 0.0,        // [mm]
+"fixed_y": 0.0,
+"fixed_z": 0.0,
 }

--- a/src/fit/include/RAT/FitQuadProc.hh
+++ b/src/fit/include/RAT/FitQuadProc.hh
@@ -32,8 +32,8 @@ class FitQuadProc : public Processor {
   double fMaxX = 0.0;  // [mm].  Optional Cartesian alternative to fMaxRadius.
   double fMaxY = 0.0;
   double fMaxZ = 0.0;
-  bool fFixedPos = false;
-  double fFixedX = 0.0;
+  int fFixedPos = false;  // If > 0, return a fitted time for the fixed position.
+  double fFixedX = 0.0;   // [mm]
   double fFixedY = 0.0;
   double fFixedZ = 0.0;
   double fMaxHitTime = -9999;  // [ns].  Optional hit time limits - ineffective when fMaxHitTime <= fMinHitTime.

--- a/src/fit/include/RAT/FitQuadProc.hh
+++ b/src/fit/include/RAT/FitQuadProc.hh
@@ -32,8 +32,8 @@ class FitQuadProc : public Processor {
   double fMaxX = 0.0;  // [mm].  Optional Cartesian alternative to fMaxRadius.
   double fMaxY = 0.0;
   double fMaxZ = 0.0;
-  int fFixedPos = false;  // If > 0, return a fitted time for the fixed position.
-  double fFixedX = 0.0;   // [mm]
+  int fFixedPos = 0;     // If > 0, return a fitted time for the fixed position.
+  double fFixedX = 0.0;  // [mm]
   double fFixedY = 0.0;
   double fFixedZ = 0.0;
   double fMaxHitTime = -9999;  // [ns].  Optional hit time limits - ineffective when fMaxHitTime <= fMinHitTime.

--- a/src/fit/include/RAT/FitQuadProc.hh
+++ b/src/fit/include/RAT/FitQuadProc.hh
@@ -32,6 +32,10 @@ class FitQuadProc : public Processor {
   double fMaxX = 0.0;  // [mm].  Optional Cartesian alternative to fMaxRadius.
   double fMaxY = 0.0;
   double fMaxZ = 0.0;
+  bool fFixedPos = false;
+  double fFixedX = 0.0;
+  double fFixedY = 0.0;
+  double fFixedZ = 0.0;
   double fMaxHitTime = -9999;  // [ns].  Optional hit time limits - ineffective when fMaxHitTime <= fMinHitTime.
   double fMinHitTime = 9999;   // [ns].
   bool fSetMaxHitTime = false;

--- a/src/fit/src/FitQuadProc.cc
+++ b/src/fit/src/FitQuadProc.cc
@@ -354,7 +354,7 @@ Processor::Result FitQuadProc::Event(DS::Root *ds, DS::EV *ev) {
     return Processor::Result(FAIL);
   }
 
-  if (!fFixedPos) {  // Don't sort position if fitting only for time
+  if (fFixedPos == 0) {  // If fixing position, don't sort
     std::sort(quad_xs.begin(), quad_xs.end());
     std::sort(quad_ys.begin(), quad_ys.end());
     std::sort(quad_zs.begin(), quad_zs.end());

--- a/src/fit/src/FitQuadProc.cc
+++ b/src/fit/src/FitQuadProc.cc
@@ -34,6 +34,10 @@ void FitQuadProc::BeginOfRun(DS::Run *run) {
     if (fMaxX <= 0.0 || fMaxY <= 0.0 || fMaxZ <= 0.0)
       Log::Die("Quad::BeginOfRun: must set either max_radius or each of max_x, max_y, and max_z.");
   }
+  fFixedPos = quad_db->GetI("fixed_position");
+  fFixedX = quad_db->GetD("fixed_x");
+  fFixedY = quad_db->GetD("fixed_y");
+  fFixedZ = quad_db->GetD("fixed_z");
 
   DBLinkPtr table = db->GetLink("FIT_COMMON", "");
   fLightSpeed = table->GetD("light_speed");
@@ -60,6 +64,8 @@ void FitQuadProc::SetI(std::string param, int value) {
       throw ParamInvalid(param, "table_cut_off cannot be larger than the size of fNumPointsTbl.");
   } else if (param == "pmt_type") {
     fPMTtype.push_back(value);
+  } else if (param == "fixed_position") {
+    fFixedPos = value;
   } else
     throw ParamUnknown(param);
 }
@@ -91,6 +97,21 @@ void FitQuadProc::SetD(std::string param, double value) {
   } else if (param == "min_hit_time") {
     fMinHitTime = value;
     fSetMinHitTime = true;
+  } else if (param == "fixed_x") {
+    if (fFixedPos)
+      fFixedX = value;
+    else
+      throw ParamInvalid(param, "To set fixed_x, first set fixed_position > 0.");
+  } else if (param == "fixed_y") {
+    if (fFixedPos)
+      fFixedY = value;
+    else
+      throw ParamInvalid(param, "To set fixed_y, first set fixed_position > 0.");
+  } else if (param == "fixed_z") {
+    if (fFixedPos)
+      fFixedZ = value;
+    else
+      throw ParamInvalid(param, "To set fixed_z, first set fixed_position > 0.");
   } else
     throw ParamUnknown(param);
 }
@@ -237,8 +258,22 @@ Processor::Result FitQuadProc::Event(DS::Root *ds, DS::EV *ev) {
   // Arrays for quad points
   std::vector<double> quad_xs, quad_ys, quad_zs, quad_ts;
   for (size_t pt_i = 0; pt_i < num_pts; pt_i++) {
-    double min_time = 1e9;
     std::array<unsigned int, 4> pmt_ids = pmt_table[pt_i];
+
+    if (fFixedPos > 0) {  // If fitting only for time (fixed position provided)
+      for (int j = 0; j < 4; j++) {
+        unsigned int i = pmt_ids[j];
+        double dist = sqrt(pow(pmtx[i] - fFixedX, 2.0) + pow(pmty[i] - fFixedY, 2.0) + pow(pmtz[i] - fFixedZ, 2.0));
+        double time = pmtt[i] - dist / fLightSpeed;
+        quad_xs.push_back(fFixedX);
+        quad_ys.push_back(fFixedY);
+        quad_zs.push_back(fFixedZ);
+        quad_ts.push_back(time);
+        if (quad_xs.size() >= fMaxQuadPoints) break;  // got enough
+      }
+    }
+
+    double min_time = 1e9;
     double pmt_pos[4][3];
 
     std::array<double, 4> t;
@@ -319,9 +354,11 @@ Processor::Result FitQuadProc::Event(DS::Root *ds, DS::EV *ev) {
     return Processor::Result(FAIL);
   }
 
-  std::sort(quad_xs.begin(), quad_xs.end());
-  std::sort(quad_ys.begin(), quad_ys.end());
-  std::sort(quad_zs.begin(), quad_zs.end());
+  if (!fFixedPos) {  // Don't sort position if fitting only for time
+    std::sort(quad_xs.begin(), quad_xs.end());
+    std::sort(quad_ys.begin(), quad_ys.end());
+    std::sort(quad_zs.begin(), quad_zs.end());
+  }
   std::sort(quad_ts.begin(), quad_ts.end());
 
   TVector3 best_fit(quad_xs[quad_pts / 2], quad_ys[quad_pts / 2], quad_zs[quad_pts / 2]);


### PR DESCRIPTION
Add the option to return a fitted time from quad by providing a fixed position.  
The test below shows that the addition works as expected.  

Using the nominal quad macro:
<img width="522" height="320" alt="Screenshot 2026-08-01 11 21 14" src="https://github.com/user-attachments/assets/05bdf2b5-2b4e-4c45-8ca5-e8d22e129565" />

Using the quad macro with the fixed position (0,0,0):
<img width="522" height="320" alt="Screenshot 2026-08-01 11 24 51" src="https://github.com/user-attachments/assets/083005ea-3444-4dc9-bfef-2357bc83a663" />
