### PR TITLE
Add extra paths for ratdb

### DIFF
--- a/doc/users_guide/database.rst
+++ b/doc/users_guide/database.rst
@@ -151,13 +151,13 @@ these tables will override any other tables with the same name. This can be very
 when an experiment wants to override the default values in certain tables, without
 worrying about telling a processor how to read a table with a non-default index.
 
-If a downstream experiment adds its own data directory by inserting directly into the
-legacy ``RAT::Rat::ratdb_directories`` set, ``$RATSHARE/ratdb`` always wins any table-name
-collision against it (in older RATPAC-2 versions this was arbitrary, not guaranteed).
-To override ``$RATSHARE/ratdb`` instead, use ``RAT::Rat::ratdb_search_path`` and
-``Prepend()`` the directory (see "For downstream experiments (C++ API)" below).
+If a downstream experiment adds its own data directory via the deprecated
+``RAT::Rat::ratdb_directories.insert()`` (see "For downstream experiments" 
+below), it is treated as highest priority and will win any
+table-name collision against ``$RATSHARE/ratdb``. To make this explicit
+instead, use ``Prepend()``/``Append()`` directly.
 **If an override is required, always place the overriding table in the
-experiment-specific directory, or use ``ratdb_search_path``.**
+experiment-specific directory, or use ``RAT::Rat::ratdb_directories``.**
 
 Adding extra RATDB search directories
 ``````````````````````````````````````
@@ -180,21 +180,18 @@ For downstream experiments
 ``````````````````````````````````````
 Experiment-specific ``RAT::Rat`` subclasses have historically added their own
 data directories by inserting directly into the public
-``RAT::Rat::ratdb_directories`` set, e.g.::
+``RAT::Rat::ratdb_directories``, which used to be a ``std::set``, e.g.::
 
   ratdb_directories.insert(my_experiment_data_dir + "/ratdb");
 
-This still compiles, and such directories are still searched by
-``DB::Load()``, ``DBTextLoader::PickFile()``, and the experiment-specific
-directory search described above. However, ``ratdb_directories`` is a
-``std::set``, which cannot express priority order: as a result,
-``$RATSHARE/ratdb`` is always loaded last (and therefore always wins any
-table-name collision) in ``DB::LoadDefaults()``, regardless of what has also
-been inserted into ``ratdb_directories``.
+This still compiles: ``ratdb_directories`` is now an ordered
+``RatdbDirectoryList``, and ``insert()`` is kept as a deprecated alias for
+old callers. A ``std::set`` cannot express priority order, so ``insert()``
+treats the directory as highest priority (equivalent to ``Prepend()``) and
+prints a warning.
 
-New code should instead use ``RAT::Rat::ratdb_search_path``, which supports
-``Prepend()`` (highest priority) and ``Append()`` (lowest priority) for
-well-defined, deterministic override behavior everywhere, including
-``LoadDefaults()``::
+New code should use ``Prepend()`` (highest priority) or ``Append()`` (lowest
+priority) directly for well-defined override behavior
+everywhere, including ``LoadDefaults()``::
 
-  RAT::Rat::ratdb_search_path.Prepend(my_experiment_data_dir + "/ratdb");
+  RAT::Rat::ratdb_directories.Prepend(my_experiment_data_dir + "/ratdb");

--- a/doc/users_guide/database.rst
+++ b/doc/users_guide/database.rst
@@ -155,3 +155,20 @@ However, other than this particular override behavior, any other collision in ta
 and index will currently result in completely undefined behavior. This is true between
 tables placed in RATPAC-two and a private experiment. **If an override is required,
 always place the overriding table in the experiment-specific directory.**
+
+Adding extra RATDB search directories
+``````````````````````````````````````
+The environment variable ``RATDB_EXTRA_PATH`` can be set to a colon-separated
+list of one or more directories to search for RATDB tables, in addition to
+``$RATSHARE/ratdb``. This is useful for local development or for overriding
+individual tables without editing or rebuilding the standard installation.
+
+::
+
+  export RATDB_EXTRA_PATH=/path/to/my/tables:/path/to/other/tables
+
+Directories listed in ``RATDB_EXTRA_PATH`` take priority over
+``$RATSHARE/ratdb``: a table of the same name and index found in one of these
+directories will override the corresponding default table. When multiple
+directories are listed, earlier ones take priority over later ones. If a
+listed directory does not exist, RAT will print a warning and skip it.

