### PR TITLE
Mc tuning options

### DIFF
--- a/develop.md
+++ b/develop.md
@@ -1,0 +1,143 @@
+# Direct-light-only photon tracking
+
+Development notes for the `/tracking/directLightOnly` feature added to this
+ratpac-two checkout.
+
+## Goal
+
+Simulate only *direct* Cherenkov and scintillation light: photons that travel in
+a straight line from their emission point to the surface where they are
+absorbed/detected, with no scattering, wavelength shifting, reemission or
+reflection along the way.
+
+## Bugs found in the original proof-of-concept
+
+The starting point was this snippet in `GLG4SteppingAction::UserSteppingAction`:
+
+```cpp
+if (track->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) {
+      const G4VProcess *creator = track->GetCreatorProcess();
+      if (creator && creator->GetProcessName() != "Cerenkov"&&creator && creator->GetProcessName() != "scitillation") {
+          track->SetTrackStatus(fStopAndKill);
+          return;
+      }
+      G4ThreeVector preStepDirection = aStep->GetPreStepPoint()->GetMomentumDirection();
+      G4ThreeVector postStepDirection = aStep->GetPostStepPoint()->GetMomentumDirection();
+      if (preStepDirection.dot(postStepDirection) < 0.96) {
+        track->SetTrackStatus(fStopAndKill);
+      }
+}
+```
+
+1. **`"Cerenkov"` never matches.** RAT uses `RAT::ThinnableG4Cerenkov`, which
+   inherits the default name of `G4CerenkovProcess`, i.e. **`"G4CerenkovProcess"`**.
+   `Gsim.cc` compares with `.find("Cerenkov")` for exactly this reason.
+2. **`"scitillation"` is a typo** and the real name is **`"Scintillation"`**
+   (`GLG4Scint.cc:70`). Combined with (1), every clause of the `if` is true for
+   every photon, so the snippet kills 100% of the optical photons.
+3. **The pre/post step direction test kills refraction.** Fresnel transmission
+   into acrylic/glass/a PMT window changes the direction legitimately, and such
+   a photon is still direct light. Conversely a grazing total internal
+   reflection deflects by less than the 16 degrees implied by `0.96` and
+   survives. The test has both false positives and false negatives.
+4. **Consecutive-step comparison lets deflections accumulate.** Ten 15 degree
+   kinks each pass `dot < 0.96` individually.
+
+Minor issues: `creator &&` is tested twice; a null creator process (generator
+primaries) silently survives; and the early `return` skips the
+`num_zero_steps_in_a_row` reset, leaking one track's zero-step count into the
+next track.
+
+## Implementation
+
+Process-based rather than angle-based.
+
+### `src/core/src/GLG4SteppingAction.cc`
+
+New static configuration and `GLG4SteppingAction::ApplyDirectLightFilter()`,
+called from the top of `UserSteppingAction` for optical photons when
+`fDirectLightOnly` is set. It returns `true` when it killed the photon, in
+which case the caller resets `num_zero_steps_in_a_row` before returning so the
+shared counter does not carry over into the next track.
+
+The filter has three parts:
+
+* **Creator process.** Checked once, on step 1. The name is taken from
+  `G4Track::GetCreatorProcess()`, overridden by `RAT::TrackInfo::GetCreatorProcess()`
+  when set, matching what `Gsim` does when it classifies photons. It is matched
+  as a *substring* against `fDirectLightProcesses`, so `"Cerenkov"` matches
+  `"G4CerenkovProcess"` and `"Scintillation"` matches `"Scintillation"` while
+  *not* matching `"Reemission"` / `"ReemissionFromCompN"`. An empty creator name
+  means a primary photon from a generator and is always kept.
+* **Scattering processes.** Killed on `OpRayleigh`, `Rayleigh`, `OpMieHG`,
+  `OpWLS` and `OpWLS2`.
+* **Boundaries.** Identified by comparing the post-step process pointer with the
+  `G4OpBoundaryProcess` instance attached to the optical photon (looked up once
+  per thread and cached), then dispatched on `GetStatus()`:
+  * kept: `Undefined`, `Transmission`, `FresnelRefraction`, `NotAtBoundary`,
+    `SameMaterial`, `StepTooSmall`, `NoRINDEX`, `Absorption`, `Detection`,
+    `CoatedDielectricRefraction`, `CoatedDielectricFrustratedTransmission`;
+  * killed: every reflection flavour, plus `Dichroic`, whose outcome is
+    ambiguous and is treated conservatively as indirect.
+
+An optional angular cut is measured against `GetVertexMomentumDirection()` (the
+emission direction) rather than the previous step, so small kinks cannot
+accumulate unnoticed. It is disabled by default.
+
+### `src/cmd/src/TrackingMessenger.cc`, `src/cmd/include/RAT/TrackingMessenger.hh`
+
+Three new macro commands, all no-ops unless the first is turned on:
+
+| command | type | default |
+| --- | --- | --- |
+| `/tracking/directLightOnly` | bool | `false` |
+| `/tracking/directLightProcesses` | string, space separated | `Cerenkov Scintillation` |
+| `/tracking/directLightMinCosine` | double, `<= -1` disables | `-1.0` |
+
+`GetCurrentValue` is implemented for all three, so `/control/getEnv`-style
+queries and `/control/manual /tracking` work as for the pre-existing commands.
+
+The messenger is constructed in `Rat.cc` before any macro is executed, so the
+commands may be placed anywhere in the macro.
+
+Example:
+
+```
+/run/initialize
+/tracking/directLightOnly true
+```
+
+## Validation
+
+Built and run inside `ratpac2.sif` (Geant4 11.4). 2.5 MeV electrons at the
+origin of the `Validation/Valid.geo` geometry, PE counted per creator process
+from the `outroot` output.
+
+| run | events | PE by creator process |
+| --- | --- | --- |
+| water, feature off | 20 | 344 `G4CerenkovProcess` |
+| water, `directLightOnly true` | 20 | 332 `G4CerenkovProcess` |
+| water, `directLightProcesses Reemission` | 20 | 0 (sanity check that the filter bites) |
+| water, `directLightMinCosine 0.9999` | 20 | 8 `G4CerenkovProcess` |
+| LABPPO, feature off | 5 | 1575 `Scintillation`, 1915 `ReemissionFromComp1`, 1348 `ReemissionFromComp0`, 70 `G4CerenkovProcess` |
+| LABPPO, `directLightOnly true` | 5 | 1290 `Scintillation`, 47 `G4CerenkovProcess`, 0 reemission |
+
+The LABPPO runs used the same geometry with
+`/rat/db/set GEO[world] material "scintillator_lab_ppo0p6"` and the same for
+`GEO[detector]`.
+
+Full `make` and `make install` succeed; `clang-format` applied per `cformat.sh`.
+
+## Known limitation
+
+Photons detected inside `GLG4PMTOpticalModel` are recorded by that fast
+simulation model, so the hit is booked before the stepping action sees the step.
+Reflections *inside* the PMT optical model are therefore not filtered. Handling
+those would require a change in `src/physics/src/GLG4PMTOpticalModel.cc`.
+
+## Files touched
+
+* `src/core/include/RAT/GLG4SteppingAction.hh`
+* `src/core/src/GLG4SteppingAction.cc`
+* `src/cmd/include/RAT/TrackingMessenger.hh`
+* `src/cmd/src/TrackingMessenger.cc`

