### PR TITLE
Add pileup generator

### DIFF
--- a/doc/users_guide/generators/toplevel.rst
+++ b/doc/users_guide/generators/toplevel.rst
@@ -3,6 +3,7 @@ Top-level generators
 Top-level generators are understood by the /generator/add command.
 
 .. include:: /users_guide/generators/toplevel/combo.rst
+.. include:: /users_guide/generators/toplevel/pileup.rst
 .. include:: /users_guide/generators/toplevel/decaychain.rst
 .. include:: /users_guide/generators/toplevel/cfsource.rst
 .. include:: /users_guide/generators/toplevel/led.rst

--- a/doc/users_guide/generators/toplevel/pileup.rst
+++ b/doc/users_guide/generators/toplevel/pileup.rst
@@ -33,9 +33,9 @@ poisson mean must be greater than 0.
 
 ::
 
-    /generator/pileup/spacing fixed:dt
-    /generator/pileup/spacing uniform:min:max
-    /generator/pileup/spacing poisson:mean
+    /generator/pileup/timing fixed:dt
+    /generator/pileup/timing uniform:min:max
+    /generator/pileup/timing poisson:mean
 
 Sets the distribution, in ns, for vertex times relative to the event start
 time (TIME). ``fixed`` places vertices dt apart, starting at TIME.
@@ -51,7 +51,7 @@ Example
 ::
 
     /generator/pileup/multiplicity poisson:5
-    /generator/pileup/spacing uniform:0:1000
+    /generator/pileup/timing uniform:0:1000
 
 A constant-rate radioactive source observed over a fixed time window: the
 number of decays in the window is Poisson-distributed, and conditioned on

--- a/doc/users_guide/generators/toplevel/pileup.rst
+++ b/doc/users_guide/generators/toplevel/pileup.rst
@@ -1,0 +1,59 @@
+pileup
+''''''
+::
+
+    /generator/add pileup VERTEX:POSITION:TIME
+
+or
+
+::
+
+    /generator/add pileup VERTEX:POSITION
+
+Creates a new pileup generator using the vertex and position generators
+described below. If the variant without a TIME parameter is used, it implies
+the "poisson" time generator. The TIME generator controls the spacing
+between separate pileup *events*; within each event, the generator produces
+multiple primary vertices from the same VERTEX/POSITION configuration,
+with a count and per-vertex timing set by the commands below.
+
+::
+
+    /generator/pileup/multiplicity fixed:N
+    /generator/pileup/multiplicity uniform:min:max
+    /generator/pileup/multiplicity poisson:mean
+
+Sets the distribution for the number of vertices generated per event.
+``fixed`` always generates exactly N vertices, ``uniform`` draws an integer
+uniformly between min and max (inclusive), and ``poisson`` draws from a
+zero-truncated Poisson distribution with the given mean (a sample of 0 is
+rejected and redrawn, since every pileup event must contain at least one
+vertex). Defaults to ``fixed:1``. N and min must be at least 1, and the
+poisson mean must be greater than 0.
+
+::
+
+    /generator/pileup/spacing fixed:dt
+    /generator/pileup/spacing uniform:min:max
+    /generator/pileup/spacing poisson:mean
+
+Sets the distribution, in ns, for vertex times relative to the event start
+time (TIME). ``fixed`` places vertices dt apart, starting at TIME.
+``uniform`` draws each vertex's offset from TIME independently and
+uniformly between min and max, then time-orders the results.
+``poisson`` draws each vertex's offset from TIME independently from an
+exponential distribution with the given mean, then time-orders the results.
+Defaults to ``fixed:0``.
+
+Example
+--------
+
+::
+
+    /generator/pileup/multiplicity poisson:5
+    /generator/pileup/spacing uniform:0:1000
+
+A constant-rate radioactive source observed over a fixed time window: the
+number of decays in the window is Poisson-distributed, and conditioned on
+that count, each decay's time within the window is independent and
+uniformly distributed.

