### PR TITLE
Standardize usage of fit->Set functions

### DIFF
--- a/src/fit/src/FitCentroidProc.cc
+++ b/src/fit/src/FitCentroidProc.cc
@@ -75,8 +75,6 @@ Processor::Result FitCentroidProc::Event(DS::Root *ds, DS::EV *ev) {
   if (totalQ) {
     centroid *= 1.0 / totalQ;
     fit->SetPosition(centroid);
-  } else {
-    fit->SetValidPosition(false);
   }
   ev->AddFitResult(fit);
 

--- a/src/fit/src/FitDirectionCenterProc.cc
+++ b/src/fit/src/FitDirectionCenterProc.cc
@@ -94,15 +94,9 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
   inputHandler.RegisterEvent(ev);
 
   DS::FitResult *fitDC = new DS::FitResult(name, fFitLabel);
+  fitDC->SetEnableDirection(true);
 
-  /// Initialize ALL parameters with placeholder values
-  fitDC->SetEnablePosition(false);
-  fitDC->SetValidPosition(false);
-  fitDC->SetPosition(TVector3(0, 0, 0));
-  fitDC->SetEnableDirection(false);
-  fitDC->SetValidDirection(false);
-  fitDC->SetDirection(TVector3(0, 0, 0));
-  // Figures of Merit
+  /// Initialize ALL Figures of Merit with placeholder values
   fitDC->SetFigureOfMerit("num_PMT", 0);
   fitDC->SetFigureOfMerit("time_resid_low", NAN);
   fitDC->SetFigureOfMerit("time_resid_up", NAN);
@@ -195,9 +189,8 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
     }
     // Save drive correction
     eventPos -= fDrive * eventDir;
-    fitDC->SetEnablePosition(true);
-    if (validPos && validDir) fitDC->SetValidPosition(true);
     fitDC->SetPosition(eventPos);
+    if (!validPos || !validDir) fitDC->SetValidPosition(false);
 
   } else if (fDrive != 0.0 && fDirFitter.empty()) {
     Log::Die("FitDirectionCenterProc: No direction fitter specified while drive value is specified.");
@@ -414,8 +407,6 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
 
   /// Save results
   if (directionMean.Mag2() > 0) {
-    fitDC->SetEnableDirection(true);
-    fitDC->SetValidDirection(true);
     fitDC->SetDirection(directionMean.Unit());
     fitDC->SetFigureOfMerit("num_PMT", numDir);
     fitDC->SetFigureOfMerit("time_resid_low", timeResLow);

--- a/src/fit/src/FitPathProc.cc
+++ b/src/fit/src/FitPathProc.cc
@@ -197,6 +197,16 @@ double FitPathProc::operator()(double *params) {
 }
 
 Processor::Result FitPathProc::Event(DS::Root *ds, DS::EV *ev) {
+  DS::FitResult *fit = new DS::FitResult("FitPath");
+  fit->SetEnableTime(true);
+  fit->SetEnablePosition(true);
+  fit->SetEnableDirection(true);
+
+  if (ev->GetPMTCount() == 0) {
+    ev->AddFitResult(fit);
+    return Processor::FAIL;
+  }
+
   fHits.resize(ev->GetPMTCount());
 
   DS::Run *run = DS::RunStore::Get()->GetRun(ds);
@@ -213,15 +223,6 @@ Processor::Result FitPathProc::Event(DS::Root *ds, DS::EV *ev) {
     fHits[i].py = pmtdir.Y();
     fHits[i].pz = pmtdir.Z();
     fHits[i].t = pmt->GetTime();
-  }
-
-  DS::FitResult *fit = new DS::FitResult("FitPath");
-
-  if (ev->GetPMTCount() == 0) {
-    fit->SetPosition(TVector3(-100000, -100000, -100000));
-    fit->SetTime(-1);
-    fit->SetDirection(TVector3(-1, 0, 0));
-    return Processor::OK;
   }
 
   std::vector<double> point, seed;

--- a/src/fit/src/FitQuadProc.cc
+++ b/src/fit/src/FitQuadProc.cc
@@ -213,14 +213,10 @@ Processor::Result FitQuadProc::Event(DS::Root *ds, DS::EV *ev) {
   size_t nhits = pmtt.size();
 
   DS::FitResult *fit = new DS::FitResult(name, fFitLabel);
-  fit->SetValidEnergy(false);
-  fit->SetValidDirection(false);
-  fit->SetPosition(TVector3(-9999, -9999, -9999));
-  fit->SetTime(-9999);
+  fit->SetEnablePosition(true);
+  fit->SetEnableTime(true);
 
   if (nhits < 4) {
-    fit->SetValidTime(false);
-    fit->SetValidPosition(false);
     ev->AddFitResult(fit);
     return Processor::Result(FAIL);
   }
@@ -313,8 +309,6 @@ Processor::Result FitQuadProc::Event(DS::Root *ds, DS::EV *ev) {
   size_t quad_pts = quad_xs.size();
   // if (quad_pts < fNumQuadPoints) {
   if (quad_pts < 1) {
-    fit->SetValidTime(false);
-    fit->SetValidPosition(false);
     ev->AddFitResult(fit);
     return Processor::Result(FAIL);
   }


### PR DESCRIPTION
- Remove unnecessary initializations that simply overwrite those of FitResult.  
- Ensure that SetValid is called after the quantity is Set because the latter automatically sets the validity to true.  
- Ensure that relevant SetEnable functions are called immediately after the FitResult is created.  