--- a/doc/users_guide/database.rst
+++ b/doc/users_guide/database.rst
@@ -151,10 +151,13 @@ these tables will override any other tables with the same name. This can be very
 when an experiment wants to override the default values in certain tables, without
 worrying about telling a processor how to read a table with a non-default index.
 
-However, other than this particular override behavior, any other collision in table name
-and index will currently result in completely undefined behavior. This is true between
-tables placed in RATPAC-two and a private experiment. **If an override is required,
-always place the overriding table in the experiment-specific directory.**
+If a downstream experiment adds its own data directory by inserting directly into the
+legacy ``RAT::Rat::ratdb_directories`` set, ``$RATSHARE/ratdb`` always wins any table-name
+collision against it (in older RATPAC-2 versions this was arbitrary, not guaranteed).
+To override ``$RATSHARE/ratdb`` instead, use ``RAT::Rat::ratdb_search_path`` and
+``Prepend()`` the directory (see "For downstream experiments (C++ API)" below).
+**If an override is required, always place the overriding table in the
+experiment-specific directory, or use ``ratdb_search_path``.**
 
 Adding extra RATDB search directories
 ``````````````````````````````````````
@@ -172,3 +175,26 @@ Directories listed in ``RATDB_EXTRA_PATH`` take priority over
 directories will override the corresponding default table. When multiple
 directories are listed, earlier ones take priority over later ones. If a
 listed directory does not exist, RAT will print a warning and skip it.
+
+For downstream experiments 
+``````````````````````````````````````
+Experiment-specific ``RAT::Rat`` subclasses have historically added their own
+data directories by inserting directly into the public
+``RAT::Rat::ratdb_directories`` set, e.g.::
+
+  ratdb_directories.insert(my_experiment_data_dir + "/ratdb");
+
+This still compiles, and such directories are still searched by
+``DB::Load()``, ``DBTextLoader::PickFile()``, and the experiment-specific
+directory search described above. However, ``ratdb_directories`` is a
+``std::set``, which cannot express priority order: as a result,
+``$RATSHARE/ratdb`` is always loaded last (and therefore always wins any
+table-name collision) in ``DB::LoadDefaults()``, regardless of what has also
+been inserted into ``ratdb_directories``.
+
+New code should instead use ``RAT::Rat::ratdb_search_path``, which supports
+``Prepend()`` (highest priority) and ``Append()`` (lowest priority) for
+well-defined, deterministic override behavior everywhere, including
+``LoadDefaults()``::
+
+  RAT::Rat::ratdb_search_path.Prepend(my_experiment_data_dir + "/ratdb");