--- a/macros/examples/pileup.mac
+++ b/macros/examples/pileup.mac
@@ -1,0 +1,34 @@
+### pileup.mac
+#
+# Demonstrates the "pileup" generator: each event contains multiple
+# primary vertices from a single vertex/position generator, with the
+# number of vertices and their times relative to the event start each
+# drawn from a configurable distribution (fixed, uniform, or poisson).
+#
+
+/glg4debug/glg4param omit_muon_processes 1.0
+/glg4debug/glg4param omit_hadronic_processes 1.0
+
+/rat/db/set DETECTOR experiment "Validation"
+/rat/db/set DETECTOR geo_file "Validation/Valid.geo"
+
+/run/initialize
+
+/rat/proc count
+/rat/procset update 10
+
+/rat/proclast outntuple
+
+# Central 1 MeV electrons, one event every 2 seconds on average
+/generator/add pileup gun:point:poisson
+/generator/vtx/set e- 0.0 0.0 0.0 1.0
+/generator/pos/set 0.0 0.0 0.0
+/generator/rate/set 0.5
+
+# Number of pile-up vertices per event: Poisson-distributed, mean of 3
+/generator/pileup/multiplicity poisson:3
+
+# Vertex times, relative to the event start: uniform over 0-50 ns
+/generator/pileup/spacing uniform:0:50
+
+/run/beamOn 100

--- a/macros/examples/pileup.mac
+++ b/macros/examples/pileup.mac
@@ -29,6 +29,6 @@
 /generator/pileup/multiplicity poisson:3
 
 # Vertex times, relative to the event start: uniform over 0-50 ns
-/generator/pileup/spacing uniform:0:50
+/generator/pileup/timing uniform:0:50
 
 /run/beamOn 100

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(cmd OBJECT
         src/GLG4VisMessenger.cc
         src/IsotopeMessenger.cc
         src/PhysicsListMessenger.cc
+        src/PileupMessenger.cc
         src/ProcBlockManager.cc
         src/IBDgenMessenger.cc
         src/RatMessenger.cc

--- a/src/cmd/include/RAT/PileupMessenger.hh
+++ b/src/cmd/include/RAT/PileupMessenger.hh
@@ -1,0 +1,36 @@
+// RAT::PileupMessenger
+// Provide user commands to allow the user to configure the multiplicity
+// and per-vertex timing distributions of the PileupGen generator.
+
+#ifndef RAT_PileupMessenger_hh
+#define RAT_PileupMessenger_hh
+
+#include <memory>
+
+#include "G4String.hh"
+#include "G4UImessenger.hh"
+
+class G4UIcommand;
+
+namespace RAT {
+
+class PileupGen;
+
+class PileupMessenger : public G4UImessenger {
+ public:
+  PileupMessenger(PileupGen *);
+  ~PileupMessenger();
+
+  void SetNewValue(G4UIcommand *command, G4String newValues);
+  G4String GetCurrentValue(G4UIcommand *command);
+
+ private:
+  PileupGen *fGen;
+
+  std::unique_ptr<G4UIcommand> MultiplicityCmd;
+  std::unique_ptr<G4UIcommand> SpacingCmd;
+};
+
+}  // namespace RAT
+
+#endif  // RAT_PileupMessenger_hh

--- a/src/cmd/include/RAT/PileupMessenger.hh
+++ b/src/cmd/include/RAT/PileupMessenger.hh
@@ -28,7 +28,7 @@ class PileupMessenger : public G4UImessenger {
   PileupGen *fGen;
 
   std::unique_ptr<G4UIcommand> MultiplicityCmd;
-  std::unique_ptr<G4UIcommand> SpacingCmd;
+  std::unique_ptr<G4UIcommand> TimingCmd;
 };
 
 }  // namespace RAT