--- a/doc/users_guide/index.rst
+++ b/doc/users_guide/index.rst
@@ -16,6 +16,7 @@ Table of Contents
    geometry
    physics_processes
    photon_processes
+   tuning
    processors
    producers
    pmt

--- a/doc/users_guide/tuning.md
+++ b/doc/users_guide/tuning.md
@@ -1,0 +1,130 @@
+# MC tuning options
+
+Some studies do not need a full, faithful simulation. When you are fitting a PMT
+time PDF you only care about the photons that actually reach a PMT, and when you
+are profiling the non-optical part of an event you do not want the optical
+simulation running at all.
+
+The `MC` RATDB table exposes a **tuning** hook for exactly these cases. Tuning
+changes the physics that is simulated or the information that is retained, so it
+is strictly opt-in: with no tuning configured, ratpac-two behaves exactly as it
+always has.
+
+```{contents} Table of Contents
+:depth: 2
+```
+
+## Enabling a tuning option
+
+Two RATDB fields control tuning, and both must be set before `/run/initialize`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `tuning` | bool | Master switch. Tuning is applied only when this is `true`. |
+| `tuning_option` | string | Which tuning to apply. |
+
+Neither field is present in the default `ratdb/MC.ratdb`, so set them from your
+macro:
+
+```
+/rat/db/set MC tuning true
+/rat/db/set MC tuning_option "profile"
+
+/run/initialize
+```
+
+Only one option can be active at a time — `tuning_option` is a single string, not
+a list.
+
+The fields are read once per run, in `Gsim::BeginOfRunAction`. Changing them
+between `/run/beamOn` calls in the same macro will take effect on the next run.
+
+## Available options
+
+### `timepdf` — keep only photon tracks that hit a PMT
+
+Optical-photon trajectories are discarded unless the photon entered a PMT
+optical model. Photons are still fully simulated and still produce
+photoelectrons; only the *stored trajectories* of the photons that never
+reached a PMT are dropped.
+
+This is what you want when generating a PMT hit-time PDF: you get the full
+arrival-time information without writing out the overwhelming majority of
+photons that were absorbed or lost in the detector.
+
+```
+/rat/db/set MC tuning true
+/rat/db/set MC tuning_option "timepdf"
+
+/run/initialize
+
+/tracking/storeTrajectory 1
+```
+
+Because this option filters trajectories, it only does anything when trajectory
+storage is enabled with `/tracking/storeTrajectory 1`. See
+`macros/examples/timepdf.mac` for a complete working macro.
+
+### `profile` — kill optical photons as soon as they are emitted
+
+Every optical photon is killed on its first step, so no optical propagation is
+simulated at all. Scintillation and Cherenkov photons are still *generated* —
+the generating processes run normally, and the energy they consume is still
+accounted for — but the photons are stopped before they travel anywhere.
+
+The consequence is that **no photoelectrons and no PMT hits are produced**. A
+20-event run of `macros/examples/timepdf.mac` gives 320 PEs across 309 MCPMTs
+untuned, and 0 PEs across 0 MCPMTs with `profile` enabled.
+
+```
+/rat/db/set MC tuning true
+/rat/db/set MC tuning_option "profile"
+
+/run/initialize
+```
+
+Use this to profile or debug the non-optical part of an event — primary
+particle transport, energy deposition, secondaries — without paying for the
+optical simulation, or as a fast baseline when you want to confirm that a
+change in the output is optical in origin.
+
+Note that killed photons are still created as tracks. If trajectory storage is
+on they are written out with a single step each, so `profile` does **not** by
+itself reduce the track count in the output — the same 20-event run stored 14811
+tracks tuned versus 14768 untuned, while wall-clock dropped from 27.1 s to
+20.4 s (most of what remains is fixed geometry setup). Combine it with
+`/tracking/storeTrajectory 0` or the `prune` processor (`mc.track:opticalphoton`)
+if output size is the concern.
+
+## Error handling
+
+Tuning fails soft, never fatally:
+
+* `tuning` absent or `false` — no tuning is applied, silently. This is the
+  default and keeps older `MC` tables working unchanged.
+* `tuning` true, `tuning_option` absent — no tuning is applied, silently.
+* `tuning` true, `tuning_option` unrecognized — no tuning is applied and a
+  warning is logged:
+
+  ```
+  Gsim: Unknown MC tuning option "..."; no tuning will be applied
+  ```
+
+When an option *is* applied, `Gsim` logs it at info level, so check the run
+header to confirm the tuning you asked for is actually active:
+
+```
+Gsim: Time-PDF tuning enabled; only optical-photon trajectories that interact with a PMT will be saved
+Gsim: Profile tuning enabled; optical photons will be killed as soon as they are emitted
+```
+
+## Adding a new tuning option
+
+The dispatch lives in `Gsim::BeginOfRunAction` (`src/core/src/Gsim.cc`). Add a
+branch comparing `tuning_option` against your new name, and have it set whatever
+flag your feature reads.
+
+Reset that flag to its default at the top of the same block, next to the
+existing resets. `BeginOfRunAction` runs once per run, and the flags for
+`profile` and `timepdf` are static/member state that would otherwise leak from a
+tuned run into an untuned one later in the same macro.

