### PR TITLE
Clang/MacOS build fix

### DIFF
--- a/src/daq/src/WaveformAnalysisLucyDDM.cc
+++ b/src/daq/src/WaveformAnalysisLucyDDM.cc
@@ -60,7 +60,7 @@ void WaveformAnalysisLucyDDM::DoAnalysis(DS::DigitPMT* digitpmt, const std::vect
   std::vector<double> demod_result = Deconvolve(voltWfm, iterations_ran);
   auto end = std::chrono::high_resolution_clock::now();
   debug << "Deconvolution took "
-        << static_cast<int64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()) << " ms."
+        << static_cast<long>(std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()) << " ms."
         << newline;
   std::vector<double> reblurred_wfm = ReblurWaveform(demod_result);
   double poisson_nll = PoissonNLL(Resample(voltWfm, reblurred_wfm.size()), reblurred_wfm);


### PR DESCRIPTION
# Clang/MacOS build fix

While trying to build ratpac on macos using the default clang compiler I ran into one compiler error where `int64_t` was used instead of `long`. Changing this to `long` fixes the error. 

The problem is that `int64_t` is typedef'd to `long` on linux but `long long` on macos (despite both being 64 bit ints). stlplus's output stream does not have an overload for long long  so it fails to compile

The `RATEvent` target still doesn't compile but the `RATPAC` and `rat` executable targets still compile so I think this is good enough for now. There is an issue with how `RATEvent` links that I will hopefully fix in a later PR. 

fix #391