### PR TITLE
Enforce absolute path requirement for rattest experiment binaries

### DIFF
--- a/python/rattest/__init__.py
+++ b/python/rattest/__init__.py
@@ -112,7 +112,10 @@ class RatTest:
         if rat_bin is None:
             self.rat_bin = os.path.abspath(os.path.join(os.environ['RATROOT'], 'bin', 'rat'))
         else:
-            self.rat_bin = rat_bin
+            self.rat_bin = os.path.abspath(rat_bin)
+            if not os.path.exists(self.rat_bin):
+                raise RuntimeError(f"Experiment binary not found: {self.rat_bin}. "
+                                   f"Expected a path to the binary.")
 
         # Set the event file basename (rat appends .root or .ntuple.root automatically)
         self.event_file_basename = 'mc_events'


### PR DESCRIPTION
The experiment binary that can be provided for a rattest should be an absolute path, but this is not explicitly enforced, causing inconsistent errors downstream if a binary name is provided instead. Added an explicit check and error in the case that an absolute path is not provided.