--- a/macros/examples/timepdf.mac
+++ b/macros/examples/timepdf.mac
@@ -1,0 +1,25 @@
+/glg4debug/glg4param omit_muon_processes 1.0
+/glg4debug/glg4param omit_hadronic_processes 1.0
+
+/rat/db/set DETECTOR experiment "Validation"
+/rat/db/set DETECTOR geo_file "Validation/Valid.geo"
+
+# Retain only optical-photon trajectories that interact with a PMT.
+/rat/db/set MC tuning true
+/rat/db/set MC tuning_option "timepdf"
+
+/run/initialize
+
+/tracking/storeTrajectory 1
+
+/rat/proc forcedtrigger
+/rat/proc count
+/rat/procset update 100
+/rat/proclast outroot
+
+# Central 2.5 MeV electrons
+/generator/add combo gun:point:poisson
+/generator/vtx/set e- 0.0 0.0 0.0 2.5
+/generator/pos/set 0.0 0.0 0.0
+
+/run/beamOn 1000

--- a/src/cmd/include/RAT/TrackingMessenger.hh
+++ b/src/cmd/include/RAT/TrackingMessenger.hh
@@ -24,6 +24,9 @@ class TrackingMessenger : public G4UImessenger {
   G4UIcmdWithABool *storeMuonTrajSpecialCmd;
   G4UIcmdWithADouble *setMaxGlobalTimeCmd;
   G4UIcmdWithABool *storeOpticalTrackIDCmd;
+  G4UIcmdWithABool *directLightOnlyCmd;
+  G4UIcmdWithAString *directLightProcessesCmd;
+  G4UIcmdWithADouble *directLightMinCosineCmd;
 };
 
 }  // namespace RAT

--- a/src/cmd/src/TrackingMessenger.cc
+++ b/src/cmd/src/TrackingMessenger.cc
@@ -3,6 +3,7 @@
 #include <RAT/Log.hh>
 #include <RAT/TrackingMessenger.hh>
 #include <RAT/Trajectory.hh>
