### PR TITLE
Fix histogram comparison log sorting and labeling

### DIFF
--- a/python/rattest/__init__.py
+++ b/python/rattest/__init__.py
@@ -250,7 +250,7 @@ class RatTest:
         critical_probability = self.KS_threshold / len(both)
         overall_success = True
 
-        for objname in both:
+        for objname in sorted(both):
             c_obj = current_file.Get(objname)
             m_obj = master_file.Get(objname)
 
@@ -273,7 +273,7 @@ class RatTest:
                     success = False
                     overall_success = False
 
-            success_message = "\033[1;32mSUCCESS\033[0m" if (success and overall_success) else "\033[1;31mFAILURE\033[0m"
+            success_message = "\033[1;32mSUCCESS\033[0m" if success else "\033[1;31mFAILURE\033[0m"
             print("  {}: KS prob = {}".format(success_message, prob))
 
             plotfile = os.path.join(self.testdir, objname + '.png')


### PR DESCRIPTION
Two minor bugfixes to the histogram comparison section of the rattest logs. 
1) Since an unordered set of histograms is iterated through, the order of the histogram comparisons in the log is randomized, as shown in the images below. The fix is to just sort the iterable.
<img width="467" height="227" alt="Screenshot From 2026-08-26 10-55-49" src="https://github.com/user-attachments/assets/5f8fc3c5-6bab-48be-af00-044cfb4e5ab3" />
<img width="467" height="227" alt="Screenshot From 2026-08-26 10-55-45" src="https://github.com/user-attachments/assets/204abc90-c194-4041-9012-505f2c080abd" />

2) The SUCCESS or FAILURE message by each histogram comparison is determined by `success and overall_success`, so once one histogram fails the comparison all subsequent comparisons will display FAILURE even if they succeeded, making determining which comparison actually failed harder at a glance. The fix is to only use `success` to choose which message to display for the individual comparisons.