### PR TITLE
Add guard to GetTime

### DIFF
--- a/src/fit/include/RAT/FitterInputHandler.hh
+++ b/src/fit/include/RAT/FitterInputHandler.hh
@@ -313,7 +313,11 @@ class FitterInputHandler {
         if (std::find(fitterNames.begin(), fitterNames.end(), wfm_ana_name) == fitterNames.end()) {
           info << "FitResult not found for pmt id " << id << " " << wfm_ana_name << newline;
         }
-        return digitpmt->GetOrCreateWaveformAnalysisResult(wfm_ana_name)->getTime(0);
+        DS::WaveformAnalysisResult* result = digitpmt->GetOrCreateWaveformAnalysisResult(wfm_ana_name);
+        if (result->getNPEs() == 0)
+          Log::Die("FitterInputHandler: " + wfm_ana_name + " reconstructed no hits on channel " + std::to_string(id) +
+                   "!");
+        return result->getTime(0);
       }
       default:
         Log::Die("INVALID TYPE! Should never reach here.");

--- a/src/fit/src/ClassifyTimesProc.cc
+++ b/src/fit/src/ClassifyTimesProc.cc
@@ -183,6 +183,9 @@ Processor::Result ClassifyTimesProc::Event(DS::Root *ds, DS::EV *ev) {
       TVector3 pmtPos = fPMTInfo->GetPosition(pmtid);
       TVector3 hitDir = pmtPos - eventPos;
 
+      // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+      if (inputHandler.GetNPEs(pmtid) == 0) continue;
+
       double transitTime = hitDir.Mag() / fLightSpeed;
       double timeResidual = inputHandler.GetTime(pmtid) - transitTime - eventTime;
       pmtTimes.push_back(timeResidual);
@@ -216,6 +219,9 @@ Processor::Result ClassifyTimesProc::Event(DS::Root *ds, DS::EV *ev) {
 
     TVector3 pmtPos = fPMTInfo->GetPosition(pmtid);
     TVector3 hitDir = pmtPos - eventPos;
+
+    // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+    if (inputHandler.GetNPEs(pmtid) == 0) continue;
 
     double transitTime = hitDir.Mag() / fLightSpeed;
     double timeResidual = inputHandler.GetTime(pmtid) - transitTime - eventTime;
@@ -258,6 +264,9 @@ Processor::Result ClassifyTimesProc::Event(DS::Root *ds, DS::EV *ev) {
 
     TVector3 pmtPos = fPMTInfo->GetPosition(pmtid);
     TVector3 hitDir = pmtPos - eventPos;
+
+    // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+    if (inputHandler.GetNPEs(pmtid) == 0) continue;
 
     double transitTime = hitDir.Mag() / fLightSpeed;
     double timeResidual = inputHandler.GetTime(pmtid) - transitTime - eventTime;

--- a/src/fit/src/FitDirectionCenterProc.cc
+++ b/src/fit/src/FitDirectionCenterProc.cc
@@ -225,6 +225,9 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
       TVector3 pmtPos = fPMTInfo->GetPosition(pmtid);
       TVector3 hitDir = pmtPos - eventPos;
 
+      // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+      if (inputHandler.GetNPEs(pmtid) == 0) continue;
+
       double transitTime = hitDir.Mag() / fLightSpeed;
       double timeResidual = inputHandler.GetTime(pmtid) - transitTime - eventTime;
       pmtTimes.push_back(timeResidual);
@@ -261,6 +264,9 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
 
     // Apply time residual cuts
     if (!fCutMethod.empty()) {
+      // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+      if (inputHandler.GetNPEs(pmtid) == 0) continue;
+
       double transitTime = hitDir.Mag() / fLightSpeed;
       double timeResidual = inputHandler.GetTime(pmtid) - transitTime - eventTime;
       if ((fCutMethod == "time" && (timeResidual < fTimeResLow || timeResidual > fTimeResUp)) ||
@@ -301,6 +307,9 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
 
     // Apply time residual cuts
     if (!fCutMethod.empty()) {
+      // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+      if (inputHandler.GetNPEs(pmtid) == 0) continue;
+
       double transitTime = hitDir.Mag() / fLightSpeed;
       double timeResidual = inputHandler.GetTime(pmtid) - transitTime - eventTime;
       if ((fCutMethod == "time" && (timeResidual < fTimeResLow || timeResidual > fTimeResUp)) ||
@@ -397,6 +406,9 @@ Processor::Result FitDirectionCenterProc::Event(DS::Root *ds, DS::EV *ev) {
 
     // Apply time residual cuts
     if (!fCutMethod.empty()) {
+      // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+      if (inputHandler.GetNPEs(pmtid) == 0) continue;
+
       double transitTime = hitDir.Mag() / fLightSpeed;
       double timeResidual = inputHandler.GetTime(pmtid) - transitTime - eventTime;
       if ((fCutMethod == "time" && (timeResidual < fTimeResLow || timeResidual > fTimeResUp)) ||

--- a/src/fit/src/FitQuadProc.cc
+++ b/src/fit/src/FitQuadProc.cc
@@ -195,6 +195,11 @@ Processor::Result FitQuadProc::Event(DS::Root *ds, DS::EV *ev) {
       if (iType == fPMTtype.size()) continue;  // No match found
     }
 
+    // Skip PMTs where the waveform analyzer reconstructed no pulse, and so has no time to offer
+    if (inputHandler.GetNPEs(pmtid) == 0) {
+      continue;
+    }
+
     double time = inputHandler.GetTime(pmtid);
     if (time > 1e6) {
       continue;


### PR DESCRIPTION
When a waveform analyzer does not reconstruct any PEs for a given DigitPMT, any event fitters that call `GetTime` from the `FitterInputHandler` will cause a crash because `GetTime` expects a non-empty vector of times. 

To fix this, I added a check to `GetTime` in `FitterInputHandler` that dies when the function is called when no PEs were reconstructed. I also added checks to all the fitters that call `GetTime` to skip PMTs with no reconstructed PEs.

I'm not sure this is the best solution, so input is appreciated, but it does fix the known crash when empty waveform analysis results from RAVEN (caused by the `max_total_charge` parameter being set too low) are fed into quad.