### PR TITLE
Add -N/--num-events option to override /run/beamOn event count

### DIFF
--- a/doc/users_guide/command_interface.md
+++ b/doc/users_guide/command_interface.md
@@ -62,6 +62,7 @@ options:
  -d, --debug             Enable debug printing
  -i, --input             Set default input filename
  -l, --log               Set log filename
+ -N, --num-events        Set the number of events to simulate, overriding /run/beamOn
  -o, --output            Set default output filename
  -p, --python            Set python processors
  -q, --quiet             Quiet mode, only show warnings
@@ -256,7 +257,12 @@ These commands manage the initialization and execution of simulation runs and di
 
  * `/run/beamOn <numberOfEvents>`: This command starts a simulation run, processing the specified number of events.
 
-   Multiple `/run/beamOn` commands can appear in a single macro, for instance, to simulate different particle types or energies sequentially after reconfiguring the event generator.
+   Multiple `/run/beamOn` commands can appear in a single macro, for instance, to simulate different particle types or energies sequentially after reconfiguring the event generator. 
+   The number of events can instead be set from the command line with `-N`/`--num-events`, e.g. `rat -N 500 example.mac`.
+   This overrides the count passed to *every* `/run/beamOn` in the invocation, regardless of what count is written in the macro. 
+   No changes to the macro itself are needed. 
+   If `/run/beamOn` is invoked more than once while `-N` is set (e.g. multiple calls in one macro, or across multiple macros passed on the command line), the first call
+   uses the override and `rat` then exits with an error before the second call runs, since the intended count would be ambiguous.
 
 
 ### 2.2. Verbosity Control

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(core OBJECT
         src/ProcBlock.cc
         src/ProducerBlock.cc
         src/RunManager.cc
+        src/RatRunManager.cc
         src/CountProc.cc
         src/PruneProc.cc
         src/Gsim.cc

--- a/src/core/include/RAT/RatRunManager.hh
+++ b/src/core/include/RAT/RatRunManager.hh
@@ -1,0 +1,27 @@
+/**
+ * @class RAT::RatRunManager
+ *
+ * @detail RAT's G4RunManager subclass, the hook point for overriding Geant4
+ * run behavior. Currently it lets the -N/--num-events command-line option
+ * override the event count passed to every /run/beamOn.
+ */
+
+#ifndef __RAT_RatRunManager__
+#define __RAT_RatRunManager__
+#include <G4RunManager.hh>
+
+namespace RAT {
+
+class RatRunManager : public G4RunManager {
+ public:
+  void SetNumEventsOverride(G4int n) { fNumEventsOverride = n; }
+  void BeamOn(G4int n_event, const char *macroFile = nullptr, G4int n_select = -1) override;
+
+ private:
+  G4int fNumEventsOverride = -1;
+  G4int fBeamOnCount = 0;
+};
+
+}  // namespace RAT
+
+#endif  // __RAT_RatRunManager__

--- a/src/core/src/RatRunManager.cc
+++ b/src/core/src/RatRunManager.cc
@@ -1,0 +1,19 @@
+#include <RAT/Log.hh>
+#include <RAT/RatRunManager.hh>
+
+namespace RAT {
+
+void RatRunManager::BeamOn(G4int n_event, const char *macroFile, G4int n_select) {
+  if (fNumEventsOverride >= 0) {
+    if (fBeamOnCount > 0) {
+      Log::Die(
+          "-N/--num-events was given but /run/beamOn was invoked more than once in this "
+          "invocation; the override would be ambiguous.");
+    }
+    n_event = fNumEventsOverride;
+    fBeamOnCount++;
+  }
+  G4RunManager::BeamOn(n_event, macroFile, n_select);
+}
+
+}  // namespace RAT

--- a/src/core/src/RunManager.cc
+++ b/src/core/src/RunManager.cc
@@ -3,6 +3,7 @@
 #include <RAT/Gsim.hh>
 #include <RAT/PhysicsList.hh>
 #include <RAT/ProcBlock.hh>
+#include <RAT/RatRunManager.hh>
 #include <RAT/RunManager.hh>
 
 namespace RAT {
@@ -18,7 +19,7 @@ RunManager::RunManager(ProcBlock *theMainBlock) {
 }
 
 void RunManager::Init() {
-  theRunManager = new G4RunManager;  // Manages GEANT4 simulation process
+  theRunManager = new RatRunManager;  // Manages GEANT4 simulation process
 
   // Particle transport and interactions.  Note that this has to be
   // created outside of Gsim, since the physics list must be

--- a/src/ratbase/include/RAT/Rat.hh
+++ b/src/ratbase/include/RAT/Rat.hh
@@ -74,6 +74,7 @@ class Rat {
   std::string vector_filename;
   std::vector<std::string> python_processors;
   int run;
+  int numEvents;
   bool vis;
   int argc;
   char **argv;

--- a/src/ratbase/src/Rat.cc
+++ b/src/ratbase/src/Rat.cc
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <G4RunManager.hh>
 #include <G4UIExecutive.hh>
 #include <G4UImanager.hh>
 #include <G4UItcsh.hh>
@@ -17,6 +18,7 @@
 #include <RAT/ProcBlockManager.hh>
 #include <RAT/PythonProc.hh>
 #include <RAT/Rat.hh>
+#include <RAT/RatRunManager.hh>
 #include <RAT/SignalHandler.hh>
 #include <RAT/TrackingMessenger.hh>
 #include <Randomize.hh>
@@ -56,6 +58,8 @@ void Rat::Configure() {
   this->parser->AddArgument("database", "", "b", 1, "URL to database", ParseString);
   this->parser->AddArgument("log", "", "l", 1, "Set log filename", ParseString);
   this->parser->AddArgument("seed", -1, "s", 1, "Set random number seed", ParseInt);
+  this->parser->AddArgument("num-events", -1, "N", 1, "Set the number of events to simulate, overriding /run/beamOn",
+                            ParseInt);
   this->parser->AddArgument("input", "", "i", 1, "Set default input filename", ParseString);
   this->parser->AddArgument("output", "", "o", 1, "Set default output filename", ParseString);
   this->parser->AddArgument("vector", "", "x", 1, "Set default vector filename", ParseString);
@@ -77,6 +81,7 @@ void Rat::Configure() {
   this->output_filename = this->parser->GetValue("output", "");
   this->vector_filename = this->parser->GetValue("output", "");
   this->run = this->parser->GetValue("run", 0);
+  this->numEvents = this->parser->GetValue("num-events", -1);
   this->vis = this->parser->GetValue("vis", false);
   this->python_processors = this->parser->GetValue("python", std::vector<std::string>());
 
@@ -178,6 +183,11 @@ void Rat::Begin() {
 
     G4UIExecutive *theSession = nullptr;
     if (this->vis) theSession = new G4UIExecutive(this->argc, this->argv);
+
+    if (this->numEvents != -1) {
+      info << "Overriding number of events per /run/beamOn: " << this->numEvents << newline;
+      static_cast<RatRunManager *>(G4RunManager::GetRunManager())->SetNumEventsOverride(this->numEvents);
+    }
 
     std::string command = "/control/execute ";
     for (auto &mac : this->parser->Positionals) {


### PR DESCRIPTION
This implements the requested feature in issue #394.

fix #394 