--- a/src/cmd/src/PileupMessenger.cc
+++ b/src/cmd/src/PileupMessenger.cc
@@ -22,14 +22,14 @@ PileupMessenger::PileupMessenger(PileupGen *gen) : fGen(gen) {
   MultiplicityCmd->SetGuidance("Usage: /generator/pileup/multiplicity fixed:N | uniform:min:max | poisson:mean");
   MultiplicityCmd->SetParameter(new G4UIparameter("dist", 's', true));
 
-  SpacingCmd = std::make_unique<G4UIcommand>("/generator/pileup/spacing", this);
-  SpacingCmd->SetGuidance("Set the distribution for vertex times (ns) relative to the event start time.");
-  SpacingCmd->SetGuidance(
+  TimingCmd = std::make_unique<G4UIcommand>("/generator/pileup/timing", this);
+  TimingCmd->SetGuidance("Set the distribution for vertex times (ns) relative to the event start time.");
+  TimingCmd->SetGuidance(
       "fixed:dt places vertices dt apart; uniform:min:max draws each vertex's offset "
       "independently and uniformly from [min,max] and time-orders them; poisson:mean draws each "
       "vertex's offset independently from Exponential(mean) and time-orders them");
-  SpacingCmd->SetGuidance("Usage: /generator/pileup/spacing fixed:dt | uniform:min:max | poisson:mean");
-  SpacingCmd->SetParameter(new G4UIparameter("dist", 's', true));
+  TimingCmd->SetGuidance("Usage: /generator/pileup/timing fixed:dt | uniform:min:max | poisson:mean");
+  TimingCmd->SetParameter(new G4UIparameter("dist", 's', true));
 }
 
 PileupMessenger::~PileupMessenger() {}
@@ -37,8 +37,8 @@ PileupMessenger::~PileupMessenger() {}
 void PileupMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
   if (command == MultiplicityCmd.get()) {
     fGen->SetMultiplicityState(newValues);
-  } else if (command == SpacingCmd.get()) {
-    fGen->SetSpacingState(newValues);
+  } else if (command == TimingCmd.get()) {
+    fGen->SetVertexTimingState(newValues);
   } else {
     RAT::warn << "Error: PileupMessenger invalid command" << newline;
   }
@@ -47,8 +47,8 @@ void PileupMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
 G4String PileupMessenger::GetCurrentValue(G4UIcommand *command) {
   if (command == MultiplicityCmd.get()) {
     return fGen->GetMultiplicityState();
-  } else if (command == SpacingCmd.get()) {
-    return fGen->GetSpacingState();
+  } else if (command == TimingCmd.get()) {
+    return fGen->GetVertexTimingState();
   }
   return G4String("invalid Pileup Messenger \"get\" command");
 }

--- a/src/cmd/src/PileupMessenger.cc
+++ b/src/cmd/src/PileupMessenger.cc
@@ -1,0 +1,56 @@
+// RAT::PileupMessenger
+// Provide user commands to allow the user to configure the multiplicity
+// and per-vertex timing distributions of the PileupGen generator.
+
+#include <G4String.hh>
+#include <G4UIcommand.hh>
+#include <G4UIdirectory.hh>
+#include <G4UIparameter.hh>
+#include <RAT/Log.hh>
+#include <RAT/PileupGen.hh>
+#include <RAT/PileupMessenger.hh>
+
+namespace RAT {
+
+PileupMessenger::PileupMessenger(PileupGen *gen) : fGen(gen) {
+  // Commands live in a /generator/pileup/ directory
+  G4UIdirectory *dir = new G4UIdirectory("/generator/pileup/");
+  dir->SetGuidance("Control the parameters of the pileup generator");
+
+  MultiplicityCmd = std::make_unique<G4UIcommand>("/generator/pileup/multiplicity", this);
+  MultiplicityCmd->SetGuidance("Set the distribution for the number of vertices per event.");
+  MultiplicityCmd->SetGuidance("Usage: /generator/pileup/multiplicity fixed:N | uniform:min:max | poisson:mean");
+  MultiplicityCmd->SetParameter(new G4UIparameter("dist", 's', true));
+
+  SpacingCmd = std::make_unique<G4UIcommand>("/generator/pileup/spacing", this);
+  SpacingCmd->SetGuidance("Set the distribution for vertex times (ns) relative to the event start time.");
+  SpacingCmd->SetGuidance(
+      "fixed:dt places vertices dt apart; uniform:min:max draws each vertex's offset "
+      "independently and uniformly from [min,max] and time-orders them; poisson:mean draws each "
+      "vertex's offset independently from Exponential(mean) and time-orders them");
+  SpacingCmd->SetGuidance("Usage: /generator/pileup/spacing fixed:dt | uniform:min:max | poisson:mean");
+  SpacingCmd->SetParameter(new G4UIparameter("dist", 's', true));
+}
+
+PileupMessenger::~PileupMessenger() {}
+
+void PileupMessenger::SetNewValue(G4UIcommand *command, G4String newValues) {
+  if (command == MultiplicityCmd.get()) {
+    fGen->SetMultiplicityState(newValues);
+  } else if (command == SpacingCmd.get()) {
+    fGen->SetSpacingState(newValues);
+  } else {
+    RAT::warn << "Error: PileupMessenger invalid command" << newline;
+  }
+}
+
+G4String PileupMessenger::GetCurrentValue(G4UIcommand *command) {
+  if (command == MultiplicityCmd.get()) {
+    return fGen->GetMultiplicityState();
+  } else if (command == SpacingCmd.get()) {
+    return fGen->GetSpacingState();
+  }
+  return G4String("invalid Pileup Messenger \"get\" command");
+}
+
+}  // namespace RAT

--- a/src/core/src/Gsim.cc
+++ b/src/core/src/Gsim.cc
@@ -34,6 +34,7 @@
 #include <RAT/PDFPMTTime.hh>
 #include <RAT/PMTFactoryBase.hh>
 #include <RAT/PhysicsList.hh>
+#include <RAT/PileupGen.hh>
 #include <RAT/PrimaryVertexInformation.hh>
 #include <RAT/ProcBlock.hh>
 #include <RAT/ReacIBDgen.hh>
@@ -131,6 +132,7 @@ void Gsim::Init() {
   GlobalFactory<GLG4Gen>::Register("he", new Alloc<GLG4Gen, HeGen>);
   GlobalFactory<GLG4Gen>::Register("led", new Alloc<GLG4Gen, Gen_LED>);
   GlobalFactory<GLG4Gen>::Register("coincidence", new Alloc<GLG4Gen, Coincidence_Gen>);
+  GlobalFactory<GLG4Gen>::Register("pileup", new Alloc<GLG4Gen, PileupGen>);
   GlobalFactory<GLG4Gen>::Register("vertexfile", new Alloc<GLG4Gen, VertexFile_Gen>);
   GlobalFactory<GLG4Gen>::Register("rootracker", new Alloc<GLG4Gen, RooTracker_Gen>);
 

--- a/src/gen/CMakeLists.txt
+++ b/src/gen/CMakeLists.txt
@@ -28,6 +28,7 @@ set(gen_sources
     src/Gen_LED.cc
     src/Gen_RandomTrigger.cc
     src/IBDgen.cc
+    src/PileupGen.cc
     src/PosGen_FillShell.cc
     src/PosGen_Line.cc
     src/PosGen_Multipoint.cc

--- a/src/gen/include/RAT/PileupGen.hh
+++ b/src/gen/include/RAT/PileupGen.hh
@@ -87,8 +87,8 @@ class PileupGen : public GLG4Gen {
 
   void SetMultiplicityState(G4String state);
   G4String GetMultiplicityState() const;
-  void SetSpacingState(G4String state);
-  G4String GetSpacingState() const;
+  void SetVertexTimingState(G4String state);
+  G4String GetVertexTimingState() const;
 
  protected:
   G4String stateStr;
@@ -97,7 +97,7 @@ class PileupGen : public GLG4Gen {
   GLG4PosGen *posGen;
 
   PileupDist multiplicityDist;
-  PileupDist spacingDist;
+  PileupDist vertexTimingDist;
 
   std::unique_ptr<PileupMessenger> messenger;
 };

--- a/src/gen/include/RAT/PileupGen.hh
+++ b/src/gen/include/RAT/PileupGen.hh
@@ -1,0 +1,107 @@
+// RAT::PileupGen
+// Generates events with multiple primary vertices from a single
+// vertex/position generator, with independently configurable
+// (fixed/uniform/poisson) distributions for the number of vertices
+// per event and their times.
+
+#ifndef __PileupGen_h__
+#define __PileupGen_h__
+
+#include <cstdint>
+#include <globals.hh>
+#include <memory>
+#include <vector>
+
+#include "RAT/GLG4Gen.hh"
+
+class GLG4TimeGen;
+class GLG4VertexGen;
+class GLG4PosGen;
+
+namespace RAT {
+
+class PileupMessenger;
+
+// Distribution used for both the number-of-vertices-per-event and the
+// per-vertex timing parameters of PileupGen.
+enum PileupDistType { kPileupFixed, kPileupUniform, kPileupPoisson };
+
+class PileupDist {
+ public:
+  PileupDist() : type(kPileupFixed), fixedValue(1.0), uniformMin(0.0), uniformMax(1.0), poissonMean(1.0){};
+
+  // Format: "fixed:value" | "uniform:min:max" | "poisson:mean"
+  void SetState(G4String state);
+  G4String GetState() const;
+
+  // Sorted event times for each vertex
+  std::vector<double> GenerateTimes(uint64_t n, double startTime) const;
+  // Non-negative integer sample, used for vertex multiplicity.
+  uint64_t SampleMultiplicity() const;
+
+  // True unless the configuration is provably able to sample a
+  // multiplicity below 1 (fixed value or uniform range starting below 1).
+  // Poisson multiplicity is always safe: SampleMultiplicity() rejects zero
+  // samples and draws from a zero-truncated Poisson distribution instead.
+  bool MultiplicityConfigIsValid() const;
+
+ protected:
+  PileupDistType type;
+  // These are used as a continuous value, in ns by
+  // GenerateTimes(), and rounded to the nearest integer count by
+  // SampleMultiplicity()/MultiplicityConfigIsValid() -- the same double
+  // does double duty as either a duration or a count depending on which
+  // method the caller invokes. Same reasoning as poissonMean below.
+  double fixedValue;
+  double uniformMin, uniformMax;
+  // Mean of a Poisson distribution when sampled by SampleMultiplicity()
+  // (a discrete vertex count), or of the exponential distribution each
+  // vertex's time offset is independently drawn from when sampled by
+  // GenerateTimes().
+  double poissonMean;
+};
+
+// Generates events made up of multiple primary vertices, (pileup) drawn
+// from a single vertex/position generator configuration.  The number of
+// vertices per event and their times relative to the event start time
+// are each independently configurable as fixed, uniform, or Poisson-mean
+// distributions.
+class PileupGen : public GLG4Gen {
+ public:
+  PileupGen();
+  virtual ~PileupGen();
+
+  virtual void GenerateEvent(G4Event *event);
+  virtual void ResetTime(double offset = 0.0);
+  virtual bool IsRepeatable() const { return true; };
+
+  virtual void SetState(G4String state);
+  virtual G4String GetState() const;
+
+  virtual void SetTimeState(G4String state);
+  virtual G4String GetTimeState() const;
+  virtual void SetVertexState(G4String state);
+  virtual G4String GetVertexState() const;
+  virtual void SetPosState(G4String state);
+  virtual G4String GetPosState() const;
+
+  void SetMultiplicityState(G4String state);
+  G4String GetMultiplicityState() const;
+  void SetSpacingState(G4String state);
+  G4String GetSpacingState() const;
+
+ protected:
+  G4String stateStr;
+  GLG4TimeGen *timeGen;
+  GLG4VertexGen *vertexGen;
+  GLG4PosGen *posGen;
+
+  PileupDist multiplicityDist;
+  PileupDist spacingDist;
+
+  std::unique_ptr<PileupMessenger> messenger;
+};
+
+}  // namespace RAT
+
+#endif

--- a/src/gen/src/PileupGen.cc
+++ b/src/gen/src/PileupGen.cc
@@ -130,7 +130,7 @@ bool PileupDist::MultiplicityConfigIsValid() const {
 PileupGen::PileupGen() : stateStr(""), vertexGen(nullptr), posGen(nullptr) {
   timeGen = new GLG4TimeGen_Poisson();
   multiplicityDist.SetState("fixed:1");
-  spacingDist.SetState("fixed:0");
+  vertexTimingDist.SetState("fixed:0");
   messenger = std::make_unique<PileupMessenger>(this);
 }
 
@@ -149,7 +149,7 @@ void PileupGen::GenerateEvent(G4Event *event) {
     return;
   }
 
-  std::vector<double> times = spacingDist.GenerateTimes(n, NextTime());
+  std::vector<double> times = vertexTimingDist.GenerateTimes(n, NextTime());
   for (uint64_t i = 0; i < n; i++) {
     G4ThreeVector pos;
     posGen->GeneratePosition(pos);
@@ -247,8 +247,8 @@ void PileupGen::SetMultiplicityState(G4String state) {
 
 G4String PileupGen::GetMultiplicityState() const { return multiplicityDist.GetState(); }
 
-void PileupGen::SetSpacingState(G4String state) { spacingDist.SetState(state); }
+void PileupGen::SetVertexTimingState(G4String state) { vertexTimingDist.SetState(state); }
 
-G4String PileupGen::GetSpacingState() const { return spacingDist.GetState(); }
+G4String PileupGen::GetVertexTimingState() const { return vertexTimingDist.GetState(); }
 
 }  // namespace RAT

--- a/src/gen/src/PileupGen.cc
+++ b/src/gen/src/PileupGen.cc
@@ -1,0 +1,254 @@
+#include "RAT/PileupGen.hh"
+
+#include <G4Event.hh>
+#include <G4ThreeVector.hh>
+#include <RAT/Factory.hh>
+#include <RAT/Log.hh>
+#include <RAT/PileupMessenger.hh>
+#include <Randomize.hh>
+#include <algorithm>
+#include <cmath>
+
+#include "RAT/GLG4PosGen.hh"
+#include "RAT/GLG4StringUtil.hh"
+#include "RAT/GLG4TimeGen.hh"
+#include "RAT/GLG4VertexGen.hh"
+
+namespace RAT {
+
+void PileupDist::SetState(G4String state) {
+  state = util_strip_default(state);
+
+  if (state.length() == 0) {
+    // print help and current state
+    info << "Current state of this PileupDist: \"" << GetState() << "\"" << newline << newline;
+    info << "Format of argument to PileupDist::SetState: " << newline
+         << " \"fixed:value\" | \"uniform:min:max\" | \"poisson:mean\"" << newline;
+    return;
+  }
+
+  std::vector<std::string> parts = util_split(state, ":");
+
+  if (parts[0] == "fixed") {
+    if (parts.size() != 2) {
+      G4Exception(__FILE__, "Invalid Parameter", FatalException,
+                  ("PileupDist syntax error, expected \"fixed:value\": " + state).c_str());
+      return;  // G4Exception(FatalException) aborts; return anyway so
+               // parts[1] below is never read out of bounds.
+    }
+    type = kPileupFixed;
+    fixedValue = util_to_double(parts[1]);
+  } else if (parts[0] == "uniform") {
+    if (parts.size() != 3) {
+      G4Exception(__FILE__, "Invalid Parameter", FatalException,
+                  ("PileupDist syntax error, expected \"uniform:min:max\": " + state).c_str());
+      return;  // see above
+    }
+    type = kPileupUniform;
+    uniformMin = util_to_double(parts[1]);
+    uniformMax = util_to_double(parts[2]);
+  } else if (parts[0] == "poisson") {
+    if (parts.size() != 2) {
+      G4Exception(__FILE__, "Invalid Parameter", FatalException,
+                  ("PileupDist syntax error, expected \"poisson:mean\": " + state).c_str());
+      return;  // see above
+    }
+    type = kPileupPoisson;
+    poissonMean = util_to_double(parts[1]);
+    if (poissonMean <= 0.0) {
+      G4Exception(__FILE__, "Invalid Parameter", FatalException,
+                  ("PileupDist poisson mean must be > 0: " + state).c_str());
+    }
+  } else {
+    G4Exception(__FILE__, "Invalid Parameter", FatalException,
+                ("PileupDist unknown distribution type: " + parts[0]).c_str());
+  }
+}
+
+G4String PileupDist::GetState() const {
+  switch (type) {
+    case kPileupFixed:
+      return util_dformat("fixed:%lf", fixedValue);
+    case kPileupUniform:
+      return util_dformat("uniform:%lf:%lf", uniformMin, uniformMax);
+    case kPileupPoisson:
+      return util_dformat("poisson:%lf", poissonMean);
+  }
+  return "";
+}
+
+std::vector<double> PileupDist::GenerateTimes(uint64_t n, double startTime) const {
+  std::vector<double> times(n);
+  switch (type) {
+    case kPileupFixed:
+      for (uint64_t i = 0; i < n; i++) times[i] = startTime + i * fixedValue;
+      break;
+    case kPileupUniform:
+      for (uint64_t i = 0; i < n; i++) times[i] = startTime + CLHEP::RandFlat::shoot(uniformMin, uniformMax);
+      std::sort(times.begin(), times.end());
+      break;
+    case kPileupPoisson:
+      for (uint64_t i = 0; i < n; i++) times[i] = startTime + CLHEP::RandExponential::shoot(poissonMean);
+      std::sort(times.begin(), times.end());
+      break;
+  }
+  return times;
+}
+
+uint64_t PileupDist::SampleMultiplicity() const {
+  switch (type) {
+    case kPileupFixed:
+      return static_cast<uint64_t>(std::round(fixedValue));
+    case kPileupUniform:
+      return static_cast<uint64_t>(
+          CLHEP::RandFlat::shootInt(static_cast<long>(uniformMin), static_cast<long>(uniformMax) + 1));
+    case kPileupPoisson: {
+      // Draw from zero truncated Poisson distribution
+      uint64_t n = 0;
+      while (n < 1) {
+        n = static_cast<uint64_t>(CLHEP::RandPoisson::shoot(poissonMean));
+      }
+      return n;
+    }
+  }
+  return 0;
+}
+
+bool PileupDist::MultiplicityConfigIsValid() const {
+  switch (type) {
+    case kPileupFixed:
+      return std::round(fixedValue) >= 1.0;
+    case kPileupUniform:
+      return std::floor(uniformMin) >= 1.0;
+    case kPileupPoisson:
+      // SampleMultiplicity() rejects zero samples, so this is always safe.
+      return true;
+  }
+  return true;
+}
+
+PileupGen::PileupGen() : stateStr(""), vertexGen(nullptr), posGen(nullptr) {
+  timeGen = new GLG4TimeGen_Poisson();
+  multiplicityDist.SetState("fixed:1");
+  spacingDist.SetState("fixed:0");
+  messenger = std::make_unique<PileupMessenger>(this);
+}
+
+PileupGen::~PileupGen() {
+  delete timeGen;
+  delete vertexGen;
+  delete posGen;
+}
+
+void PileupGen::GenerateEvent(G4Event *event) {
+  uint64_t n = multiplicityDist.SampleMultiplicity();
+  if (n < 1) {
+    G4Exception(__FILE__, "Invalid Multiplicity", FatalException,
+                "PileupGen sampled zero vertices for this event; every pileup event must "
+                "contain at least one vertex. Adjust the multiplicity configuration.");
+    return;
+  }
+
+  std::vector<double> times = spacingDist.GenerateTimes(n, NextTime());
+  for (uint64_t i = 0; i < n; i++) {
+    G4ThreeVector pos;
+    posGen->GeneratePosition(pos);
+    vertexGen->GeneratePrimaryVertex(event, pos, times[i]);
+  }
+}
+
+void PileupGen::ResetTime(double offset) { nextTime = timeGen->GenerateEventTime() + offset; }
+
+void PileupGen::SetState(G4String state) {
+  state = util_strip_default(state);
+
+  std::vector<std::string> parts = util_split(state, ":");
+
+  try {
+    switch (parts.size()) {
+      case 3:
+        // last is optional time generator
+        delete timeGen;
+        timeGen = nullptr;  // In case of exception in next line
+        timeGen = RAT::GlobalFactory<GLG4TimeGen>::New(parts[2]);
+        [[fallthrough]];
+      case 2:
+        delete vertexGen;
+        vertexGen = nullptr;
+        vertexGen = RAT::GlobalFactory<GLG4VertexGen>::New(parts[0]);
+        delete posGen;
+        posGen = nullptr;
+        posGen = RAT::GlobalFactory<GLG4PosGen>::New(parts[1]);
+        break;
+      default:
+        G4Exception(__FILE__, "Invalid Parameter", FatalException, ("Pileup generator syntax error: " + state).c_str());
+        break;
+    }
+
+    stateStr = state;  // Save for later call to GetState()
+  } catch (RAT::FactoryUnknownID &unknown) {
+    warn << "Unknown generator \"" << unknown.id << "\"" << newline;
+  }
+}
+
+G4String PileupGen::GetState() const { return stateStr; }
+
+void PileupGen::SetTimeState(G4String state) {
+  if (timeGen)
+    timeGen->SetState(state);
+  else
+    warn << "PileupGen error: Cannot set time state, no time generator selected" << newline;
+}
+
+G4String PileupGen::GetTimeState() const {
+  if (timeGen)
+    return timeGen->GetState();
+  else
+    return G4String("PileupGen error: no time generator selected");
+}
+
+void PileupGen::SetVertexState(G4String state) {
+  if (vertexGen)
+    vertexGen->SetState(state);
+  else
+    warn << "PileupGen error: Cannot set vertex state, no vertex generator selected" << newline;
+}
+
+G4String PileupGen::GetVertexState() const {
+  if (vertexGen)
+    return vertexGen->GetState();
+  else
+    return G4String("PileupGen error: no vertex generator selected");
+}
+
+void PileupGen::SetPosState(G4String state) {
+  if (posGen)
+    posGen->SetState(state);
+  else
+    warn << "PileupGen error: Cannot set position state, no position generator selected" << newline;
+}
+
+G4String PileupGen::GetPosState() const {
+  if (posGen)
+    return posGen->GetState();
+  else
+    return G4String("PileupGen error: no pos generator selected");
+}
+
+void PileupGen::SetMultiplicityState(G4String state) {
+  multiplicityDist.SetState(state);
+  if (!multiplicityDist.MultiplicityConfigIsValid()) {
+    G4Exception(__FILE__, "Invalid Parameter", FatalException,
+                ("PileupGen multiplicity configuration can produce zero vertices per event: \"" + state +
+                 "\". Every pileup event must contain at least one vertex.")
+                    .c_str());
+  }
+}
+
+G4String PileupGen::GetMultiplicityState() const { return multiplicityDist.GetState(); }
+
+void PileupGen::SetSpacingState(G4String state) { spacingDist.SetState(state); }
+
+G4String PileupGen::GetSpacingState() const { return spacingDist.GetState(); }
+
+}  // namespace RAT


### PR DESCRIPTION
I've added a new generator to simulate various forms of pileup. It uses the standard vertex, position and time generators with `/generator/add pileup VERTEX:POSITION:TIME` but also allows you generate different multiplicities with `/generator/pileup/multiplicity` and different timings of the pileup events with `/generator/pileup/timing`. 

The multiplicity has three distribution options: fixed, uniform, poisson. The timing has three independent distributions of fixed (constant spacing between vertices), uniform (each time sampled in a uniform distribution) and poisson (exponential time distribution).