--- a/src/db/include/RAT/DB.hh
+++ b/src/db/include/RAT/DB.hh
@@ -170,8 +170,9 @@ class DB : public DBFieldCallback {
    *  directory, all of the files in that directory ending in .ratdb
    *  will be loaded.
    *
-   *  The current directory is searched first, then the $RATSHARE/ratdb
-   *  directory.
+   *  The current directory is searched first, then each directory listed in
+   *  $RATDB_EXTRA_PATH (colon-separated, checked in order), then the
+   *  $RATSHARE/ratdb directory.
    *
    *  If printFullPath is true, then an info message is printed
    *  to stdout (and logged) indicating the path of the
@@ -202,7 +203,11 @@ class DB : public DBFieldCallback {
 
   /** Load standard tables into memory.
    *
-   *  Currently, the standard tables are $RATSHARE/ratdb/ *.ratdb.
+   *  Currently, the standard tables are $RATSHARE/ratdb/ *.ratdb, plus
+   *  *.ratdb in each directory listed in $RATDB_EXTRA_PATH (colon-separated).
+   *  Tables from $RATDB_EXTRA_PATH directories take priority and overwrite
+   *  same-named tables from $RATSHARE/ratdb; among multiple $RATDB_EXTRA_PATH
+   *  directories, earlier-listed ones take priority over later ones.
    */
   int LoadDefaults();
 

--- a/src/db/src/DB.cc
+++ b/src/db/src/DB.cc
@@ -159,7 +159,10 @@ int DB::LoadAll(std::string dirname, std::string pattern) {
 }
 
 int DB::LoadDefaults() {
-  for (auto dir : Rat::ratdb_directories) LoadAll(dir);
+  // Load lowest-priority directories first so higher-priority directories
+  // (e.g. RATDB_EXTRA_PATH, which appear first in ratdb_directories) are
+  // loaded last and correctly overwrite same-named default tables.
+  for (auto it = Rat::ratdb_directories.rbegin(); it != Rat::ratdb_directories.rend(); ++it) LoadAll(*it);
   return 1;
 }
 

--- a/src/db/src/DB.cc
+++ b/src/db/src/DB.cc
@@ -45,7 +45,7 @@ int DB::Load(std::string filename, bool printPath) {
       return LoadFile(filename);
   } else {
     // Check through the data directories
-    for (auto dir : Rat::ratdb_directories) {
+    for (auto &dir : Rat::ratdb_search_path) {
       std::string newfilename = dir + "/" + filename;
       if (printPath) info << "DB: Loading " << newfilename << newline;
       if (stat(newfilename.c_str(), &s) == 0) {
@@ -160,9 +160,8 @@ int DB::LoadAll(std::string dirname, std::string pattern) {
 
 int DB::LoadDefaults() {
   // Load lowest-priority directories first so higher-priority directories
-  // (e.g. RATDB_EXTRA_PATH, which appear first in ratdb_directories) are
-  // loaded last and correctly overwrite same-named default tables.
-  for (auto it = Rat::ratdb_directories.rbegin(); it != Rat::ratdb_directories.rend(); ++it) LoadAll(*it);
+  // are loaded last and correctly overwrite same-named default tables.
+  for (auto it = Rat::ratdb_search_path.rbegin(); it != Rat::ratdb_search_path.rend(); ++it) LoadAll(*it);
   return 1;
 }
 

--- a/src/db/src/DB.cc
+++ b/src/db/src/DB.cc
@@ -45,7 +45,7 @@ int DB::Load(std::string filename, bool printPath) {
       return LoadFile(filename);
   } else {
     // Check through the data directories
-    for (auto &dir : Rat::ratdb_search_path) {
+    for (auto &dir : Rat::ratdb_directories) {
       std::string newfilename = dir + "/" + filename;
       if (printPath) info << "DB: Loading " << newfilename << newline;
       if (stat(newfilename.c_str(), &s) == 0) {
@@ -161,7 +161,7 @@ int DB::LoadAll(std::string dirname, std::string pattern) {
 int DB::LoadDefaults() {
   // Load lowest-priority directories first so higher-priority directories
   // are loaded last and correctly overwrite same-named default tables.
-  for (auto it = Rat::ratdb_search_path.rbegin(); it != Rat::ratdb_search_path.rend(); ++it) LoadAll(*it);
+  for (auto it = Rat::ratdb_directories.rbegin(); it != Rat::ratdb_directories.rend(); ++it) LoadAll(*it);
   return 1;
 }
 

--- a/src/db/src/DBTextLoader.cc
+++ b/src/db/src/DBTextLoader.cc
@@ -68,7 +68,7 @@ std::string PickFile(std::string name, std::string enclosing_file) {
   }
 
   // Finally try file in data directory
-  for (auto dir : Rat::ratdb_directories) {
+  for (auto &dir : Rat::ratdb_search_path) {
     newname = dir + "/" + name;
     if (stat(newname.c_str(), &s) == 0) return newname;
   }

--- a/src/db/src/DBTextLoader.cc
+++ b/src/db/src/DBTextLoader.cc
@@ -68,7 +68,7 @@ std::string PickFile(std::string name, std::string enclosing_file) {
   }
 
   // Finally try file in data directory
-  for (auto &dir : Rat::ratdb_search_path) {
+  for (auto &dir : Rat::ratdb_directories) {
     newname = dir + "/" + name;
     if (stat(newname.c_str(), &s) == 0) return newname;
   }

--- a/src/geo/src/DetectorConstruction.cc
+++ b/src/geo/src/DetectorConstruction.cc
@@ -55,7 +55,7 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     if (result == 2) {
       info << "Found experiment files in " << experiment << newline;
     } else {
-      for (auto dir : Rat::ratdb_directories) {
+      for (auto &dir : Rat::ratdb_search_path) {
         std::string experimentDirectoryString = dir + "/" + experiment;
         int result = db->LoadAll(experimentDirectoryString);
         if (result == 2) {

--- a/src/geo/src/DetectorConstruction.cc
+++ b/src/geo/src/DetectorConstruction.cc
@@ -55,7 +55,7 @@ G4VPhysicalVolume *DetectorConstruction::Construct() {
     if (result == 2) {
       info << "Found experiment files in " << experiment << newline;
     } else {
-      for (auto &dir : Rat::ratdb_search_path) {
+      for (auto &dir : Rat::ratdb_directories) {
         std::string experimentDirectoryString = dir + "/" + experiment;
         int result = db->LoadAll(experimentDirectoryString);
         if (result == 2) {

--- a/src/ratbase/include/RAT/Rat.hh
+++ b/src/ratbase/include/RAT/Rat.hh
@@ -5,6 +5,7 @@
 #include <RAT/AnyParse.hh>
 #include <RAT/DB.hh>
 #include <RAT/DBMessenger.hh>
+#include <RAT/Log.hh>
 #include <RAT/ProducerBlock.hh>
 #include <RAT/RatMessenger.hh>
 #include <algorithm>
@@ -19,38 +20,49 @@ namespace RAT {
  *
  *  Prepend()/Append() give a directory higher/lower priority than anything
  *  already present. If it's already in the list, it's moved rather than
- *  duplicated. Both also insert into the legacy Rat::ratdb_directories set so
- *  old code that inserts into or iterates that set directly still works and
- *  sees everything.
+ *  duplicated.
  *
- *  Forward iteration (begin()/end()) yields Prepended/Appended directories in
- *  priority order, then whatever's left in ratdb_directories. Reverse
- *  iteration (rbegin()/rend()) yields the same back-to-front, so loading each
- *  directory in reverse order and letting later loads overwrite earlier ones
- *  makes the highest-priority directory win (see DB::LoadDefaults()). Every
- *  begin()/rbegin() call re-pulls ratdb_directories' current contents into
- *  this combined view; don't hold an iterator across a fresh begin()/rbegin()
- *  call, since it rewrites the storage that iterator points into. Normal
- *  iteration (which calls begin()/rbegin() once, then end()/rend() once) is
- *  unaffected.
+ *  Forward iteration (begin()/end()) yields directories highest priority
+ *  first. Reverse iteration (rbegin()/rend()) yields the same back-to-front,
+ *  so loading each directory in reverse order and letting later loads
+ *  overwrite earlier ones makes the highest-priority directory win (see
+ *  DB::LoadDefaults()).
+ *
+ *  insert() is a legacy alias for downstream code that used to insert
+ *  directly into the old std::set<std::string> ratdb_directories. A
+ *  std::set has no priority order, so insert() treats the directory as
+ *  highest priority (equivalent to Prepend()) and warns.
  **/
 
 class RatdbDirectoryList {
  public:
-  void Prepend(const std::string &dir);
-  void Append(const std::string &dir);
+  void Prepend(const std::string &dir) {
+    // Delete if already exists
+    fDirs.erase(std::remove(fDirs.begin(), fDirs.end(), dir), fDirs.end());
+    fDirs.insert(fDirs.begin(), dir);
+  }
+
+  void Append(const std::string &dir) {
+    fDirs.erase(std::remove(fDirs.begin(), fDirs.end(), dir), fDirs.end());
+    fDirs.push_back(dir);
+  }
+
+  void insert(const std::string &dir) {
+    warn << "RAT::Rat::ratdb_directories.insert() is deprecated: std::set has no priority order, so \"" << dir
+         << "\" is being treated as highest priority (equivalent to Prepend()). Use Prepend()/Append() instead."
+         << newline;
+    Prepend(dir);
+  }
+
   bool Contains(const std::string &dir) const { return std::find(fDirs.begin(), fDirs.end(), dir) != fDirs.end(); }
 
-  std::vector<std::string>::const_iterator begin() const;
-  std::vector<std::string>::const_iterator end() const { return fCombined.end(); }
-  std::vector<std::string>::const_reverse_iterator rbegin() const;
-  std::vector<std::string>::const_reverse_iterator rend() const { return fCombined.rend(); }
+  std::vector<std::string>::const_iterator begin() const { return fDirs.begin(); }
+  std::vector<std::string>::const_iterator end() const { return fDirs.end(); }
+  std::vector<std::string>::const_reverse_iterator rbegin() const { return fDirs.rbegin(); }
+  std::vector<std::string>::const_reverse_iterator rend() const { return fDirs.rend(); }
 
  private:
-  void RebuildCombined() const;
-
   std::vector<std::string> fDirs;
-  mutable std::vector<std::string> fCombined;
 };
 
 class Rat {
@@ -72,12 +84,9 @@ class Rat {
   ProducerBlock prodBlock;
 
  public:
-  // Priority-ordered RATDB search directories (e.g. RATDB_EXTRA_PATH), highest
-  // priority first. Use Prepend()/Append() to add to this rather than
-  // inserting into ratdb_directories, so priority order is preserved.
-  inline static RatdbDirectoryList ratdb_search_path = {};
-  // Retained for backwards compatibility with code that inserts into it directly.
-  inline static std::set<std::string> ratdb_directories = {};
+  // Priority-ordered RATDB search directories, highest
+  // priority first. Use Prepend()/Append() to add to this.
+  inline static RatdbDirectoryList ratdb_directories = {};
   inline static std::set<std::string> model_directories = {};
 
   Rat(AnyParse *parser, int argc, char **argv) : parser(parser), argc(argc), argv(argv){};
@@ -86,36 +95,6 @@ class Rat {
   void Begin();
   void Report();
 };
-
-inline void RatdbDirectoryList::Prepend(const std::string &dir) {
-  // Delete if already exists
-  fDirs.erase(std::remove(fDirs.begin(), fDirs.end(), dir), fDirs.end());
-  fDirs.insert(fDirs.begin(), dir);
-  Rat::ratdb_directories.insert(dir);
-}
-
-inline void RatdbDirectoryList::Append(const std::string &dir) {
-  fDirs.erase(std::remove(fDirs.begin(), fDirs.end(), dir), fDirs.end());
-  fDirs.push_back(dir);
-  Rat::ratdb_directories.insert(dir);
-}
-
-inline void RatdbDirectoryList::RebuildCombined() const {
-  fCombined = fDirs;
-  for (const auto &dir : Rat::ratdb_directories) {
-    if (!Contains(dir)) fCombined.push_back(dir);
-  }
-}
-
-inline std::vector<std::string>::const_iterator RatdbDirectoryList::begin() const {
-  RebuildCombined();
-  return fCombined.begin();
-}
-
-inline std::vector<std::string>::const_reverse_iterator RatdbDirectoryList::rbegin() const {
-  RebuildCombined();
-  return fCombined.rbegin();
-}
 
 }  // namespace RAT
 

--- a/src/ratbase/include/RAT/Rat.hh
+++ b/src/ratbase/include/RAT/Rat.hh
@@ -7,11 +7,51 @@
 #include <RAT/DBMessenger.hh>
 #include <RAT/ProducerBlock.hh>
 #include <RAT/RatMessenger.hh>
+#include <algorithm>
 #include <set>
 #include <string>
 #include <vector>
 
 namespace RAT {
+
+/** An iterable, ordered list of RATDB search directories with explicit
+ *  priority control.
+ *
+ *  Prepend()/Append() give a directory higher/lower priority than anything
+ *  already present. If it's already in the list, it's moved rather than
+ *  duplicated. Both also insert into the legacy Rat::ratdb_directories set so
+ *  old code that inserts into or iterates that set directly still works and
+ *  sees everything.
+ *
+ *  Forward iteration (begin()/end()) yields Prepended/Appended directories in
+ *  priority order, then whatever's left in ratdb_directories. Reverse
+ *  iteration (rbegin()/rend()) yields the same back-to-front, so loading each
+ *  directory in reverse order and letting later loads overwrite earlier ones
+ *  makes the highest-priority directory win (see DB::LoadDefaults()). Every
+ *  begin()/rbegin() call re-pulls ratdb_directories' current contents into
+ *  this combined view; don't hold an iterator across a fresh begin()/rbegin()
+ *  call, since it rewrites the storage that iterator points into. Normal
+ *  iteration (which calls begin()/rbegin() once, then end()/rend() once) is
+ *  unaffected.
+ **/
+
+class RatdbDirectoryList {
+ public:
+  void Prepend(const std::string &dir);
+  void Append(const std::string &dir);
+  bool Contains(const std::string &dir) const { return std::find(dirs_.begin(), dirs_.end(), dir) != dirs_.end(); }
+
+  std::vector<std::string>::const_iterator begin() const;
+  std::vector<std::string>::const_iterator end() const { return combined_.end(); }
+  std::vector<std::string>::const_reverse_iterator rbegin() const;
+  std::vector<std::string>::const_reverse_iterator rend() const { return combined_.rend(); }
+
+ private:
+  void RebuildCombined() const;
+
+  std::vector<std::string> dirs_;
+  mutable std::vector<std::string> combined_;
+};
 
 class Rat {
  protected:
@@ -32,8 +72,12 @@ class Rat {
   ProducerBlock prodBlock;
 
  public:
-  // Ordered highest-priority first: RATDB_EXTRA_PATH directories, then $RATSHARE/ratdb.
-  inline static std::vector<std::string> ratdb_directories = {};
+  // Priority-ordered RATDB search directories (e.g. RATDB_EXTRA_PATH), highest
+  // priority first. Use Prepend()/Append() to add to this rather than
+  // inserting into ratdb_directories, so priority order is preserved.
+  inline static RatdbDirectoryList ratdb_search_path = {};
+  // Retained for backwards compatibility with code that inserts into it directly.
+  inline static std::set<std::string> ratdb_directories = {};
   inline static std::set<std::string> model_directories = {};
 
   Rat(AnyParse *parser, int argc, char **argv) : parser(parser), argc(argc), argv(argv){};
@@ -42,6 +86,36 @@ class Rat {
   void Begin();
   void Report();
 };
+
+inline void RatdbDirectoryList::Prepend(const std::string &dir) {
+  // Delete if already exists
+  dirs_.erase(std::remove(dirs_.begin(), dirs_.end(), dir), dirs_.end());
+  dirs_.insert(dirs_.begin(), dir);
+  Rat::ratdb_directories.insert(dir);
+}
+
+inline void RatdbDirectoryList::Append(const std::string &dir) {
+  dirs_.erase(std::remove(dirs_.begin(), dirs_.end(), dir), dirs_.end());
+  dirs_.push_back(dir);
+  Rat::ratdb_directories.insert(dir);
+}
+
+inline void RatdbDirectoryList::RebuildCombined() const {
+  combined_ = dirs_;
+  for (const auto &dir : Rat::ratdb_directories) {
+    if (!Contains(dir)) combined_.push_back(dir);
+  }
+}
+
+inline std::vector<std::string>::const_iterator RatdbDirectoryList::begin() const {
+  RebuildCombined();
+  return combined_.begin();
+}
+
+inline std::vector<std::string>::const_reverse_iterator RatdbDirectoryList::rbegin() const {
+  RebuildCombined();
+  return combined_.rbegin();
+}
 
 }  // namespace RAT
 

--- a/src/ratbase/include/RAT/Rat.hh
+++ b/src/ratbase/include/RAT/Rat.hh
@@ -9,6 +9,7 @@
 #include <RAT/RatMessenger.hh>
 #include <set>
 #include <string>
+#include <vector>
 
 namespace RAT {
 
@@ -31,7 +32,8 @@ class Rat {
   ProducerBlock prodBlock;
 
  public:
-  inline static std::set<std::string> ratdb_directories = {};
+  // Ordered highest-priority first: RATDB_EXTRA_PATH directories, then $RATSHARE/ratdb.
+  inline static std::vector<std::string> ratdb_directories = {};
   inline static std::set<std::string> model_directories = {};
 
   Rat(AnyParse *parser, int argc, char **argv) : parser(parser), argc(argc), argv(argv){};

--- a/src/ratbase/include/RAT/Rat.hh
+++ b/src/ratbase/include/RAT/Rat.hh
@@ -39,18 +39,18 @@ class RatdbDirectoryList {
  public:
   void Prepend(const std::string &dir);
   void Append(const std::string &dir);
-  bool Contains(const std::string &dir) const { return std::find(dirs_.begin(), dirs_.end(), dir) != dirs_.end(); }
+  bool Contains(const std::string &dir) const { return std::find(fDirs.begin(), fDirs.end(), dir) != fDirs.end(); }
 
   std::vector<std::string>::const_iterator begin() const;
-  std::vector<std::string>::const_iterator end() const { return combined_.end(); }
+  std::vector<std::string>::const_iterator end() const { return fCombined.end(); }
   std::vector<std::string>::const_reverse_iterator rbegin() const;
-  std::vector<std::string>::const_reverse_iterator rend() const { return combined_.rend(); }
+  std::vector<std::string>::const_reverse_iterator rend() const { return fCombined.rend(); }
 
  private:
   void RebuildCombined() const;
 
-  std::vector<std::string> dirs_;
-  mutable std::vector<std::string> combined_;
+  std::vector<std::string> fDirs;
+  mutable std::vector<std::string> fCombined;
 };
 
 class Rat {
@@ -89,32 +89,32 @@ class Rat {
 
 inline void RatdbDirectoryList::Prepend(const std::string &dir) {
   // Delete if already exists
-  dirs_.erase(std::remove(dirs_.begin(), dirs_.end(), dir), dirs_.end());
-  dirs_.insert(dirs_.begin(), dir);
+  fDirs.erase(std::remove(fDirs.begin(), fDirs.end(), dir), fDirs.end());
+  fDirs.insert(fDirs.begin(), dir);
   Rat::ratdb_directories.insert(dir);
 }
 
 inline void RatdbDirectoryList::Append(const std::string &dir) {
-  dirs_.erase(std::remove(dirs_.begin(), dirs_.end(), dir), dirs_.end());
-  dirs_.push_back(dir);
+  fDirs.erase(std::remove(fDirs.begin(), fDirs.end(), dir), fDirs.end());
+  fDirs.push_back(dir);
   Rat::ratdb_directories.insert(dir);
 }
 
 inline void RatdbDirectoryList::RebuildCombined() const {
-  combined_ = dirs_;
+  fCombined = fDirs;
   for (const auto &dir : Rat::ratdb_directories) {
-    if (!Contains(dir)) combined_.push_back(dir);
+    if (!Contains(dir)) fCombined.push_back(dir);
   }
 }
 
 inline std::vector<std::string>::const_iterator RatdbDirectoryList::begin() const {
   RebuildCombined();
-  return combined_.begin();
+  return fCombined.begin();
 }
 
 inline std::vector<std::string>::const_reverse_iterator RatdbDirectoryList::rbegin() const {
   RebuildCombined();
-  return combined_.rbegin();
+  return fCombined.rbegin();
 }
 
 }  // namespace RAT

--- a/src/ratbase/src/Rat.cc
+++ b/src/ratbase/src/Rat.cc
@@ -1,5 +1,6 @@
 #include <TRandom.h>
 #include <sys/resource.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <time.h>
@@ -20,7 +21,9 @@
 #include <RAT/SignalHandler.hh>
 #include <RAT/TrackingMessenger.hh>
 #include <Randomize.hh>
+#include <algorithm>
 #include <globals.hh>
+#include <sstream>
 #include <string>
 
 namespace RAT {
@@ -66,11 +69,6 @@ void Rat::Configure() {
   // Database management
   rdb = DB::Get();
   rdb_messenger = new DBMessenger();
-  // Local data management
-  if (getenv("RATSHARE") != NULL) {
-    ratdb_directories.insert(static_cast<std::string>(getenv("RATSHARE")) + "/ratdb");
-    model_directories.insert(static_cast<std::string>(getenv("RATSHARE")) + "/models");
-  }
   // Rat Messenger
   rat_messenger = new RatMessenger();
 
@@ -105,6 +103,30 @@ void Rat::Configure() {
   detail << "Seeding random number generator: " << this->seed << newline;
   CLHEP::HepRandom::setTheSeed(this->seed);
   gRandom->SetSeed(static_cast<UInt_t>(this->seed));  // ROOT rng should not be used, but just in case
+
+  // Local data management
+  // RATDB_EXTRA_PATH is a colon-separated list of directories searched (and
+  // loaded) with priority over $RATSHARE/ratdb, highest priority first.
+  if (getenv("RATDB_EXTRA_PATH") != NULL) {
+    std::stringstream extra_path(static_cast<std::string>(getenv("RATDB_EXTRA_PATH")));
+    std::string dir;
+    while (std::getline(extra_path, dir, ':')) {
+      if (dir.empty()) continue;
+      struct stat s;
+      if (stat(dir.c_str(), &s) != 0 || !S_ISDIR(s.st_mode)) {
+        warn << "RATDB_EXTRA_PATH: " << dir << " is not a directory, skipping." << newline;
+        continue;
+      }
+      if (std::find(ratdb_directories.begin(), ratdb_directories.end(), dir) == ratdb_directories.end()) {
+        ratdb_directories.push_back(dir);
+      }
+    }
+  }
+  if (getenv("RATSHARE") != NULL) {
+    ratdb_directories.push_back(static_cast<std::string>(getenv("RATSHARE")) + "/ratdb");
+    model_directories.insert(static_cast<std::string>(getenv("RATSHARE")) + "/models");
+  }
+
   rdb->LoadDefaults();
 }
 

--- a/src/ratbase/src/Rat.cc
+++ b/src/ratbase/src/Rat.cc
@@ -1,6 +1,5 @@
 #include <TRandom.h>
 #include <sys/resource.h>
-#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <time.h>
@@ -22,6 +21,7 @@
 #include <RAT/TrackingMessenger.hh>
 #include <Randomize.hh>
 #include <algorithm>
+#include <filesystem>
 #include <globals.hh>
 #include <sstream>
 #include <string>
@@ -113,8 +113,7 @@ void Rat::Configure() {
     std::string dir;
     while (std::getline(extra_path, dir, ':')) {
       if (dir.empty()) continue;
-      struct stat s;
-      if (stat(dir.c_str(), &s) != 0 || !S_ISDIR(s.st_mode)) {
+      if (!std::filesystem::is_directory(dir)) {
         warn << "RATDB_EXTRA_PATH: " << dir << " is not a directory, skipping." << newline;
         continue;
       }

--- a/src/ratbase/src/Rat.cc
+++ b/src/ratbase/src/Rat.cc
@@ -106,7 +106,8 @@ void Rat::Configure() {
 
   // Local data management
   // RATDB_EXTRA_PATH is a colon-separated list of directories searched (and
-  // loaded) with priority over $RATSHARE/ratdb, highest priority first.
+  // loaded) with priority over $RATSHARE/ratdb (appended below, so it's
+  // always lowest priority), highest priority first.
   if (getenv("RATDB_EXTRA_PATH") != NULL) {
     std::stringstream extra_path(static_cast<std::string>(getenv("RATDB_EXTRA_PATH")));
     std::string dir;
@@ -117,13 +118,11 @@ void Rat::Configure() {
         warn << "RATDB_EXTRA_PATH: " << dir << " is not a directory, skipping." << newline;
         continue;
       }
-      if (std::find(ratdb_directories.begin(), ratdb_directories.end(), dir) == ratdb_directories.end()) {
-        ratdb_directories.push_back(dir);
-      }
+      ratdb_search_path.Append(dir);
     }
   }
   if (getenv("RATSHARE") != NULL) {
-    ratdb_directories.push_back(static_cast<std::string>(getenv("RATSHARE")) + "/ratdb");
+    ratdb_search_path.Append(static_cast<std::string>(getenv("RATSHARE")) + "/ratdb");
     model_directories.insert(static_cast<std::string>(getenv("RATSHARE")) + "/models");
   }
 

--- a/src/ratbase/src/Rat.cc
+++ b/src/ratbase/src/Rat.cc
@@ -117,11 +117,11 @@ void Rat::Configure() {
         warn << "RATDB_EXTRA_PATH: " << dir << " is not a directory, skipping." << newline;
         continue;
       }
-      ratdb_search_path.Append(dir);
+      ratdb_directories.Append(dir);
     }
   }
   if (getenv("RATSHARE") != NULL) {
-    ratdb_search_path.Append(static_cast<std::string>(getenv("RATSHARE")) + "/ratdb");
+    ratdb_directories.Append(static_cast<std::string>(getenv("RATSHARE")) + "/ratdb");
     model_directories.insert(static_cast<std::string>(getenv("RATSHARE")) + "/models");
   }
 


### PR DESCRIPTION
RATDB currently only looks for `.ratdb` table files in `$RATSHARE/ratdb`. This adds a new environment variable, `RATDB_EXTRA_PATH`, that lets users point RAT at additional directories.
- `RATDB_EXTRA_PATH` is a colon-separated list of one or more directories (like `$PATH`).
- Directories listed take priority over `$RATSHARE/ratdb`: a table with the same name/index in one of these directories overrides the corresponding default. Among multiple directories, earlier-listed ones take priority over later ones.
- If a listed directory doesn't exist (or isn't a directory), RAT prints a warning and skips it rather than failing silently or hard-erroring.
- Behavior is unchanged when `RATDB_EXTRA_PATH` is unset.
- Previously the ratdb directories were stored in a `std::set` so the ratdb priority was lexicographic. Directories are now stored in a `std::vector` so that any order can be enforced