+#include <sstream>
 
 namespace RAT {
 
@@ -41,6 +42,38 @@ TrackingMessenger::TrackingMessenger() {
       "value <= 0.0 means do not kill any tracks.");
   setMaxGlobalTimeCmd->SetParameterName("value", true, false);
   setMaxGlobalTimeCmd->SetDefaultValue(0.0);
+
+  directLightOnlyCmd = new G4UIcmdWithABool("/tracking/directLightOnly", this);
+  directLightOnlyCmd->SetGuidance("Keep only direct optical photons.");
+  directLightOnlyCmd->SetGuidance(
+      "A photon is killed as soon as it is created by a process not listed in "
+      "/tracking/directLightProcesses (reemission, wavelength shifting, ...), "
+      "or as soon as it scatters, wavelength shifts or is reflected at a "
+      "surface.  Refraction into the next volume is kept, since the photon has "
+      "still travelled straight from its emission point to that surface.");
+  directLightOnlyCmd->SetParameterName("on", true, false);
+  directLightOnlyCmd->SetDefaultValue(false);
+
+  directLightProcessesCmd = new G4UIcmdWithAString("/tracking/directLightProcesses", this);
+  directLightProcessesCmd->SetGuidance(
+      "Space separated list of creator process names kept by "
+      "/tracking/directLightOnly.");
+  directLightProcessesCmd->SetGuidance(
+      "Names are matched as substrings, so \"Cerenkov\" matches the "
+      "\"G4CerenkovProcess\" name that RAT actually uses.  Default is "
+      "\"Cerenkov Scintillation\".  Photons with no creator process at all "
+      "(primaries from a photon generator) are always kept.");
+  directLightProcessesCmd->SetParameterName("processes", true, false);
+  directLightProcessesCmd->SetDefaultValue("Cerenkov Scintillation");
+
+  directLightMinCosineCmd = new G4UIcmdWithADouble("/tracking/directLightMinCosine", this);
+  directLightMinCosineCmd->SetGuidance(
+      "Optional angular cut used by /tracking/directLightOnly: kill a photon "
+      "once the cosine of the angle between its current direction and its "
+      "emission direction drops below this (double) value.");
+  directLightMinCosineCmd->SetGuidance("Values <= -1.0 (the default) disable the cut.");
+  directLightMinCosineCmd->SetParameterName("value", true, false);
+  directLightMinCosineCmd->SetDefaultValue(-1.0);
 }
 
 TrackingMessenger::~TrackingMessenger() {
@@ -50,6 +83,9 @@ TrackingMessenger::~TrackingMessenger() {
   delete storeMuonTrajSpecialCmd;
   delete setMaxGlobalTimeCmd;
   delete storeOpticalTrackIDCmd;
+  delete directLightOnlyCmd;
+  delete directLightProcessesCmd;
+  delete directLightMinCosineCmd;
 }
 
 G4String TrackingMessenger::GetCurrentValue(G4UIcommand *command) {
@@ -65,6 +101,17 @@ G4String TrackingMessenger::GetCurrentValue(G4UIcommand *command) {
     return Trajectory::GetDoAppendMuonStepSpecial() ? "True" : "False";
   } else if (command == setMaxGlobalTimeCmd) {
     return setMaxGlobalTimeCmd->ConvertToString(GLG4SteppingAction::max_global_time);
+  } else if (command == directLightOnlyCmd) {
+    return GLG4SteppingAction::fDirectLightOnly ? "True" : "False";
+  } else if (command == directLightProcessesCmd) {
+    std::ostringstream processes;
+    for (size_t i = 0; i < GLG4SteppingAction::fDirectLightProcesses.size(); i++) {
+      if (i > 0) processes << " ";
+      processes << GLG4SteppingAction::fDirectLightProcesses[i];
+    }
+    return processes.str();
+  } else if (command == directLightMinCosineCmd) {
+    return directLightMinCosineCmd->ConvertToString(GLG4SteppingAction::fDirectLightMinCosine);
   } else {
     Log::Die("TrackingMessenger sent unknown get command: " + command->GetCommandPath());
     return "";  // never get here
@@ -116,6 +163,30 @@ void TrackingMessenger::SetNewValue(G4UIcommand *command, G4String newValue) {
     else
       detail << "Tracking: Max global time for tracks set to " << val << newline;
     GLG4SteppingAction::max_global_time = val;
+  } else if (command == directLightOnlyCmd) {
+    bool on = G4UIcmdWithABool::GetNewBoolValue(newValue);
+    if (on)
+      detail << "Tracking: keeping direct optical photons only" << newline;
+    else
+      detail << "Tracking: keeping all optical photons" << newline;
+    GLG4SteppingAction::fDirectLightOnly = on;
+  } else if (command == directLightProcessesCmd) {
+    std::vector<std::string> processes;
+    std::istringstream stream(newValue);
+    std::string process;
+    while (stream >> process) processes.push_back(process);
+    if (processes.empty()) {
+      Log::Die("Tracking: /tracking/directLightProcesses needs at least one process name.");
+    }
+    GLG4SteppingAction::fDirectLightProcesses = processes;
+    detail << "Tracking: direct light kept for photons created by " << newValue << newline;
+  } else if (command == directLightMinCosineCmd) {
+    G4double val = G4UIcmdWithADouble::GetNewDoubleValue(newValue);
+    if (val <= -1.0)
+      detail << "Tracking: no angular cut applied to direct light." << newline;
+    else
+      detail << "Tracking: direct light killed below cos(angle to emission direction) = " << val << newline;
+    GLG4SteppingAction::fDirectLightMinCosine = val;
   } else {
     Log::Die("TrackingMessenger sent unknown set command: " + command->GetCommandPath());
   }

--- a/src/core/include/RAT/GLG4SteppingAction.hh
+++ b/src/core/include/RAT/GLG4SteppingAction.hh
@@ -20,6 +20,10 @@ class GLG4SteppingAction : public G4UserSteppingAction {
   // Default is 0, or no time limit.
   static G4double max_global_time;
 
+  // Kill every optical photon on its first step, so no optical propagation is
+  // simulated. Set by the "profile" MC tuning option.
+  static G4bool fKillOpticalPhotons;
+
  private:
   GLG4PrimaryGeneratorAction *myGenerator;
 };

--- a/src/core/include/RAT/GLG4SteppingAction.hh
+++ b/src/core/include/RAT/GLG4SteppingAction.hh
@@ -4,6 +4,9 @@
 #ifndef __GLG4SteppingAction_H__
 #define __GLG4SteppingAction_H__ 1
 
+#include <string>
+#include <vector>
+
 #include "G4ParticleChange.hh"
 #include "G4UserSteppingAction.hh"
 #include "globals.hh"
@@ -24,7 +27,32 @@ class GLG4SteppingAction : public G4UserSteppingAction {
   // simulated. Set by the "profile" MC tuning option.
   static G4bool fKillOpticalPhotons;
 
+  // "Direct light only" mode: keep an optical photon only while it is still on
+  // the straight line it was emitted along.  A photon is killed as soon as it
+  // is created by a process not listed in fDirectLightProcesses (reemission,
+  // wavelength shifting, ...) or as soon as it scatters, wavelength shifts or
+  // reflects.  Refraction into the next volume is kept, since a refracted
+  // photon has still travelled straight from the emission point to the surface
+  // it crossed.  Off by default; see /tracking/directLightOnly.
+  static G4bool fDirectLightOnly;
+
+  // Creator process names accepted by the direct light filter, matched as
+  // substrings so that e.g. "Cerenkov" matches "G4CerenkovProcess".  Photons
+  // with no creator process at all (primaries from a photon generator) are
+  // always kept.  See /tracking/directLightProcesses.
+  static std::vector<std::string> fDirectLightProcesses;
+
+  // Optional extra cut for the direct light filter: kill a photon once the
+  // cosine of the angle between its current direction and its emission
+  // direction drops below this value.  Values <= -1 (the default) disable the
+  // cut.  See /tracking/directLightMinCosine.
+  static G4double fDirectLightMinCosine;
+
  private:
+  // Apply the direct light filter to an optical photon.  Returns true if the
+  // photon was killed.
+  bool ApplyDirectLightFilter(const G4Step *aStep, G4Track *track);
+
   GLG4PrimaryGeneratorAction *myGenerator;
 };
 

--- a/src/core/include/RAT/Gsim.hh
+++ b/src/core/include/RAT/Gsim.hh
@@ -96,6 +96,7 @@ class Gsim : public Producer, G4UserRunAction, G4UserEventAction, G4UserTracking
   TTimeStamp utc;
   int maxpe;
   int nabort;
+  bool fTimePDFTuning;
 
   /** PMT and noise simulation */
   int npmts;

--- a/src/core/include/RAT/TrackInfo.hh
+++ b/src/core/include/RAT/TrackInfo.hh
@@ -28,6 +28,9 @@ class TrackInfo : public G4VUserTrackInformation {
   // double counting
   bool preUserTrackingActionDone = false;
 
+  /** Whether this optical photon entered a PMT optical model. */
+  bool fTouchedPMT = false;
+
   /** Centroid of steps, weighted by energy loss. */
   CentroidCalculator energyCentroid;
   /** Centroid of optical photon creation vertices. */

--- a/src/core/src/GLG4SteppingAction.cc
+++ b/src/core/src/GLG4SteppingAction.cc
@@ -20,8 +20,11 @@
 #include <RAT/TrackInfo.hh>
 
 #include "CLHEP/Units/PhysicalConstants.h"
+#include "G4OpBoundaryProcess.hh"
 #include "G4OpticalPhoton.hh"
 #include "G4ParticleChange.hh"
+#include "G4ProcessManager.hh"
+#include "G4ProcessVector.hh"
 #include "G4Step.hh"
 #include "G4StepPoint.hh"
 #include "G4SteppingManager.hh"
@@ -140,6 +143,117 @@ G4int GLG4SteppingAction_MaxStepNumber = 100000000;
 G4double GLG4SteppingAction::max_global_time = 0.0;
 G4bool GLG4SteppingAction::fUseGLG4 = true;
 G4bool GLG4SteppingAction::fKillOpticalPhotons = false;
+G4bool GLG4SteppingAction::fDirectLightOnly = false;
+std::vector<std::string> GLG4SteppingAction::fDirectLightProcesses = {"Cerenkov", "Scintillation"};
+G4double GLG4SteppingAction::fDirectLightMinCosine = -1.0;
+
+namespace {
+
+// Processes that redirect an optical photon without it crossing a geometrical
+// boundary.  A photon that has undergone any of them is no longer direct light.
+// Boundaries are handled separately in ApplyDirectLightFilter, because
+// refraction into the next volume still counts as direct light while every
+// flavour of reflection does not.
+bool IsOpticalScatteringProcess(const G4String &name) {
+  return name == "OpRayleigh" || name == "Rayleigh" || name == "OpMieHG" || name == "OpWLS" || name == "OpWLS2";
+}
+
+// The boundary process instance attached to the optical photon in this thread,
+// needed to ask what actually happened at a boundary step.  Cached because the
+// lookup walks the whole process list.
+G4OpBoundaryProcess *GetOpBoundaryProcess() {
+  static G4ThreadLocal G4OpBoundaryProcess *boundaryProcess = nullptr;
+  static G4ThreadLocal bool searched = false;
+  if (!searched) {
+    searched = true;
+    G4ProcessManager *pm = G4OpticalPhoton::OpticalPhotonDefinition()->GetProcessManager();
+    if (pm) {
+      G4ProcessVector *pv = pm->GetProcessList();
+      for (G4int i = 0; i < (G4int)pv->size(); i++) {
+        boundaryProcess = dynamic_cast<G4OpBoundaryProcess *>((*pv)[i]);
+        if (boundaryProcess) break;
+      }
+    }
+  }
+  return boundaryProcess;
+}
+
+}  // namespace
+
+bool GLG4SteppingAction::ApplyDirectLightFilter(const G4Step *aStep, G4Track *track) {
+  // Where did this photon come from?  GLG4Scint hands out its own dummy
+  // processes ("Scintillation", "Reemission", "ReemissionFromCompN") and RAT
+  // records the name in the TrackInfo as well, so prefer that when it is set,
+  // exactly as Gsim does when it classifies photons.
+  if (track->GetCurrentStepNumber() <= 1) {
+    std::string creatorName;
+    const G4VProcess *creator = track->GetCreatorProcess();
+    if (creator) creatorName = creator->GetProcessName();
+    RAT::TrackInfo *trackInfo = dynamic_cast<RAT::TrackInfo *>(track->GetUserInformation());
+    if (trackInfo && trackInfo->GetCreatorProcess() != "") creatorName = trackInfo->GetCreatorProcess();
+
+    // An empty name means a primary photon straight from the generator, which
+    // has not been produced by any secondary process and so is kept.
+    if (!creatorName.empty()) {
+      bool keep = false;
+      for (size_t i = 0; i < fDirectLightProcesses.size(); i++) {
+        if (creatorName.find(fDirectLightProcesses[i]) != std::string::npos) {
+          keep = true;
+          break;
+        }
+      }
+      if (!keep) {
+        track->SetTrackStatus(fStopAndKill);
+        return true;
+      }
+    }
+  }
+
+  const G4VProcess *postProcess = aStep->GetPostStepPoint()->GetProcessDefinedStep();
+  if (postProcess) {
+    if (IsOpticalScatteringProcess(postProcess->GetProcessName())) {
+      track->SetTrackStatus(fStopAndKill);
+      return true;
+    }
+
+    const G4OpBoundaryProcess *boundary = GetOpBoundaryProcess();
+    if (boundary && postProcess == boundary) {
+      switch (boundary->GetStatus()) {
+        case Undefined:
+        case Transmission:
+        case FresnelRefraction:
+        case NotAtBoundary:
+        case SameMaterial:
+        case StepTooSmall:
+        case NoRINDEX:
+        case Absorption:
+        case Detection:
+        case CoatedDielectricRefraction:
+        case CoatedDielectricFrustratedTransmission:
+          // Still direct: the photon either kept going into the next volume or
+          // is about to be absorbed/detected anyway.
+          break;
+        default:
+          // Every kind of reflection, plus Dichroic, whose outcome is ambiguous
+          // and is treated conservatively as indirect.
+          track->SetTrackStatus(fStopAndKill);
+          return true;
+      }
+    }
+  }
+
+  // Optional angular cut, measured against the emission direction rather than
+  // the previous step, so that many small deflections cannot add up to a large
+  // one without being noticed.
+  if (fDirectLightMinCosine > -1.0) {
+    if (track->GetVertexMomentumDirection().dot(track->GetMomentumDirection()) < fDirectLightMinCosine) {
+      track->SetTrackStatus(fStopAndKill);
+      return true;
+    }
+  }
+
+  return false;
+}
 
 void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
   G4Track *track = aStep->GetTrack();
@@ -149,6 +263,16 @@ void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
   // non-optical part of the event is simulated.
   if (fKillOpticalPhotons && track->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) {
     track->SetTrackStatus(fStopAndKill);
+  }
+
+  // Keep only unscattered, unreflected Cerenkov/scintillation light if asked to.
+  if (fDirectLightOnly && track->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) {
+    if (ApplyDirectLightFilter(aStep, track)) {
+      // The track is finished, so the shared zero step counter must not carry
+      // this track's history over into the next one.
+      num_zero_steps_in_a_row = 0;
+      return;
+    }
   }
 
   // check for too many zero steps in a row

--- a/src/core/src/GLG4SteppingAction.cc
+++ b/src/core/src/GLG4SteppingAction.cc
@@ -136,7 +136,7 @@ int GLG4SteppingAction_dump_IlluminationMap(void) {
 G4double GLG4SteppingAction_totEdep = 0.0;
 #endif /* G4DEBUG */
 
-G4int GLG4SteppingAction_MaxStepNumber = 100000;
+G4int GLG4SteppingAction_MaxStepNumber = 100000000;
 G4double GLG4SteppingAction::max_global_time = 0.0;
 G4bool GLG4SteppingAction::fUseGLG4 = true;
 G4bool GLG4SteppingAction::fKillOpticalPhotons = false;

--- a/src/core/src/GLG4SteppingAction.cc
+++ b/src/core/src/GLG4SteppingAction.cc
@@ -139,10 +139,17 @@ G4double GLG4SteppingAction_totEdep = 0.0;
 G4int GLG4SteppingAction_MaxStepNumber = 100000;
 G4double GLG4SteppingAction::max_global_time = 0.0;
 G4bool GLG4SteppingAction::fUseGLG4 = true;
+G4bool GLG4SteppingAction::fKillOpticalPhotons = false;
 
 void GLG4SteppingAction::UserSteppingAction(const G4Step *aStep) {
   G4Track *track = aStep->GetTrack();
   static G4int num_zero_steps_in_a_row = 0;
+
+  // Kill optical photons as soon as they are emitted, so that only the
+  // non-optical part of the event is simulated.
+  if (fKillOpticalPhotons && track->GetDefinition() == G4OpticalPhoton::OpticalPhotonDefinition()) {
+    track->SetTrackStatus(fStopAndKill);
+  }
 
   // check for too many zero steps in a row
   if (aStep->GetStepLength() <= 0.0 && track->GetCurrentStepNumber() > 1) {

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -175,6 +175,23 @@ void Gsim::BeginOfRunAction(const G4Run * /*aRun*/) {
   runID = DB::Get()->GetDefaultRun();
   utc = TTimeStamp();  // default to now
 
+  fTimePDFTuning = false;
+  try {
+    if (lmc->GetZ("tuning")) {
+      const std::string tuningOption = lmc->GetS("tuning_option");
+      if (tuningOption == "timepdf") {
+        fTimePDFTuning = true;
+        info << "Gsim: Time-PDF tuning enabled; only optical-photon trajectories that interact with a PMT will be "
+                "saved"
+             << newline;
+      } else {
+        warn << "Gsim: Unknown MC tuning option \"" << tuningOption << "\"; no tuning will be applied" << newline;
+      }
+    }
+  } catch (DBNotFoundError &e) {
+    // Tuning is opt-in so older MC tables retain their existing behavior.
+  }
+
   info << "Gsim: Simulating run " << runID << newline;
   info << "Gsim: Run start at " << utc.AsString() << newline;
 
@@ -390,6 +407,11 @@ void Gsim::PostUserTrackingAction(const G4Track *aTrack) {
   // Now deal with creator process naming override from trackInfo
   if (trackInfo && trackInfo->GetCreatorProcess() != "") {
     creatorProcessName = trackInfo->GetCreatorProcess();
+  }
+
+  if (fTimePDFTuning && trackInfo && aTrack->GetDefinition()->GetParticleName() == "opticalphoton" &&
+      !trackInfo->fTouchedPMT) {
+    fpTrackingManager->SetStoreTrajectory(false);
   }
 
   if (trackInfo) {

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -176,6 +176,7 @@ void Gsim::BeginOfRunAction(const G4Run * /*aRun*/) {
   utc = TTimeStamp();  // default to now
 
   fTimePDFTuning = false;
+  GLG4SteppingAction::fKillOpticalPhotons = false;
   try {
     if (lmc->GetZ("tuning")) {
       const std::string tuningOption = lmc->GetS("tuning_option");
@@ -184,6 +185,9 @@ void Gsim::BeginOfRunAction(const G4Run * /*aRun*/) {
         info << "Gsim: Time-PDF tuning enabled; only optical-photon trajectories that interact with a PMT will be "
                 "saved"
              << newline;
+      } else if (tuningOption == "profile") {
+        GLG4SteppingAction::fKillOpticalPhotons = true;
+        info << "Gsim: Profile tuning enabled; optical photons will be killed as soon as they are emitted" << newline;
       } else {
         warn << "Gsim: Unknown MC tuning option \"" << tuningOption << "\"; no tuning will be applied" << newline;
       }

--- a/src/io/src/OutROOTProc.cc
+++ b/src/io/src/OutROOTProc.cc
@@ -202,7 +202,7 @@ Processor::Result OutROOTProc::DSEvent(DS::Root *ds) {
       RAT::DS::MCTrack *mctrack = mc->GetMCTrack(i);
       int nsteps = mctrack->GetMCTrackStepCount();
       bool isMuon = (mctrack->GetParticleName().compare("mu-") == 0 || mctrack->GetParticleName().compare("mu+") == 0);
-      if (nsteps > 1e5 && !isMuon) {
+      if (nsteps > 1e8 && !isMuon) {
         warn << "outroot: trimming intermediate steps from MC event #" << mc->GetID() << ", track #" << mctrack->GetID()
              << " which has " << nsteps << " steps" << newline;
         mctrack->PruneIntermediateMCTrackSteps();

--- a/src/physics/src/GLG4PMTOpticalModel.cc
+++ b/src/physics/src/GLG4PMTOpticalModel.cc
@@ -33,6 +33,7 @@
 #include "G4Version.hh"
 #include "RAT/GLG4HitPhoton.hh"
 #include "RAT/GLG4VEventAction.hh"
+#include "RAT/TrackInfo.hh"
 #include "Randomize.hh"
 #include "local_g4compat.hh"
 
@@ -237,6 +238,8 @@ void GLG4PMTOpticalModel::DoIt(const G4FastTrack &fastTrack, G4FastStep &fastSte
 
   // find which pmt we are in
   ipmt = GetPMTID(fastTrack);
+  RAT::TrackInfo *trackInfo = dynamic_cast<RAT::TrackInfo *>(fastTrack.GetPrimaryTrack()->GetUserInformation());
+  if (trackInfo) trackInfo->fTouchedPMT = true;
 
   // get position and direction in local coordinates
   pos = fastTrack.GetPrimaryTrackLocalPosition();


### PR DESCRIPTION
# MC tuning options

Some studies do not need a full, faithful simulation. When you are fitting a PMT
time PDF you only care about the photons that actually reach a PMT, and when you
are profiling the non-optical part of an event you do not want the optical
simulation running at all.

The `MC` RATDB table exposes a **tuning** hook for exactly these cases. Tuning
changes the physics that is simulated or the information that is retained, so it
is strictly opt-in: with no tuning configured, ratpac-two behaves exactly as it
always has.

```{contents} Table of Contents
:depth: 2
```

## Enabling a tuning option

Two RATDB fields control tuning, and both must be set before `/run/initialize`:

| Field | Type | Meaning |
| --- | --- | --- |
| `tuning` | bool | Master switch. Tuning is applied only when this is `true`. |
| `tuning_option` | string | Which tuning to apply. |

Neither field is present in the default `ratdb/MC.ratdb`, so set them from your
macro:

```
/rat/db/set MC tuning true
/rat/db/set MC tuning_option "profile"

/run/initialize
```

Only one option can be active at a time — `tuning_option` is a single string, not
a list.

The fields are read once per run, in `Gsim::BeginOfRunAction`. Changing them
between `/run/beamOn` calls in the same macro will take effect on the next run.

## Available options

### `timepdf` — keep only photon tracks that hit a PMT

Optical-photon trajectories are discarded unless the photon entered a PMT
optical model. Photons are still fully simulated and still produce
photoelectrons; only the *stored trajectories* of the photons that never
reached a PMT are dropped.

This is what you want when generating a PMT hit-time PDF: you get the full
arrival-time information without writing out the overwhelming majority of
photons that were absorbed or lost in the detector.

```
/rat/db/set MC tuning true
/rat/db/set MC tuning_option "timepdf"

/run/initialize

/tracking/storeTrajectory 1
```

Because this option filters trajectories, it only does anything when trajectory
storage is enabled with `/tracking/storeTrajectory 1`. See
`macros/examples/timepdf.mac` for a complete working macro.

### `profile` — kill optical photons as soon as they are emitted

Every optical photon is killed on its first step, so no optical propagation is
simulated at all. Scintillation and Cherenkov photons are still *generated* —
the generating processes run normally, and the energy they consume is still
accounted for — but the photons are stopped before they travel anywhere.

The consequence is that **no photoelectrons and no PMT hits are produced**. A
20-event run of `macros/examples/timepdf.mac` gives 320 PEs across 309 MCPMTs
untuned, and 0 PEs across 0 MCPMTs with `profile` enabled.

```
/rat/db/set MC tuning true
/rat/db/set MC tuning_option "profile"

/run/initialize
```

Use this to profile or debug the non-optical part of an event — primary
particle transport, energy deposition, secondaries — without paying for the
optical simulation, or as a fast baseline when you want to confirm that a
change in the output is optical in origin.

Note that killed photons are still created as tracks. If trajectory storage is
on they are written out with a single step each, so `profile` does **not** by
itself reduce the track count in the output — the same 20-event run stored 14811
tracks tuned versus 14768 untuned, while wall-clock dropped from 27.1 s to
20.4 s (most of what remains is fixed geometry setup). Combine it with
`/tracking/storeTrajectory 0` or the `prune` processor (`mc.track:opticalphoton`)
if output size is the concern.

## Error handling

Tuning fails soft, never fatally:

* `tuning` absent or `false` — no tuning is applied, silently. This is the
  default and keeps older `MC` tables working unchanged.
* `tuning` true, `tuning_option` absent — no tuning is applied, silently.
* `tuning` true, `tuning_option` unrecognized — no tuning is applied and a
  warning is logged:

  ```
  Gsim: Unknown MC tuning option "..."; no tuning will be applied
  ```

When an option *is* applied, `Gsim` logs it at info level, so check the run
header to confirm the tuning you asked for is actually active:

```
Gsim: Time-PDF tuning enabled; only optical-photon trajectories that interact with a PMT will be saved
Gsim: Profile tuning enabled; optical photons will be killed as soon as they are emitted
```

## Adding a new tuning option

The dispatch lives in `Gsim::BeginOfRunAction` (`src/core/src/Gsim.cc`). Add a
branch comparing `tuning_option` against your new name, and have it set whatever
flag your feature reads.

Reset that flag to its default at the top of the same block, next to the
existing resets. `BeginOfRunAction` runs once per run, and the flags for
`profile` and `timepdf` are static/member state that would otherwise leak from a
tuned run into an untuned one later in the same macro.
